### PR TITLE
Fix crash loop error in longhorn-iscsi-installation

### DIFF
--- a/deploy/iscsi/longhorn-iscsi-installation.yaml
+++ b/deploy/iscsi/longhorn-iscsi-installation.yaml
@@ -16,7 +16,8 @@ spec:
         app: longhorn-iscsi-installation
     spec:
       hostNetwork: true
-      containers:
+      hostPID: true
+      initContainers:
       - name: iscsi-installation
         command:
           - nsenter
@@ -28,4 +29,8 @@ spec:
         image: alpine:3.7
         securityContext:
           privileged: true
-      hostPID: true
+      containers:
+      - name: sleep
+        image: k8s.gcr.io/pause:3.1
+  updateStrategy:
+    type: RollingUpdate


### PR DESCRIPTION
We install iscsi in the init container then sleep in the main container. This avoids crash loop after finishing installing iscsi

longhorn/longhorn#1741