### PR TITLE
Allow user to set node selector for system managed components, manager, UI, driver deployer

### DIFF
--- a/chart/questions.yml
+++ b/chart/questions.yml
@@ -304,26 +304,6 @@ The available modes are:
     type: int
     min: 0
     default: 300
-  - variable: defaultSettings.taintToleration
-    label: Kubernetes Taint Toleration
-    description: "To dedicate nodes to store Longhorn replicas and reject other general workloads, set tolerations for Longhorn and add taints for the storage nodes.
-All Longhorn volumes should be detached before modifying toleration settings.
-We recommend setting tolerations during Longhorn deployment because the Longhorn system cannot be operated during the update.
-Multiple tolerations can be set here, and these tolerations are separated by semicolon. For example:
-* `key1=value1:NoSchedule; key2:NoExecute`
-* `:` this toleration tolerates everything because an empty key with operator `Exists` matches all keys, values and effects
-* `key1=value1:`  this toleration has empty effect. It matches all effects with key `key1`
-Because `kubernetes.io` is used as the key of all Kubernetes default tolerations, it should not be used in the toleration settings.
-WARNING: DO NOT CHANGE THIS SETTING WITH ATTACHED VOLUMES!"
-    group: "Longhorn Default Settings"
-    type: string
-    default: ""
-  - variable: defaultSettings.priorityClass
-    label: Priority Class
-    description: "The name of the Priority Class to set on the Longhorn workloads. This can help prevent Longhorn workloads from being evicted under Node Pressure. WARNING: DO NOT CHANGE THIS SETTING WITH ATTACHED VOLUMES."
-    group: "Longhorn Default Settings"
-    type: string
-    default: ""
   - variable: defaultSettings.autoSalvage
     label: Automatic salvage
     description: "If enabled, volumes will be automatically salvaged when all the replicas become faulty e.g. due to network disconnection. Longhorn will try to figure out which replica(s) are usable, then use them for the volume. By default true."

--- a/chart/templates/daemonset-sa.yaml
+++ b/chart/templates/daemonset-sa.yaml
@@ -96,6 +96,10 @@ spec:
       tolerations:
 {{ toYaml .Values.longhornManager.tolerations | indent 6 }}
       {{- end }}
+      {{- if .Values.longhornManager.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.longhornManager.nodeSelector | indent 8 }}
+      {{- end }}
   updateStrategy:
     rollingUpdate:
       maxUnavailable: "100%"

--- a/chart/templates/default-setting.yaml
+++ b/chart/templates/default-setting.yaml
@@ -21,6 +21,7 @@ data:
     default-longhorn-static-storage-class: {{ .Values.defaultSettings.defaultLonghornStaticStorageClass }}
     backupstore-poll-interval: {{ .Values.defaultSettings.backupstorePollInterval }}
     taint-toleration: {{ .Values.defaultSettings.taintToleration }}
+    system-managed-components-node-selector: {{ .Values.defaultSettings.systemManagedComponentsNodeSelector }}
     priority-class: {{ .Values.defaultSettings.priorityClass }}
     auto-salvage: {{ .Values.defaultSettings.autoSalvage }}
     auto-delete-pod-when-volume-detached-unexpectedly: {{ .Values.defaultSettings.autoDeletePodWhenVolumeDetachedUnexpectedly }}

--- a/chart/templates/deployment-driver.yaml
+++ b/chart/templates/deployment-driver.yaml
@@ -95,6 +95,10 @@ spec:
       tolerations:
 {{ toYaml .Values.longhornDriver.tolerations | indent 6 }}
       {{- end }}
+      {{- if .Values.longhornDriver.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.longhornDriver.nodeSelector | indent 8 }}
+      {{- end }}
       serviceAccountName: longhorn-service-account
       securityContext:
         runAsUser: 0

--- a/chart/templates/deployment-ui.yaml
+++ b/chart/templates/deployment-ui.yaml
@@ -38,6 +38,10 @@ spec:
       tolerations:
 {{ toYaml .Values.longhornManager.tolerations | indent 6 }}
       {{- end }}
