### PR TITLE
chart: Update default tag for instance manager in question.yml

### DIFF
--- a/chart/questions.yml
+++ b/chart/questions.yml
@@ -53,7 +53,7 @@ questions:
     label: Longhorn Instance Manager Image Repository
     group: "Longhorn Images Settings"
   - variable: image.longhorn.instanceManager.tag
-    default: v1_20201216
+    default: v1_20210621
     description: "Specify Longhorn Instance Manager Image Tag"
     type: string
     label: Longhorn Instance Manager Image Tag


### PR DESCRIPTION
Need to reconsider if we can remove the default values in `question.yml` since we already have ones in `values.yaml`