### PR TITLE
Fixed the path for manifest in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/exa
 
 Now you can create a pod using Longhorn like this:
 ```
-kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/examples/pvc.yaml
+kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/examples/pod_with_vpc.yaml
 ```
 
 The above yaml file contains two parts:


### PR DESCRIPTION
The kubectl command to create a pvc and pod had the incorrect path to the yaml file.

Signed-off-by: Sheng Yang <ashvarts@gmail.com>