### PR TITLE
scripts: fix the scripts load-images.sh and save-images.sh in the case user provides invalid flags

### DIFF
--- a/scripts/load-images.sh
+++ b/scripts/load-images.sh
@@ -24,6 +24,11 @@ while [[ $# -gt 0 ]]; do
         help="true"
         shift
         ;;
+        *)
+        echo "Error! invalid flag: ${key}"
+        help="true"
+        break
+        ;;
     esac
 done
 

--- a/scripts/save-images.sh
+++ b/scripts/save-images.sh
@@ -19,6 +19,11 @@ while [[ $# -gt 0 ]]; do
 		help="true"
 		shift
 		;;
+		*)
+		echo "Error! invalid flag: ${key}"
+		help="true"
+		break
+		;;
 	esac
 done
 


### PR DESCRIPTION
When user provides an invalid flag, print out error message and help menu instead of looping forever

longhorn/longhorn#1419