### PR TITLE
[Chart Helm] Allow to specify custom labels/annotations for managers pods

### DIFF
--- a/chart/templates/daemonset-sa.yaml
+++ b/chart/templates/daemonset-sa.yaml
@@ -11,8 +11,15 @@ spec:
       app: longhorn-manager
   template:
     metadata:
+      annotations:
+      {{- with .Values.managers.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels: {{- include "longhorn.labels" . | nindent 8 }}
         app: longhorn-manager
+      {{- with .Values.managers.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       containers:
       - name: longhorn-manager

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -114,6 +114,12 @@ resources: {}
   #  memory: 128Mi
   #
 
+managers:
+  # Additional pod annotations (e.g. for mesh injection or prometheus scraping)
+  podAnnotations: {}
+  # Additional Pod labels (e.g. for filtering Pod by custom labels)
+  podLabels: {}
+
 ingress:
   ## Set to true to enable ingress record generation
   enabled: false


### PR DESCRIPTION
# Resume
The goal of this PR is to allow users to set custom labels/annotations on longhorn managers pods.

# Use case
According to [longhorn prometheus integration documentation](https://longhorn.io/docs/1.1.0/monitoring/prometheus_and_grafana_setup/), longhorn managers expose `/metrics` endpoint that can be scraped by Prometheus.

# Usage

Specifying thoses options in chart values should enable Prometheus auto-discovery : 
```yaml
managers:
  # Additional pod annotations (e.g. for mesh injection or prometheus scraping)
  podAnnotations:
    prometheus.io/path: "/metrics"
    prometheus.io/port: "9500"
    prometheus.io/scheme: "http"
    prometheus.io/scrape: "true"
```

# References

- [Prometheus service auto discovery through pod annotations](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config)
- [Prometheus Chart auto discovery config](https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/values.yaml#L1575)