### PR TITLE
remove backupstore from S3 path

### DIFF
--- a/docs/snapshot-backup.md
+++ b/docs/snapshot-backup.md
@@ -92,7 +92,7 @@ kubectl create -f https://raw.githubusercontent.com/rancher/longhorn/master/depl
 
 Now set `Settings/General/BackupTarget` to
 ```
-s3://backupbucket@us-east-1/backupstore
+s3://backupbucket@us-east-1/
 ```
 And `Setttings/General/BackupTargetSecret` to
 ```


### PR DESCRIPTION
The docs say to use `s3://backupbucket@us-east-1/backupstore` but the app already appears to create `backupstore` in the bucket. This means we end up with `backupbucket/backupstore/backupstore/volumes/...`

This edit removes `backupstore` from the S3 path.