### PR TITLE
feat: add csi.resizerReplicaCount to chart values

### DIFF
--- a/chart/templates/deployment-driver.yaml
+++ b/chart/templates/deployment-driver.yaml
@@ -70,6 +70,10 @@ spec:
           - name: CSI_PROVISIONER_REPLICA_COUNT
             value: "{{ .Values.csi.provisionerReplicaCount }}"
           {{- end }}
+          {{- if .Values.csi.resizerReplicaCount }}
+          - name: CSI_RESIZER_REPLICA_COUNT
+            value: "{{ .Values.csi.resizerReplicaCount }}"
+          {{- end }}
       {{- if .Values.defaultSettings.registrySecret }}
       imagePullSecrets:
       - name: {{ .Values.defaultSettings.registrySecret }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -33,6 +33,7 @@ csi:
   kubeletRootDir:
   attacherReplicaCount:
   provisionerReplicaCount:
+  resizerReplicaCount:
 
 defaultSettings:
   backupTarget:


### PR DESCRIPTION
I was deploying longhorn on a local single-node cluster for local development and I didn't want many replicas. Let me know if this is something not desirable.