### PR TITLE
chart: Update Kubernetes version requirement for chart

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: longhorn
 version: 1.1.0-rc1
 appVersion: v1.1.0-rc1
-kubeVersion: ">=v1.14.0-r0"
+kubeVersion: ">=v1.16.0-r0"
 description: Longhorn is a distributed block storage system for Kubernetes.
 keywords:
 - longhorn

--- a/chart/README.md
+++ b/chart/README.md
@@ -16,7 +16,7 @@ Longhorn is 100% open source software. Project source code is spread across a nu
 ## Prerequisites
 
 1. Docker v1.13+
-2. Kubernetes v1.15+
+2. Kubernetes v1.16+
 3. Make sure `curl`, `findmnt`, `grep`, `awk` and `blkid` has been installed in all nodes of the Kubernetes cluster.
 4. Make sure `open-iscsi` has been installed in all nodes of the Kubernetes cluster. For GKE, recommended Ubuntu as guest OS image since it contains `open-iscsi` already.
 


### PR DESCRIPTION
Since we update the CRD apiVersion to apiextensions.k8s.io/v1, the
minimal Kubernetes version requirement is v1.16 now.

Longhorn #2061