### PR TITLE
Reference correct PodSecurityPolicy name

### DIFF
--- a/examples/rwx/01-security.yaml
+++ b/examples/rwx/01-security.yaml
@@ -44,7 +44,7 @@ rules:
     verbs: ["get"]
   - apiGroups: ["extensions"]
     resources: ["podsecuritypolicies"]
-    resourceNames: ["nfs-provisioner"]
+    resourceNames: ["longhorn-nfs-provisioner"]
     verbs: ["use"]
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
ClusterRoleBinding must declare use of the PodSecurityPolicy properly. The current yaml template references a PSP named "nfs-provisioner", when the name of the PSP defined in this yaml is "longhorn-nfs-provisioner"