+      {{- if .Values.longhornUI.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.longhornManager.nodeSelector | indent 8 }}
+      {{- end }}
 ---
 kind: Service
 apiVersion: v1

--- a/chart/templates/postupgrade-job.yaml
+++ b/chart/templates/postupgrade-job.yaml
@@ -42,3 +42,7 @@ spec:
       tolerations:
 {{ toYaml .Values.longhornManager.tolerations | indent 6 }}
       {{- end }}
+      {{- if .Values.longhornManager.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.longhornManager.nodeSelector | indent 8 }}
+      {{- end }}

--- a/chart/templates/uninstall-job.yaml
+++ b/chart/templates/uninstall-job.yaml
@@ -43,3 +43,7 @@ spec:
       tolerations:
 {{ toYaml .Values.longhornManager.tolerations | indent 6 }}
       {{- end }}
+      {{- if .Values.longhornManager.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.longhornManager.nodeSelector | indent 8 }}
+      {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -82,6 +82,7 @@ defaultSettings:
   defaultLonghornStaticStorageClass: ~
   backupstorePollInterval: ~
   taintToleration: ~
+  systemManagedComponentsNodeSelector: ~
   priorityClass: ~
   autoSalvage: ~
   autoDeletePodWhenVolumeDetachedUnexpectedly: ~
@@ -116,26 +117,41 @@ longhornManager:
   #   operator: "Equal"
   #   value: "value"
   #   effect: "NoSchedule"
+  nodeSelector: {}
+  ## If you want to set node selector for Longhorn Manager DaemonSet, delete the `{}` in the line above
+  ## and uncomment this example block
+  #  label-key1: "label-value1"
+  #  label-key2: "label-value2"
 
 longhornDriver:
   priorityClass: ~
   tolerations: []
-  ## If you want to set tolerations for Longhorn Manager DaemonSet, delete the `[]` in the line above
+  ## If you want to set tolerations for Longhorn Driver Deployer Deployment, delete the `[]` in the line above
   ## and uncomment this example block
   # - key: "key"
   #   operator: "Equal"
   #   value: "value"
   #   effect: "NoSchedule"
+  nodeSelector: {}
+  ## If you want to set node selector for Longhorn Driver Deployer Deployment, delete the `{}` in the line above
+  ## and uncomment this example block
+  #  label-key1: "label-value1"
+  #  label-key2: "label-value2"
 
 longhornUI:
   priorityClass: ~
   tolerations: []
-  ## If you want to set tolerations for Longhorn Manager DaemonSet, delete the `[]` in the line above
+  ## If you want to set tolerations for Longhorn UI Deployment, delete the `[]` in the line above
   ## and uncomment this example block
   # - key: "key"
   #   operator: "Equal"
   #   value: "value"
   #   effect: "NoSchedule"
+  nodeSelector: {}
+  ## If you want to set node selector for Longhorn UI Deployment, delete the `{}` in the line above
+  ## and uncomment this example block
+  #  label-key1: "label-value1"
+  #  label-key2: "label-value2"
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This feature allow user to deploy Longhorn only on a specific
set of nodes

Modification:
1. Remove the `toleration` and `priority class` settings from `question.yaml`. 
 User cannot set `toleration` for the user-deployed components  (manager, UI, Driver) from the `question.yaml` because Rancher chart [doesn't allow question of type `array`](https://github.com/rancher/rancher/issues/24918). Therefore, user must choose to `Edit as YAML` in Rancher Ui when install Longhorn . On the other hand, if user wants set `toleration` and `priority class` for Longhorn, they must set them for both system managed components and user-deployed components. Therefore, to avoid the mistakes, we remove everything from the `question.yaml` and user can edit the yaml to specify value for both system managed components and user-deployed components. 
2. Allow user to specify node selector for  system managed components and user-deployed components. Again, user must chose `edit as YAML` because the limitation of Rancher chart.

longhorn/longhorn#2199