### PR TITLE
Add example deployment of nfs on top of a longhorn for RWX volumes

### DIFF
--- a/examples/rwx/01-security.yaml
+++ b/examples/rwx/01-security.yaml
@@ -1,0 +1,85 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: longhorn-nfs-provisioner
+spec:
+  fsGroup:
+    rule: RunAsAny
+  allowedCapabilities:
+    - DAC_READ_SEARCH
+    - SYS_RESOURCE
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+    - configMap
+    - downwardAPI
+    - emptyDir
+    - persistentVolumeClaim
+    - secret
+    - hostPath
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: longhorn-nfs-provisioner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["services", "endpoints"]
+    verbs: ["get"]
+  - apiGroups: ["extensions"]
+    resources: ["podsecuritypolicies"]
+    resourceNames: ["nfs-provisioner"]
+    verbs: ["use"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: longhorn-nfs-provisioner
+subjects:
+  - kind: ServiceAccount
+    name: longhorn-nfs-provisioner
+    namespace: longhorn-system
+roleRef:
+  kind: ClusterRole
+  name: longhorn-nfs-provisioner
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: longhorn-nfs-provisioner
+rules:
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: longhorn-nfs-provisioner
+subjects:
+  - kind: ServiceAccount
+    name: longhorn-nfs-provisioner
+    namespace: longhorn-system
+roleRef:
+  kind: Role
+  name: longhorn-nfs-provisioner
+  apiGroup: rbac.authorization.k8s.io
+---
+

--- a/examples/rwx/02-longhorn-nfs-provisioner.yaml
+++ b/examples/rwx/02-longhorn-nfs-provisioner.yaml
@@ -102,6 +102,7 @@ spec:
                 - SYS_RESOURCE
           args:
             - "-provisioner=nfs.longhorn.io"
+            - "-device-based-fsids=false"
           env:
             - name: POD_IP
               valueFrom:
@@ -114,6 +115,20 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
           imagePullPolicy: "IfNotPresent"
+          readinessProbe:
+            exec:
+              command:
+                - ls
+                - /export
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command:
+                - ls
+                - /export
+            initialDelaySeconds: 5
+            periodSeconds: 5
           volumeMounts:
             - name: export-volume
               mountPath: /export
@@ -121,6 +136,17 @@ spec:
         - name: export-volume
           persistentVolumeClaim:
             claimName: longhorn-nfs-provisioner
+      # we want really quick failover
+      terminationGracePeriodSeconds: 30
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 60
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 60
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -139,5 +165,5 @@ kind: StorageClass
 metadata:
   name: longhorn-nfs # workload storage class
 provisioner: nfs.longhorn.io
-parameters:
-  mountOptions: "vers=4.1"
+mountOptions:
+  - "vers=4.1"

--- a/examples/rwx/02-longhorn-nfs-provisioner.yaml
+++ b/examples/rwx/02-longhorn-nfs-provisioner.yaml
@@ -1,0 +1,143 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: longhorn-nfs-provisioner
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: longhorn-nfs-provisioner
+  labels:
+    app: longhorn-nfs-provisioner
+spec:
+  ports:
+    - name: nfs
+      port: 2049
+    - name: nfs-udp
+      port: 2049
+      protocol: UDP
+    - name: nlockmgr
+      port: 32803
+    - name: nlockmgr-udp
+      port: 32803
+      protocol: UDP
+    - name: mountd
+      port: 20048
+    - name: mountd-udp
+      port: 20048
+      protocol: UDP
+    - name: rquotad
+      port: 875
+    - name: rquotad-udp
+      port: 875
+      protocol: UDP
+    - name: rpcbind
+      port: 111
+    - name: rpcbind-udp
+      port: 111
+      protocol: UDP
+    - name: statd
+      port: 662
+    - name: statd-udp
+      port: 662
+      protocol: UDP
+  selector:
+    app: longhorn-nfs-provisioner
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: longhorn-nfs-provisioner
+spec:
+  selector:
+    matchLabels:
+      app: longhorn-nfs-provisioner
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: longhorn-nfs-provisioner
+    spec:
+      serviceAccount: longhorn-nfs-provisioner
+      containers:
+        - name: longhorn-nfs-provisioner
+          image: quay.io/kubernetes_incubator/nfs-provisioner:latest
+          ports:
+            - name: nfs
+              containerPort: 2049
+            - name: nfs-udp
+              containerPort: 2049
+              protocol: UDP
+            - name: nlockmgr
+              containerPort: 32803
+            - name: nlockmgr-udp
+              containerPort: 32803
+              protocol: UDP
+            - name: mountd
+              containerPort: 20048
+            - name: mountd-udp
+              containerPort: 20048
+              protocol: UDP
+            - name: rquotad
+              containerPort: 875
+            - name: rquotad-udp
+              containerPort: 875
+              protocol: UDP
+            - name: rpcbind
+              containerPort: 111
+            - name: rpcbind-udp
+              containerPort: 111
+              protocol: UDP
+            - name: statd
+              containerPort: 662
+            - name: statd-udp
+              containerPort: 662
+              protocol: UDP
+          securityContext:
+            capabilities:
+              add:
+                - DAC_READ_SEARCH
+                - SYS_RESOURCE
+          args:
+            - "-provisioner=nfs.longhorn.io"
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: SERVICE_NAME
+              value: longhorn-nfs-provisioner
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: export-volume
+              mountPath: /export
+      volumes:
+        - name: export-volume
+          persistentVolumeClaim:
+            claimName: longhorn-nfs-provisioner
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: longhorn-nfs-provisioner # longhorn backing pvc
+spec:
+  storageClassName: longhorn
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "20G" # make this 10% bigger then the workload pvc
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-nfs # workload storage class
+provisioner: nfs.longhorn.io
+parameters:
+  mountOptions: "vers=4.1"

--- a/examples/rwx/02-longhorn-nfs-provisioner.yaml
+++ b/examples/rwx/02-longhorn-nfs-provisioner.yaml
@@ -10,6 +10,10 @@ metadata:
   labels:
     app: longhorn-nfs-provisioner
 spec:
+  # hardcode a cluster ip for the service
+  # so that on delete & recreate of the service the previous pv's still point
+  # to this nfs-provisioner, pick a new ip for each new nfs provisioner
+  clusterIP: 10.43.111.111
   ports:
     - name: nfs
       port: 2049

--- a/examples/rwx/02-longhorn-nfs-provisioner.yaml
+++ b/examples/rwx/02-longhorn-nfs-provisioner.yaml
@@ -167,3 +167,4 @@ metadata:
 provisioner: nfs.longhorn.io
 mountOptions:
   - "vers=4.1"
+  - "noresvport"

--- a/examples/rwx/03-rwx-test.yaml
+++ b/examples/rwx/03-rwx-test.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nfs-test
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: longhorn-nfs
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nfs-test
+  labels:
+    app: nfs-test
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: nfs-test
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: nfs-test
+    spec:
+      containers:
+        - image: ubuntu:xenial
+          imagePullPolicy: Always
+          command: ["/bin/sh", "-c"]
+          args:
+            - sleep 30; touch /mnt/nfs-test/test.log; while true; do date >> /mnt/nfs-test/test.log; sleep 1; done;
+          name: nfs-test
+          stdin: true
+          tty: true
+          livenessProbe:
+            exec:
+              command:
+                - timeout
+                - "10"
+                - ls
+                - /mnt/nfs-test
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 10
+          volumeMounts:
+            - mountPath: /mnt/nfs-test
+              name: nfs-test
+      restartPolicy: Always
+      volumes:
+        - name: nfs-test
+          persistentVolumeClaim:
+            claimName: nfs-test


### PR DESCRIPTION
Below are the example deployment for nfs on top of a longhorn volume.
The nfs volume can then be used in RWX mode.

**For quicker pod eviction:**
We add tolerations so that nfs provisioner pod gets evicted from a failing
node after 60 second + 30 grace period (relevant for va recovery policy).
Add liveness + readyness probe, so that no traffic gets routed to a failed
nfs server. Disable device based fsids (major:minor) since our block device
mapping can change from node to node, which makes the id's unstable.

**To enable nfs reconnection to the new pod ip via the service:**
We add noresvport to the nfs mount options
This makes the nfs client use a new src port for each tcp reconnect.
This way after a crash the faulty connection isn't kept alive in the
connection cache (nat). This should allow to resolve the cluster ip to
the new destination pod ip.

**Hardcoded service cluster ip**
We hardcode nfs service cluster ip, so that on a delete & recreate of the service the previous pv's still point to this nfs-provisioner. We cannot use the hostname since the actual host doesn't know how to resolve service addresses inside of the cluster.

longhorn/longhorn#1183

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>