### PR TITLE
chart: Remove the annotation which causes CRDs not removed during uninstallation

### DIFF
--- a/chart/templates/crds.yaml
+++ b/chart/templates/crds.yaml
@@ -3,8 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: Engine
-  annotations:
-    helm.sh/resource-policy: keep
   name: engines.longhorn.io
 spec:
   group: longhorn.io
@@ -56,8 +54,6 @@ kind: CustomResourceDefinition
 metadata:
   labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: Replica
-  annotations:
-    helm.sh/resource-policy: keep
   name: replicas.longhorn.io
 spec:
   group: longhorn.io
@@ -113,8 +109,6 @@ kind: CustomResourceDefinition
 metadata:
   labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: Setting
-  annotations:
-    helm.sh/resource-policy: keep
   name: settings.longhorn.io
 spec:
   group: longhorn.io
@@ -147,8 +141,6 @@ kind: CustomResourceDefinition
 metadata:
   labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: Volume
-  annotations:
-    helm.sh/resource-policy: keep
   name: volumes.longhorn.io
 spec:
   group: longhorn.io
@@ -204,8 +196,6 @@ kind: CustomResourceDefinition
 metadata:
   labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: EngineImage
-  annotations:
-    helm.sh/resource-policy: keep
   name: engineimages.longhorn.io
 spec:
   group: longhorn.io
@@ -257,8 +247,6 @@ kind: CustomResourceDefinition
 metadata:
   labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: Node
-  annotations:
-    helm.sh/resource-policy: keep
   name: nodes.longhorn.io
 spec:
   group: longhorn.io
@@ -306,8 +294,6 @@ kind: CustomResourceDefinition
 metadata:
   labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: InstanceManager
-  annotations:
-    helm.sh/resource-policy: keep
   name: instancemanagers.longhorn.io
 spec:
   group: longhorn.io
@@ -355,8 +341,6 @@ kind: CustomResourceDefinition
 metadata:
   labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: ShareManager
-  annotations:
-    helm.sh/resource-policy: keep
   name: sharemanagers.longhorn.io
 spec:
   group: longhorn.io


### PR DESCRIPTION
Will find another way to migrate the CRD file later.

Longhorn #2035

Signed-off-by: Shuo Wu <shuo@rancher.com>