### PR TITLE
add units for the staleReplicaTimeout

### DIFF
--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -421,7 +421,7 @@ metadata:
 provisioner: driver.longhorn.io
 parameters:
   numberOfReplicas: "3"
-  staleReplicaTimeout: "2880"
+  staleReplicaTimeout: "2880" # 48 hours in minutes
   fromBackup: ""
 #  diskSelector: "ssd,fast"
 #  nodeSelector: "storage,fast"

--- a/docs/restore_statefulset.md
+++ b/docs/restore_statefulset.md
@@ -49,7 +49,7 @@ spec:
     fsType: ext4
     volumeAttributes:
       numberOfReplicas: <replicas> # must match Longhorn volume value
-      staleReplicaTimeout: '30'
+      staleReplicaTimeout: '30' # in minutes
     volumeHandle: statefulset-vol-0 # must match volume name from Longhorn
   storageClassName: longhorn # must be same name that we will use later
 ---

--- a/docs/storage-tags.md
+++ b/docs/storage-tags.md
@@ -36,7 +36,7 @@ metadata:
 provisioner: rancher.io/longhorn
 parameters:
   numberOfReplicas: "3"
-  staleReplicaTimeout: "480"
+  staleReplicaTimeout: "480" # 8 hours in minutes
   diskSelector: "ssd"
   nodeSelector: "storage,fast"
 ```

--- a/examples/storageclass.yaml
+++ b/examples/storageclass.yaml
@@ -5,7 +5,7 @@ metadata:
 provisioner: driver.longhorn.io
 parameters:
   numberOfReplicas: "3"
-  staleReplicaTimeout: "2880"
+  staleReplicaTimeout: "2880" # 48 hours in minutes
   fromBackup: ""
 #  diskSelector: "ssd,fast"
 #  nodeSelector: "storage,fast"


### PR DESCRIPTION
I can't find a single "spec" for the parameters, so I figure it's best to explain it in the examples and documentation. It took me a while to find the units in the code.

I'm still curious the mechanism of it- is this for a single replica before it gets replaced? What are the hazards of setting it too low or high?