### PR TITLE
Make service ipFamilies configurable

### DIFF
--- a/chart/templates/daemonset-sa.yaml
+++ b/chart/templates/daemonset-sa.yaml
@@ -102,6 +102,12 @@ metadata:
   namespace: {{ include "release_namespace" . }}
 spec:
   type: {{ .Values.service.manager.type }}
+  {{- if .Values.service.manager.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.service.manager.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.service.manager.ipFamilies }}
+  ipFamilies: {{ .Values.service.manager.ipFamilies }}
+  {{- end }}
   sessionAffinity: ClientIP
   selector:
     app: longhorn-manager

--- a/chart/templates/deployment-ui.yaml
+++ b/chart/templates/deployment-ui.yaml
@@ -48,6 +48,13 @@ spec:
   {{- else }}
   type: {{ .Values.service.ui.type }}
   {{- end }}
+  type: {{ .Values.service.ui.type }}
+  {{- if .Values.service.ui.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.service.ui.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.service.ui.ipFamilies }}
+  ipFamilies: {{ .Values.service.ui.ipFamilies }}
+  {{- end }}
   selector:
     app: longhorn-ui
   ports:

--- a/chart/templates/deployment-ui.yaml
+++ b/chart/templates/deployment-ui.yaml
@@ -48,7 +48,6 @@ spec:
   {{- else }}
   type: {{ .Values.service.ui.type }}
   {{- end }}
-  type: {{ .Values.service.ui.type }}
   {{- if .Values.service.ui.ipFamilyPolicy }}
   ipFamilyPolicy: {{ .Values.service.ui.ipFamilyPolicy }}
   {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -44,9 +44,13 @@ service:
   ui:
     type: ClusterIP
     nodePort: null
+    ipFamilyPolicy: null
+    ipFamilies: null
   manager:
     type: ClusterIP
     nodePort: ""
+    ipFamilyPolicy: null
+    ipFamilies: null
 
 persistence:
   defaultClass: true


### PR DESCRIPTION
This pull request is mostly an reference to the linked issue, but I can develop it further if it is something you would like to merge. 

Current Helm chart does not work in dual-stack cluster. This configuration addition makes it possible to force services into IPv4 only mode.

See: https://github.com/longhorn/longhorn/issues/2452