### PR TITLE
Improve the way to validate the current engine

### DIFF
--- a/chart/templates/crds.yaml
+++ b/chart/templates/crds.yaml
@@ -920,6 +920,8 @@ spec:
           spec:
             description: EngineSpec defines the desired state of the Longhorn engine
             properties:
+              active:
+                type: boolean
               backupVolume:
                 type: string
               desireState:


### PR DESCRIPTION
Introduce a new field engine.Spec.Active to indicate if the engine is the current one
    
https://github.com/longhorn/longhorn/issues/3206