### PR TITLE
Fix ability to provide own tls certificate for ingress.

### DIFF
--- a/chart/templates/tls-secrets.yaml
+++ b/chart/templates/tls-secrets.yaml
@@ -3,9 +3,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: longhorn
-  namespace: {{ include "release_namespace" . }}
-  labels: {{- include "longhorn.labels" . | nindent 4 }}
+  name: {{ .name }}
+  namespace: {{ include "release_namespace" $ }}
+  labels: {{- include "longhorn.labels" $ | nindent 4 }}
     app: longhorn
 type: kubernetes.io/tls
 data:


### PR DESCRIPTION
This fixes longhorn/longhorn#2615.

`$ cat values-fix.yaml`
```yaml
ingress:
  enabled: true
  ingressClassName: nginx
  host: xip.io
  tls: true
  tlsSecret:
    name: longhorn-tls
    certificate: |
      -----BEGIN CERTIFICATE-----
      MIIGUzCCBDugAwIBAgICAMswDQYJKoZIhvcNAQELBQAwZDELMAkGA1UEBhMCQ1ox
      GzAZBgNVBAoTEkNlc2tlIGRyYWh5LCBhLiBzLjEmMCQGA1UECxMdQ0QgLSBJbmZv
      AXherC8keWXJ+9dmeG5PkU5gFHFKDc3gnTeYnD2PaagwaD/StqEk
      -----END CERTIFICATE-----
    key: |
      -----BEGIN RSA PRIVATE KEY-----
      MIIEowIBAAKCAQEAp8uLTKyoizTbuj4axag7xGx6yxGCcAlQWt25SQFPfA1H/o2v
      Vzz40D9RNjezIjDRw4BEarYmJ8qu3TkAdhIpRz0eLy4qC1CoyRUvyjwZglJt0MXK
      +UZlBYbzNVp72UVrwkC1irCjGta9bkZuKZc6HaX+HiOxKpH3WZYO
      -----END RSA PRIVATE KEY-----
```

```bash
$ helm install longhorn ../jC3rny/longhorn/chart/ --values values-fix.yaml --dry-run --debug

---
# Source: longhorn/templates/tls-secrets.yaml
apiVersion: v1
kind: Secret
metadata:
  name: longhorn-tls
  namespace: default
  labels:
    app.kubernetes.io/name: longhorn
    helm.sh/chart: longhorn-1.1.1
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/instance: longhorn
    app.kubernetes.io/version: v1.1.1
    app: longhorn
type: kubernetes.io/tls
data:
  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUdVekNDQkR1Z0F3SUJBZ0lDQU1zd0RRWUpLb1pJaHZjTkFRRUxCUUF3WkRFTE1Ba0dBMVVFQmhNQ1Exb3gKR3pBWkJnTlZCQW9URWtObGMydGxJR1J5WVdoNUxDQmhMaUJ6TGpF
bU1DUUdBMVVFQ3hNZFEwUWdMU0JKYm1adgpBWGhlckM4a2VXWEorOWRtZUc1UGtVNWdGSEZLRGMzZ25UZVluRDJQYWFnd2FEL1N0cUVrCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
  tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBcDh1TFRLeW9pelRidWo0YXhhZzd4R3g2eXhHQ2NBbFFXdDI1U1FGUGZBMUgvbzJ2ClZ6ejQwRDlSTmpleklqRFJ3NEJFYXJZbUo4cXUzVGtBZGhJ
cFJ6MGVMeTRxQzFDb3lSVXZ5andaZ2xKdDBNWEsKK1VabEJZYnpOVnA3MlVWcndrQzFpckNqR3RhOWJrWnVLWmM2SGFYK0hpT3hLcEgzV1pZTwotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
---
# Source: longhorn/templates/ingress.yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: longhorn-ingress
  namespace: default
  labels:
    app.kubernetes.io/name: longhorn
    helm.sh/chart: longhorn-1.1.1
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/instance: longhorn
    app.kubernetes.io/version: v1.1.1
    app: longhorn-ingress
  annotations:
    ingress.kubernetes.io/secure-backends: "true"
spec:
  ingressClassName: nginx
  rules:
  - host: xip.io
    http:
      paths:
        - path:
          backend:
            serviceName: longhorn-frontend
            servicePort: 80
  tls:
  - hosts:
    - xip.io
    secretName: longhorn-tls

```

Works as expected...
