### PR TITLE
Update default share-manager image to v1_20210302

### DIFF
--- a/chart/questions.yml
+++ b/chart/questions.yml
@@ -65,7 +65,7 @@ questions:
     label: Longhorn Share Manager Image Repository
     group: "Longhorn Images Settings"
   - variable: image.longhorn.shareManager.tag
-    default: v1_20210106
+    default: v1_20210302
     description: "Specify Longhorn Share Manager Image Tag"
     type: string
     label: Longhorn Share Manager Image Tag

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -21,7 +21,7 @@ image:
       tag: v1_20201216
     shareManager:
       repository: longhornio/longhorn-share-manager
-      tag: v1_20210106
+      tag: v1_20210302
   csi:
     attacher:
       repository: longhornio/csi-attacher


### PR DESCRIPTION
Include
- Patched nfs-ganesha v3.3 to fallback to ipv4 when ipv6 is not available.
  https://github.com/longhorn/longhorn/issues/2197

- Fix for pod hanging at ganasha server error due to missing /etc/mtab file in Ubuntu image.
  https://github.com/longhorn/longhorn/issues/2111

Test: https://github.com/longhorn/longhorn/issues/2197#issuecomment-788595045