### PR TITLE
change registry secret location

### DIFF
--- a/chart/questions.yml
+++ b/chart/questions.yml
@@ -130,6 +130,12 @@ questions:
   group: "Private Registry Settings"
   type: password
   default: ""
+- variable: privateRegistry.registrySecret
+  label: Private registry secret name
+  description: "Longhorn will automatically generate a Kubernetes secret with this name and use it to pull images from your private registry."
+  group: "Private Registry Settings"
+  type: string
+  default: ""
 - variable: longhorn.default_setting
   default: "false"
   description: "Customize the default settings before installing Longhorn for the first time. This option will only work if the cluster hasn't installed Longhorn."
@@ -138,12 +144,6 @@ questions:
   show_subquestion_if: true
   group: "Longhorn Default Settings"
   subquestions:
-  - variable: defaultSettings.registrySecret
-    label: Private registry secret
-    description: "The Kubernetes Secret name"
-    group: "Longhorn Default Settings"
-    type: string
-    default: ""
   - variable: csi.kubeletRootDir
     default:
     description: "Specify kubelet root-dir. Leave blank to autodetect."

--- a/chart/templates/daemonset-sa.yaml
+++ b/chart/templates/daemonset-sa.yaml
@@ -82,9 +82,9 @@ spec:
       - name: longhorn-default-setting
         configMap:
           name: longhorn-default-setting
-      {{- if .Values.defaultSettings.registrySecret }}
+      {{- if .Values.privateRegistry.registrySecret }}
       imagePullSecrets:
-      - name: {{ .Values.defaultSettings.registrySecret }}
+      - name: {{ .Values.privateRegistry.registrySecret }}
       {{- end }}
       serviceAccountName: longhorn-service-account
   updateStrategy:

--- a/chart/templates/default-setting.yaml
+++ b/chart/templates/default-setting.yaml
@@ -21,7 +21,6 @@ data:
     backupstore-poll-interval: {{ .Values.defaultSettings.backupstorePollInterval }}
     taint-toleration: {{ .Values.defaultSettings.taintToleration }}
     priority-class: {{ .Values.defaultSettings.priorityClass }}
-    registry-secret: {{ .Values.defaultSettings.registrySecret }}
     auto-salvage: {{ .Values.defaultSettings.autoSalvage }}
     auto-delete-pod-when-volume-detached-unexpectedly: {{ .Values.defaultSettings.autoDeletePodWhenVolumeDetachedUnexpectedly }}
     disable-scheduling-on-cordoned-node: {{ .Values.defaultSettings.disableSchedulingOnCordonedNode }}

--- a/chart/templates/deployment-driver.yaml
+++ b/chart/templates/deployment-driver.yaml
@@ -84,9 +84,9 @@ spec:
             value: {{ .Values.csi.snapshotterReplicaCount | quote }}
           {{- end }}
 
-      {{- if .Values.defaultSettings.registrySecret }}
+      {{- if .Values.privateRegistry.registrySecret }}
       imagePullSecrets:
-      - name: {{ .Values.defaultSettings.registrySecret }}
+      - name: {{ .Values.privateRegistry.registrySecret }}
       {{- end }}
       serviceAccountName: longhorn-service-account
       securityContext:

--- a/chart/templates/deployment-ui.yaml
+++ b/chart/templates/deployment-ui.yaml
@@ -27,9 +27,9 @@ spec:
         env:
           - name: LONGHORN_MANAGER_IP
             value: "http://longhorn-backend:9500"
-      {{- if .Values.defaultSettings.registrySecret }}
+      {{- if .Values.privateRegistry.registrySecret }}
       imagePullSecrets:
-      - name: {{ .Values.defaultSettings.registrySecret }}
+      - name: {{ .Values.privateRegistry.registrySecret }}
       {{- end }}
 ---
 kind: Service

--- a/chart/templates/postupgrade-job.yaml
+++ b/chart/templates/postupgrade-job.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
       - name: longhorn-post-upgrade
         image: {{ template "registry_url" . }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command:
         - longhorn-manager
         - post-upgrade
@@ -28,8 +28,8 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
       restartPolicy: OnFailure
-      {{- if .Values.defaultSettings.registrySecret }}
+      {{- if .Values.privateRegistry.registrySecret }}
       imagePullSecrets:
-      - name: {{ .Values.defaultSettings.registrySecret }}
+      - name: {{ .Values.privateRegistry.registrySecret }}
       {{- end }}
       serviceAccountName: longhorn-service-account

--- a/chart/templates/registry-secret.yml
+++ b/chart/templates/registry-secret.yml
@@ -1,8 +1,8 @@
-{{- if .Values.defaultSettings.registrySecret }}
+{{- if .Values.privateRegistry.registrySecret }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.defaultSettings.registrySecret }}
+  name: {{ .Values.privateRegistry.registrySecret }}
   labels: {{- include "longhorn.labels" . | nindent 4 }}
 type: kubernetes.io/dockerconfigjson
 data:

--- a/chart/templates/uninstall-job.yaml
+++ b/chart/templates/uninstall-job.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
       - name: longhorn-uninstall
         image: {{ template "registry_url" . }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command:
         - longhorn-manager
         - uninstall
@@ -29,8 +29,8 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
       restartPolicy: OnFailure
-      {{- if .Values.defaultSettings.registrySecret }}
+      {{- if .Values.privateRegistry.registrySecret }}
       imagePullSecrets:
-      - name: {{ .Values.defaultSettings.registrySecret }}
+      - name: {{ .Values.privateRegistry.registrySecret }}
       {{- end }}
       serviceAccountName: longhorn-service-account

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -81,7 +81,6 @@ defaultSettings:
   backupstorePollInterval: ~
   taintToleration: ~
   priorityClass: ~
-  registrySecret: ~
   autoSalvage: ~
   autoDeletePodWhenVolumeDetachedUnexpectedly: ~
   disableSchedulingOnCordonedNode: ~
@@ -100,6 +99,7 @@ privateRegistry:
   registryUrl: ~
   registryUser: ~
   registryPasswd: ~
+  registrySecret: ~
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
To avoid confusing user, we move the registry secret setting outside of default setting section. Now, user will set registry secret setting in `privateRegistry.registrySecret`

Also, we change `imagesPullPolicy` of `longhorn-post-upgrade` job and `longhorn-uninstall` job to `IfNotPresent` so that user can upgrade/uninstall Longhorn using Helm in airgap environment. 

longhorn/longhorn#1670
longhorn/longhorn#1986
