### PR TITLE
Updating ClusterRole to reference correct PSP

### DIFF
--- a/examples/rwx/01-security.yaml
+++ b/examples/rwx/01-security.yaml
@@ -44,7 +44,7 @@ rules:
     verbs: ["get"]
   - apiGroups: ["extensions"]
     resources: ["podsecuritypolicies"]
-    resourceNames: ["nfs-provisioner"]
+    resourceNames: ["longhorn-nfs-provisioner"]
     verbs: ["use"]
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
Updating the ClusterRole such that it references the correct name of the PodSecurityPolicy. Current yaml references a PSP named "nfs-provisioner", while the yaml created a PSP named "longhorn-nfs-provisioner"

Signed-off-by: Zach Bialik <zachbialik1207@gmail.com>