### PR TITLE
Set securityContext for deployer and ui (for use with PSP)

### DIFF
--- a/chart/templates/deployment-driver.yaml
+++ b/chart/templates/deployment-driver.yaml
@@ -75,3 +75,5 @@ spec:
       - name: {{ .Values.defaultSettings.registrySecret }}
       {{- end }}
       serviceAccountName: longhorn-service-account
+      securityContext:
+        runAsUser: 0

--- a/chart/templates/deployment-ui.yaml
+++ b/chart/templates/deployment-ui.yaml
@@ -19,6 +19,8 @@ spec:
       - name: longhorn-ui
         image: "{{ .Values.image.longhorn.ui }}:{{ .Values.image.longhorn.uiTag }}"
         imagePullPolicy: Always
+        securityContext:
+          runAsUser: 0
         ports:
         - containerPort: 8000
           name: http

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -348,6 +348,8 @@ spec:
       - name: longhorn-ui
         image: longhornio/longhorn-ui:v0.8.1
         imagePullPolicy: Always
+        securityContext:
+          runAsUser: 0
         ports:
         - containerPort: 8000
           name: http
@@ -439,6 +441,8 @@ spec:
       #imagePullSecrets:
       #- name:
       serviceAccountName: longhorn-service-account
+      securityContext:
+        runAsUser: 0
 ---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1


### PR DESCRIPTION
When pod security policies are used, the typical default of a very restricted policy does not allow root permissions. Even when a more permissive policy is assigned to the service account, we need to inform k8s that we need root permissions so that the correct policy can be selected. This PR does that.

Note: when PSPs are enforced, one still needs to explicitly set the correct PSP for both the default account in the longhorn-system namespace (allow root user) and the "longhorn-service-account" (allow everything).