### PR TITLE
Remove maximum limitation for engine/replica CPU request

### DIFF
--- a/chart/templates/crds.yaml
+++ b/chart/templates/crds.yaml
@@ -1326,7 +1326,6 @@ spec:
                   type: object
                 type: object
               engineManagerCPURequest:
-                maximum: 40
                 minimum: 0
                 type: integer
               evictionRequested:
@@ -1334,7 +1333,6 @@ spec:
               name:
                 type: string
               replicaManagerCPURequest:
-                maximum: 40
                 minimum: 0
                 type: integer
               tags:


### PR DESCRIPTION
#### Proposal Change

There're 2 settings to control the engine/replica CPU request.
One is the global setting, the unit is the percentage(%).
The other one is per node setting, the unit is the milli CPU.

The max limit applies to the global setting only, which means a maximum of 40% of
total CPU per node.

The global setting will be ignored for a node if the node's
engine/replica on the node is set.

#### Issue

https://github.com/longhorn/longhorn/issues/791

#### Additional Context

This fixes https://ci.longhorn.io/job/public/job/master/job/ubuntu/job/amd64/job/longhorn-tests-ubuntu-amd64/500/testReport/junit/tests/test_settings/test_instance_manager_cpu_reservation/
