### PR TITLE
dev scripts: update lm-update.sh and update-image-pull-policy.sh

### DIFF
--- a/dev/scripts/lm-update.sh
+++ b/dev/scripts/lm-update.sh
@@ -29,8 +29,10 @@ docker push ${private}
 escaped_private=${private//\//\\\/}
 sed -i "s/image\:\ .*\/${project}:.*/image\:\ ${escaped_private}/g" $yaml
 sed -i "s/-\ .*\/${project}:.*/-\ ${escaped_private}/g" $yaml
+sed -i "s/imagePullPolicy\:\ .*/imagePullPolicy\:\ Always/g" $yaml
 sed -i "s/image\:\ .*\/${project}:.*/image\:\ ${escaped_private}/g" $driver_yaml
 sed -i "s/-\ .*\/${project}:.*/-\ ${escaped_private}/g" $driver_yaml
+sed -i "s/imagePullPolicy\:\ .*/imagePullPolicy\:\ Always/g" $driver_yaml
 
 set +e
 


### PR DESCRIPTION
To include a way to restart every Longhorn components automatically with
the latest image.

1. Now `lm-update.sh` will set `imagePullPolicy: Always` for the manager
and the driver.
2. Now update-image-pull-policy.sh will update the `imagePullPolicy` for
all the running deployments and daemonsets in the `longhorn-system`
namespace, including CSI components.

Signed-off-by: Sheng Yang <sheng.yang@rancher.com>