### PR TITLE
Revert "Update chart to allow user to disable-profiler"

### DIFF
--- a/chart/templates/daemonset-sa.yaml
+++ b/chart/templates/daemonset-sa.yaml
@@ -40,9 +40,6 @@ spec:
         - "{{ template "registry_url" . }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}"
         - --service-account
         - longhorn-service-account
-        {{- if .Values.longhornManager.disableProfiler }}
-        - --disable-profiler
-        {{- end }}
         ports:
         - containerPort: 9500
           name: manager

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -124,9 +124,6 @@ longhornManager:
   #  label-key1: "label-value1"
   #  label-key2: "label-value2"
 
-  ## Set to true to disable profiler
-  disableProfiler: false
-
 longhornDriver:
   priorityClass: ~
   tolerations: []


### PR DESCRIPTION
This reverts commit 3b64d301eeeffc3a7be1ae33d5ca346a74d816c0.

https://github.com/longhorn/longhorn-manager/pull/938
https://github.com/longhorn/longhorn/issues/2696#issuecomment-863995649