### PR TITLE
Update default share-manager image to v1_20210106

### DIFF
--- a/chart/questions.yml
+++ b/chart/questions.yml
@@ -65,7 +65,7 @@ questions:
     label: Longhorn Share Manager Image Repository
     group: "Longhorn Images Settings"
   - variable: image.longhorn.shareManager.tag
-    default: v1_20201204
+    default: v1_20210106
     description: "Specify Longhorn Share Manager Image Tag"
     type: string
     label: Longhorn Share Manager Image Tag

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -21,7 +21,7 @@ image:
       tag: v1_20201216
     shareManager:
       repository: longhornio/longhorn-share-manager
-      tag: v1_20201204
+      tag: v1_20210106
   csi:
     attacher:
       repository: longhornio/csi-attacher


### PR DESCRIPTION
We switched from fedora to an ubuntu base image, to support the security
scanner.

longhorn/longhorn#2111

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>
