### PR TITLE
example: Fix example rwx

### DIFF
--- a/examples/rwx/01-security.yaml
+++ b/examples/rwx/01-security.yaml
@@ -63,7 +63,8 @@ roleRef:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: longhorn-nfs-provisioner
+  name: leader-locking-longhorn-nfs-provisioner
+  namespace: longhorn-system
 rules:
   - apiGroups: [""]
     resources: ["endpoints"]
@@ -72,14 +73,13 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: longhorn-nfs-provisioner
+  name: leader-locking-longhorn-nfs-provisioner
+  namespace: longhorn-system
 subjects:
   - kind: ServiceAccount
     name: longhorn-nfs-provisioner
     namespace: longhorn-system
 roleRef:
   kind: Role
-  name: longhorn-nfs-provisioner
+  name: leader-locking-longhorn-nfs-provisioner
   apiGroup: rbac.authorization.k8s.io
----
-

--- a/examples/rwx/02-longhorn-nfs-provisioner.yaml
+++ b/examples/rwx/02-longhorn-nfs-provisioner.yaml
@@ -2,11 +2,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: longhorn-nfs-provisioner
+  namespace: longhorn-system
 ---
 kind: Service
 apiVersion: v1
 metadata:
   name: longhorn-nfs-provisioner
+  namespace: longhorn-system
   labels:
     app: longhorn-nfs-provisioner
 spec:
@@ -52,6 +54,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: longhorn-nfs-provisioner
+  namespace: longhorn-system
 spec:
   selector:
     matchLabels:
@@ -156,6 +159,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: longhorn-nfs-provisioner # longhorn backing pvc
+  namespace: longhorn-system
 spec:
   storageClassName: longhorn
   accessModes:


### PR DESCRIPTION
1. Use different names for the 2 roles
(and the related role bindings)
2. Make sure the role binding namespace is the same as the
namespace where nfs provisioner is deployed
