### PR TITLE
chart: change the CSI Driver Registrar image variable in question.yaml to have the same name as in values.yaml

### DIFF
--- a/chart/questions.yml
+++ b/chart/questions.yml
@@ -70,11 +70,11 @@ questions:
     type: string
     label: Longhorn CSI Provisioner Image
     group: "Longhorn CSI Driver Images"
-  - variable: csi.driverRegistrarImage
+  - variable: csi.nodeDriverRegistrarImage
     default:
-    description: "Specify CSI Driver Registrar image. Leave blank to autodetect."
+    description: "Specify CSI Node Driver Registrar image. Leave blank to autodetect."
     type: string
-    label: Longhorn CSI Driver Registrar Image
+    label: Longhorn CSI Node Driver Registrar Image
     group: "Longhorn CSI Driver Images"
   - variable: csi.resizerImage
     default:


### PR DESCRIPTION
This makes sure that the Rancher chart correctly passes the user-provided CSI Driver Registrar image registry value to `values.yaml` and therefore to the yaml template `deployment-driver.yaml`

longhorn/longhorn#1590