### PR TITLE
Update default share-manager image to v1_20210406

### DIFF
--- a/chart/questions.yml
+++ b/chart/questions.yml
@@ -65,7 +65,7 @@ questions:
     label: Longhorn Share Manager Image Repository
     group: "Longhorn Images Settings"
   - variable: image.longhorn.shareManager.tag
-    default: v1_20210302
+    default: v1_20210406
     description: "Specify Longhorn Share Manager Image Tag"
     type: string
     label: Longhorn Share Manager Image Tag

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -21,7 +21,7 @@ image:
       tag: v1_20201216
     shareManager:
       repository: longhornio/longhorn-share-manager
-      tag: v1_20210302
+      tag: v1_20210406
   csi:
     attacher:
       repository: longhornio/csi-attacher

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -1,6 +1,6 @@
 longhornio/longhorn-engine:v1.1.1-preview1
 longhornio/longhorn-instance-manager:v1_20201216
-longhornio/longhorn-share-manager:v1_20210302
+longhornio/longhorn-share-manager:v1_20210406
 longhornio/longhorn-manager:v1.1.1-preview1
 longhornio/longhorn-ui:v1.1.1-preview1
 longhornio/csi-attacher:v2.2.1-lh1

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -652,7 +652,7 @@ spec:
         - --instance-manager-image
         - longhornio/longhorn-instance-manager:v1_20201216
         - --share-manager-image
-        - longhornio/longhorn-share-manager:v1_20210302
+        - longhornio/longhorn-share-manager:v1_20210406
         - --manager-image
         - longhornio/longhorn-manager:v1.1.1-preview1
         - --service-account

--- a/deploy/release-images.txt
+++ b/deploy/release-images.txt
@@ -1,6 +1,6 @@
 longhornio/longhorn-engine:v1.1.1-preview1
 longhornio/longhorn-instance-manager:v1_20201216
-longhornio/longhorn-share-manager:v1_20210302
+longhornio/longhorn-share-manager:v1_20210406
 longhornio/longhorn-manager:v1.1.1-preview1
 longhornio/longhorn-ui:v1.1.1-preview1
 longhornio/csi-attacher:v2.2.1-lh1


### PR DESCRIPTION
Include:
* Fix rwx mount ownership reset to nobody (https://github.com/longhorn/longhorn/issues/2357)