### PR TITLE
fix: update host for ingress

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -179,7 +179,7 @@ ingress:
   ## Can replace the kubernetes.io/ingress.class annotation on v1.18+
   ingressClassName: ~
 
-  host: xip.io
+  host: sslip.io
 
   ## Set this to true in order to enable TLS on the ingress record
   ## A side effect of this will be that the backend service will be connected at port 443


### PR DESCRIPTION
`xip.io` has been shut down for a while now. So, I have updated the host parameter to what rancher now uses ie `sslip.io`