### PR TITLE
fix: remove beta annotation from storage class

### DIFF
--- a/chart/templates/storageclass.yaml
+++ b/chart/templates/storageclass.yaml
@@ -2,13 +2,8 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: longhorn
-  {{- if .Values.persistence.defaultClass }}
   annotations:
-    storageclass.beta.kubernetes.io/is-default-class: "true"
-  {{- else }}
-  annotations:
-    storageclass.beta.kubernetes.io/is-default-class: "false"
-  {{- end }}
+    storageclass.kubernetes.io/is-default-class: {{ .Values.persistence.defaultClass | quote }}
   labels: {{- include "longhorn.labels" . | nindent 4 }}
 provisioner: driver.longhorn.io
 allowVolumeExpansion: true


### PR DESCRIPTION
Since the storage.k8s.io/v1 API, the annotation for is-default-class is no longer in beta and was deprecated.
https://github.com/kubernetes/kubernetes/pull/40088