### PR TITLE
Helm default schedule

### DIFF
--- a/chart/questions.yml
+++ b/chart/questions.yml
@@ -175,6 +175,11 @@ questions:
     min: 1
     max: 10
     label: Default Storage Class Replica Count
+  - variable: persistence.defaultRecurringJobs
+    description: "Set snapshot and backup jobs for default StorageClass"
+    group: "Longhorn CSI Driver Settings"
+    type: string
+    default: '[]'
   - variable: defaultSettings.backupTarget
     label: Backup Target
     description: "The endpoint used to access the backupstore. NFS and S3 are supported."

--- a/chart/templates/storageclass.yaml
+++ b/chart/templates/storageclass.yaml
@@ -12,3 +12,4 @@ parameters:
   staleReplicaTimeout: "30"
   fromBackup: ""
   baseImage: ""
+  recurringJobs: "{{ .Values.persistence.defaultRecurringJobs }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -24,6 +24,7 @@ service:
 persistence:
   defaultClass: true
   defaultClassReplicaCount: 3
+  defaultRecurringJobs: ~
 
 csi:
   attacherImage: longhornio/csi-attacher


### PR DESCRIPTION
Allow to specify a schedule for snapshots and backups in default storage class created by helm.

values.yaml example:

```
persistence:
  defaultRecurringJobs: '[{\"name\":\"snap\", \"task\":\"snapshot\", \"cron\":\"*/1 * * * *\", \"retain\":1}, {\"name\":\"backup\", \"task\":\"backup\", \"cron\":\"*/2 * * * *\", \"retain\":1}]'
```