### PR TITLE
feat(longhorn-UI): Allow specifying loadBalancer IP/SourceRanges

### DIFF
--- a/chart/templates/deployment-ui.yaml
+++ b/chart/templates/deployment-ui.yaml
@@ -59,6 +59,12 @@ spec:
   {{- else }}
   type: {{ .Values.service.ui.type }}
   {{- end }}
+  {{- if and .Values.service.ui.loadBalancerIP (eq .Values.service.ui.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.service.ui.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.service.ui.type "LoadBalancer") .Values.service.ui.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- toYaml .Values.service.ui.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
   selector:
     app: longhorn-ui
   ports:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -50,6 +50,8 @@ service:
   manager:
     type: ClusterIP
     nodePort: ""
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: ""
 
 persistence:
   defaultClass: true


### PR DESCRIPTION
This change allows users to specify loadBalancerIP/SourceRanges while for loadBalancer service type in Longhorn-UI service.