### PR TITLE
Add option to modify the ServiceAccount name & Add it to the UI pod spec

### DIFF
--- a/chart/questions.yml
+++ b/chart/questions.yml
@@ -262,7 +262,7 @@ questions:
   show_if: "ingress.enabled=false"
   group: "Services and Load Balancing"
   show_subquestion_if: "NodePort"
-  subquestions: 
+  subquestions:
   - variable: service.ui.nodePort
     default: ""
     description: "NodePort port number(to set explicitly, choose port between 30000-32767)"
@@ -271,3 +271,9 @@ questions:
     max: 32767
     show_if: "service.ui.type=NodePort||service.ui.type=LoadBalancer"
     label: UI Service NodePort number
+- variable: serviceAccount.name
+  default: "longhorn-service-account"
+  description: "The name of the Kubernetes ServiceAccount to create"
+  type: string
+  group: "Kubernetes RBAC"
+  label: Kubernetes ServiceAccount name

--- a/chart/templates/clusterrolebinding.yaml
+++ b/chart/templates/clusterrolebinding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: longhorn-role
 subjects:
 - kind: ServiceAccount
-  name: longhorn-service-account
+  name: {{ .Values.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}

--- a/chart/templates/daemonset-sa.yaml
+++ b/chart/templates/daemonset-sa.yaml
@@ -31,7 +31,7 @@ spec:
         - --manager-image
         - "{{ .Values.image.longhorn.manager }}:{{ .Values.image.longhorn.managerTag }}"
         - --service-account
-        - longhorn-service-account
+        - {{ .Values.serviceAccount.name }}
         ports:
         - containerPort: 9500
           name: manager
@@ -85,7 +85,7 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.defaultSettings.registrySecret }}
       {{- end }}
-      serviceAccountName: longhorn-service-account
+      serviceAccountName: {{ .Values.serviceAccount.name }}
   updateStrategy:
     rollingUpdate:
       maxUnavailable: "100%"

--- a/chart/templates/deployment-driver.yaml
+++ b/chart/templates/deployment-driver.yaml
@@ -78,4 +78,4 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.defaultSettings.registrySecret }}
       {{- end }}
-      serviceAccountName: longhorn-service-account
+      serviceAccountName: {{ .Values.serviceAccount.name }}

--- a/chart/templates/deployment-ui.yaml
+++ b/chart/templates/deployment-ui.yaml
@@ -29,6 +29,7 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.defaultSettings.registrySecret }}
       {{- end }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
 ---
 kind: Service
 apiVersion: v1

--- a/chart/templates/postupgrade-job.yaml
+++ b/chart/templates/postupgrade-job.yaml
@@ -30,4 +30,4 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.defaultSettings.registrySecret }}
       {{- end }}
-      serviceAccountName: longhorn-service-account
+      serviceAccountName: {{ .Values.serviceAccount.name }}

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: longhorn-service-account
+  name: {{ .Values.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}

--- a/chart/templates/uninstall-job.yaml
+++ b/chart/templates/uninstall-job.yaml
@@ -31,4 +31,4 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.defaultSettings.registrySecret }}
       {{- end }}
-      serviceAccountName: longhorn-service-account
+      serviceAccountName: {{ .Values.serviceAccount.name }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -108,3 +108,6 @@ ingress:
   # - name: longhorn.local-tls
   #   key:
   #   certificate:
+
+serviceAccount:
+  name: longhorn-service-account


### PR DESCRIPTION
Hey there!

When deploying Longhorn using this chart, I noticed that the UI pod was not able to start in our k8s-environment.

We do have to add OSS software ServiceAccounts to a ClusterRoleBinding if root access is demanded by any container.

But the UI spec did not use the ServiceAccount at all.

Beside adding it to the template, I also updated all existing occurrences in order to make the name configureable.

My PR might be conflicting with https://github.com/longhorn/longhorn/pull/1281, so ping my if I shall rebase mine after it was merged.

Thanks and awesome work!