### PR TITLE
dev, deploy, chart: change imagePullPolicy to IfNotPresent for manager, ui, driver deployer.

### DIFF
--- a/chart/templates/daemonset-sa.yaml
+++ b/chart/templates/daemonset-sa.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: longhorn-manager
         image: "{{ .Values.image.longhorn.manager }}:{{ .Values.image.longhorn.managerTag }}"
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
         command:

--- a/chart/templates/deployment-driver.yaml
+++ b/chart/templates/deployment-driver.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
         - name: longhorn-driver-deployer
           image: {{ printf "%s:%s" .Values.image.longhorn.manager .Values.image.longhorn.managerTag | quote }}
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           command:
           - longhorn-manager
           - -d

--- a/chart/templates/deployment-ui.yaml
+++ b/chart/templates/deployment-ui.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
       - name: longhorn-ui
         image: "{{ .Values.image.longhorn.ui }}:{{ .Values.image.longhorn.uiTag }}"
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0
         ports:

--- a/dev/scripts/update-image-pull-policy.sh
+++ b/dev/scripts/update-image-pull-policy.sh
@@ -1,0 +1,35 @@
+echo "Update imagePullPolicy to be Always for manager, UI, driver deployer, engine image"
+
+# Update imagePullPolicy for Longhorn manager daemonset
+kubectl patch daemonset longhorn-manager -n longhorn-system -p \
+'{"spec":{"template":{"spec":{"containers":[{"name":"longhorn-manager", "imagePullPolicy":"Always"}]}}}}'
+sleep 5
+
+# Update imagePullPolicy for Longhorn UI deployment
+kubectl patch deployment longhorn-ui -n longhorn-system -p \
+'{"spec":{"template":{"spec":{"containers":[{"name":"longhorn-ui", "imagePullPolicy":"Always"}]}}}}'
+sleep 5
+
+# Update imagePullPolicy for Longhorn Driver Deployer deployment
+kubectl patch deployment longhorn-driver-deployer -n longhorn-system -p \
+'{"spec":{"template":{"spec":{"containers":[{"name":"longhorn-driver-deployer", "imagePullPolicy":"Always"}]}}}}'
+sleep 1
+echo "wait 15s to make sure that the updated longhorn manager pods come up ..."
+sleep 15
+
+# Update all imagePullPolicy for Longhorn Engine Image Daemonsets
+temp_file='./.engine-image-daemon-list'
+kubectl get daemonsets -n longhorn-system | grep -oE "engine-image-ei-.{8}" > ${temp_file}
+
+while IFS= read -r line
+do
+        kubectl patch daemonset ${line} -n longhorn-system -p \
+                "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"${line}\", \"imagePullPolicy\":\"Always\"}]}}}}"
+        sleep 5
+done < ${temp_file}
+
+rm ${temp_file}
+
+echo "Warning: Make sure check and wait for all pods running again!"
+echo "Current status: (Ctl+c to exit)"
+kubectl get pods -w -n longhorn-system


### PR DESCRIPTION
We changed the imagePullPolicy to IfNotPresent so that user can easily install Longhorn in air-gap installation.
Also added a bash script for the developer to quickly change all the magePullPolicies back to Always.

longhorn/longhorn#1491