### PR TITLE
Prevent Longhorn upgrade failure due to changed StorageClass when using Helm installation/upgrade

### DIFF
--- a/chart/templates/storageclass.yaml
+++ b/chart/templates/storageclass.yaml
@@ -1,3 +1,5 @@
+{{- $longhornSC := (lookup "storage.k8s.io/v1" "StorageClass" "" "longhorn") -}}
+{{- if not $longhornSC }}
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
@@ -16,3 +18,8 @@ parameters:
   {{- if .Values.recurringJobs.enable }}
   recurringJobs: '{{ .Values.recurringJobs.jobsList | toPrettyJson | indent 2 | trim }}'
   {{- end }}
+{{- else if eq $longhornSC.provisioner "driver.longhorn.io"}}
+{{ $longhornSC | mustToPrettyJson }}
+{{- else}}
+{{- fail "the existing longhorn storageclass doesn't have provisioner as driver.longhorn.io" }}
+{{- end}}


### PR DESCRIPTION
Add the logic to `storageclass.yaml` template to detect the existing `longhorn` storageclass. There are 3 cases:

1. If there is no `longhorn` storageclass, `storageclass.yaml` template output a yaml file for `longhorn` storageclass. Helm install/upgrade will succeed.
2. If there is a longhorn storageclass with provisoner `driver.longhorn.io`, storageclass.yaml template outputs an identical storageclass. Helm install/upgrade will succeed.
3. If there is a `longhorn` storageclass but its provisoner is not `driver.longhorn.io`, storageclass.yaml template outputs an error. Helm install will fail. In this case, users have to follow the [document](https://longhorn.io/docs/0.8.1/deploy/upgrade/longhorn-manager/#error-longhorn-is-invalid-provisioner-forbidden-updates-to-provisioner-are-forbidden) to resolve the problem. (In short, users have to delete the existing `longhorn` storageclass and retry)

longhorn/longhorn#1527