### PR TITLE
chore: fix wrong values used for ui tolerations and nodeselectors

### DIFF
--- a/chart/templates/deployment-ui.yaml
+++ b/chart/templates/deployment-ui.yaml
@@ -36,11 +36,11 @@ spec:
       {{- end }}
       {{- if .Values.longhornUI.tolerations }}
       tolerations:
-{{ toYaml .Values.longhornManager.tolerations | indent 6 }}
+{{ toYaml .Values.longhornUI.tolerations | indent 6 }}
       {{- end }}
       {{- if .Values.longhornUI.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.longhornManager.nodeSelector | indent 8 }}
+{{ toYaml .Values.longhornUI.nodeSelector | indent 8 }}
       {{- end }}
 ---
 kind: Service


### PR DESCRIPTION
Micro PR to fix a typo in Helm chart. UI deployment was using the manager tolerations and nodeselectors.