### PR TITLE
Fixed bug chart cannot be installed with Helm 2

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: longhorn
 version: 1.1.3-rc2
 appVersion: v1.1.3-rc2
-kubeVersion: ">=v1.16.0-r0 <v1.22.0-r0"
+kubeVersion: ">= v1.16.0-0, < v1.22.0-0"
 description: Longhorn is a distributed block storage system for Kubernetes.
 keywords:
 - longhorn


### PR DESCRIPTION
* Separate Kubernetes version by command  so the chart work in Helm 2
* Also, use "-0" instead of "-r0" to capture pre-releases. See https://github.com/helm/helm/issues/6190

longhorn/longhorn#3356