### PR TITLE
Chart: explicitly set default fsType to EXT4

### DIFF
--- a/chart/templates/storageclass.yaml
+++ b/chart/templates/storageclass.yaml
@@ -20,6 +20,9 @@ data:
       numberOfReplicas: "{{ .Values.persistence.defaultClassReplicaCount }}"
       staleReplicaTimeout: "30"
       fromBackup: ""
+      {{- if .Values.persistence.defaultFsType }}
+      fsType: "{{.Values.persistence.defaultFsType}}"
+      {{- end }}
       {{- if .Values.persistence.backingImage.enable }}
       backingImage: {{ .Values.persistence.backingImage.name }}
       backingImageDataSourceType: {{ .Values.persistence.backingImage.dataSourceType }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -53,6 +53,7 @@ service:
 
 persistence:
   defaultClass: true
+  defaultFsType: ext4
   defaultClassReplicaCount: 3
   reclaimPolicy: Delete
   recurringJobSelector:


### PR DESCRIPTION
This allow Kubernetes to properly changes the volume ownership
and permissions when user specify fsGroup in workload pod

longhorn/longhorn#2964