### PR TITLE
Explicitly set default fsType to EXT4

### DIFF
--- a/chart/templates/storageclass.yaml
+++ b/chart/templates/storageclass.yaml
@@ -20,6 +20,9 @@ data:
       numberOfReplicas: "{{ .Values.persistence.defaultClassReplicaCount }}"
       staleReplicaTimeout: "30"
       fromBackup: ""
+      {{- if .Values.persistence.defaultFsType }}
+      fsType: "{{.Values.persistence.defaultFsType}}"
+      {{- end }}
       {{- if .Values.persistence.backingImage.enable }}
       backingImage: {{ .Values.persistence.backingImage.name }}
       backingImageDataSourceType: {{ .Values.persistence.backingImage.dataSourceType }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -53,6 +53,7 @@ service:
 
 persistence:
   defaultClass: true
+  defaultFsType: ext4
   defaultClassReplicaCount: 3
   reclaimPolicy: Delete
   recurringJobSelector:

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -954,6 +954,7 @@ data:
       numberOfReplicas: "3"
       staleReplicaTimeout: "2880"
       fromBackup: ""
+      fsType: "ext4"
     #  backingImage: "bi-test"
     #  backingImageDataSourceType: "download"
     #  backingImageDataSourceParameters: '{"url": "https://backing-image-example.s3-region.amazonaws.com/test-backing-image"}'

--- a/examples/storageclass.yaml
+++ b/examples/storageclass.yaml
@@ -10,6 +10,7 @@ parameters:
   numberOfReplicas: "2"
   staleReplicaTimeout: "2880"
   fromBackup: ""
+  fsType: "ext4"
 #  backingImage: "bi-test"
 #  backingImageDataSourceType: "download"
 #  backingImageDataSourceParameters: '{"url": "https://backing-image-example.s3-region.amazonaws.com/test-backing-image"}'


### PR DESCRIPTION
This allow Kubernetes to properly changes the volume ownership
and permissions when user specify fsGroup in workload pod

https://github.com/longhorn/longhorn/issues/2964

Signed-off-by: phanle1010 <phan.le@suse.com>
(cherry picked from commit f2856cd358007d9409fdfec5dbcb8094bc085c2f)