### PR TITLE
Add maximum supported Kubernetes version

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: longhorn
 version: 1.1.3-rc1
 appVersion: v1.1.3-rc1
-kubeVersion: ">=v1.16.0-r0"
+kubeVersion: ">=v1.16.0-r0 <v1.22.0-r0"
 description: Longhorn is a distributed block storage system for Kubernetes.
 keywords:
 - longhorn


### PR DESCRIPTION
The maximum supported Kubernetes version of Longhorn v1.1.x is v1.21.x.

https://github.com/longhorn/longhorn/issues/3319

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>