### PR TITLE
Add support for ingressClassName in helm chart

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -14,6 +14,9 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   rules:
   - host: {{ .Values.ingress.host }}
     http:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -151,6 +151,9 @@ ingress:
   ## Set to true to enable ingress record generation
   enabled: false
 
+  ## Add ingressClassName to the Ingress
+  ## Can replace the kubernetes.io/ingress.class annotation on v1.18+
+  ingressClassName: ~
 
   host: xip.io
 


### PR DESCRIPTION
This PR adds support for `ingressClassName` on `Ingress` object in the Helm Chart.

See related [blog post](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/)

Fixes #2257