### PR TITLE
add manifest to install nfs using daemonset (#2033)

### DIFF
--- a/deploy/nfs/longhorn-nfs-installation.yaml
+++ b/deploy/nfs/longhorn-nfs-installation.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: longhorn-nfs-installation
+  labels:
+    app: longhorn-nfs-installation
+  annotations:
+    command: &cmd OS=$(grep "ID_LIKE" /etc/os-release | cut -d '=' -f 2); if [[ "${OS}" == *"debian"* ]]; then sudo apt-get update -q -y && sudo apt-get install -q -y nfs-common; elif [[ "${OS}" == *"suse"* ]]; then sudo zypper --gpg-auto-import-keys -q refresh && sudo zypper --gpg-auto-import-keys -q install -y nfs-client; else sudo yum makecache fast -q -y && sudo yum --setopt=tsflags=noscripts install -q -y nfs-utils; fi && if [ $? -eq 0 ]; then echo "nfs install successfully"; else echo "nfs install failed error code $?"; fi
+spec:
+  selector:
+    matchLabels:
+      app: longhorn-nfs-installation
+  template:
+    metadata:
+      labels:
+        app: longhorn-nfs-installation
+    spec:
+      hostNetwork: true
+      hostPID: true
+      initContainers:
+      - name: nfs-installation
+        command:
+          - nsenter
+          - --mount=/proc/1/ns/mnt
+          - --
+          - bash
+          - -c
+          - *cmd
+        image: alpine:3.12
+        securityContext:
+          privileged: true
+      containers:
+      - name: sleep
+        image: k8s.gcr.io/pause:3.1
+  updateStrategy:
+    type: RollingUpdate


### PR DESCRIPTION
#### Proposed Changes ####

1. Add manifest to install `nkfs-client` using deamonset/initcontainer

#### Types of Changes ####

New Feature.

#### Verification ####

1. Deploy RKE/K3S on Centos/Ubuntu/SLES15SP2 and Verify if containers run successfully on each node and installed package run successfully.

#### Linked Issues ####

Refs: #2033

#### Further Comments ####

None

Signed-off-by: cclhsu <clark.hsu@suse.com>