### PR TITLE
Do not generate schema for longhorn.io/v1beta1 CRD

### DIFF
--- a/chart/templates/crds.yaml
+++ b/chart/templates/crds.yaml
@@ -52,51 +52,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: BackingImageDataSourceSpec defines the desired state of the Longhorn backing image data source
-            properties:
-              checksum:
-                type: string
-              diskPath:
-                type: string
-              diskUUID:
-                type: string
-              fileTransferred:
-                type: boolean
-              nodeID:
-                type: string
-              parameters:
-                additionalProperties:
-                  type: string
-                type: object
-              sourceType:
-                enum:
-                - download
-                - upload
-                - export-from-volume
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
-            description: BackingImageDataSourceStatus defines the observed state of the Longhorn backing image data source
-            properties:
-              checksum:
-                type: string
-              currentState:
-                type: string
-              message:
-                type: string
-              ownerID:
-                type: string
-              progress:
-                type: integer
-              runningParameters:
-                additionalProperties:
-                  type: string
-                nullable: true
-                type: object
-              size:
-                format: int64
-                type: integer
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: false
@@ -251,69 +209,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: BackingImageManagerSpec defines the desired state of the Longhorn backing image manager
-            properties:
-              backingImages:
-                additionalProperties:
-                  type: string
-                type: object
-              diskPath:
-                type: string
-              diskUUID:
-                type: string
-              image:
-                type: string
-              nodeID:
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
-            description: BackingImageManagerStatus defines the observed state of the Longhorn backing image manager
-            properties:
-              apiMinVersion:
-                type: integer
-              apiVersion:
-                type: integer
-              backingImageFileMap:
-                additionalProperties:
-                  properties:
-                    currentChecksum:
-                      type: string
-                    directory:
-                      description: 'Deprecated: This field is useless.'
-                      type: string
-                    downloadProgress:
-                      description: 'Deprecated: This field is renamed to `Progress`.'
-                      type: integer
-                    message:
-                      type: string
-                    name:
-                      type: string
-                    progress:
-                      type: integer
-                    senderManagerAddress:
-                      type: string
-                    sendingReference:
-                      type: integer
-                    size:
-                      format: int64
-                      type: integer
-                    state:
-                      type: string
-                    url:
-                      description: 'Deprecated: This field is useless now. The manager of backing image files doesn''t care if a file is downloaded and how.'
-                      type: string
-                    uuid:
-                      type: string
-                  type: object
-                nullable: true
-                type: object
-              currentState:
-                type: string
-              ip:
-                type: string
-              ownerID:
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: false
@@ -474,73 +372,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: BackingImageSpec defines the desired state of the Longhorn backing image
-            properties:
-              checksum:
-                type: string
-              disks:
-                additionalProperties:
-                  type: string
-                type: object
-              imageURL:
-                description: 'Deprecated: This kind of info will be included in the related BackingImageDataSource.'
-                type: string
-              sourceParameters:
-                additionalProperties:
-                  type: string
-                type: object
-              sourceType:
-                enum:
-                - download
-                - upload
-                - export-from-volume
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
-            description: BackingImageStatus defines the observed state of the Longhorn backing image status
-            properties:
-              checksum:
-                type: string
-              diskDownloadProgressMap:
-                additionalProperties:
-                  type: integer
-                description: 'Deprecated: Replaced by field `Progress` in `DiskFileStatusMap`.'
-                nullable: true
-                type: object
-              diskDownloadStateMap:
-                additionalProperties:
-                  description: BackingImageDownloadState is replaced by BackingImageState.
-                  type: string
-                description: 'Deprecated: Replaced by field `State` in `DiskFileStatusMap`.'
-                nullable: true
-                type: object
-              diskFileStatusMap:
-                additionalProperties:
-                  properties:
-                    lastStateTransitionTime:
-                      type: string
-                    message:
-                      type: string
-                    progress:
-                      type: integer
-                    state:
-                      type: string
-                  type: object
-                nullable: true
-                type: object
-              diskLastRefAtMap:
-                additionalProperties:
-                  type: string
-                nullable: true
-                type: object
-              ownerID:
-                type: string
-              size:
-                format: int64
-                type: integer
-              uuid:
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: false
@@ -702,85 +536,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: BackupSpec defines the desired state of the Longhorn backup
-            properties:
-              labels:
-                additionalProperties:
-                  type: string
-                description: The labels of snapshot backup.
-                type: object
-              snapshotName:
-                description: The snapshot name.
-                type: string
-              syncRequestedAt:
-                description: The time to request run sync the remote backup.
-                format: date-time
-                nullable: true
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
-            description: BackupStatus defines the observed state of the Longhorn backup
-            properties:
-              backupCreatedAt:
-                description: The snapshot backup upload finished time.
-                type: string
-              error:
-                description: The error message when taking the snapshot backup.
-                type: string
-              labels:
-                additionalProperties:
-                  type: string
-                description: The labels of snapshot backup.
-                nullable: true
-                type: object
-              lastSyncedAt:
-                description: The last time that the backup was synced with the remote backup target.
-                format: date-time
-                nullable: true
-                type: string
-              messages:
-                additionalProperties:
-                  type: string
-                description: The error messages when calling longhorn engine on listing or inspecting backups.
-                nullable: true
-                type: object
-              ownerID:
-                description: The node ID on which the controller is responsible to reconcile this backup CR.
-                type: string
-              progress:
-                description: The snapshot backup progress.
-                type: integer
-              replicaAddress:
-                description: The address of the replica that runs snapshot backup.
-                type: string
-              size:
-                description: The snapshot size.
-                type: string
-              snapshotCreatedAt:
-                description: The snapshot creation time.
-                type: string
-              snapshotName:
-                description: The snapshot name.
-                type: string
-              state:
-                description: The backup creation state. Can be "", "InProgress", "Completed", "Error", "Unknown".
-                type: string
-              url:
-                description: The snapshot backup URL.
-                type: string
-              volumeBackingImageName:
-                description: The volume's backing image name.
-                type: string
-              volumeCreated:
-                description: The volume creation time.
-                type: string
-              volumeName:
-                description: The volume name.
-                type: string
-              volumeSize:
-                description: The volume size.
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: false
@@ -967,63 +725,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: BackupTargetSpec defines the desired state of the Longhorn backup target
-            properties:
-              backupTargetURL:
-                description: The backup target URL.
-                type: string
-              credentialSecret:
-                description: The backup target credential secret.
-                type: string
-              pollInterval:
-                description: The interval that the cluster needs to run sync with the backup target.
-                type: string
-              syncRequestedAt:
-                description: The time to request run sync the remote backup target.
-                format: date-time
-                nullable: true
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
-            description: BackupTargetStatus defines the observed state of the Longhorn backup target
-            properties:
-              available:
-                description: Available indicates if the remote backup target is available or not.
-                type: boolean
-              conditions:
-                additionalProperties:
-                  properties:
-                    lastProbeTime:
-                      description: Last time we probed the condition.
-                      type: string
-                    lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
-                      type: string
-                    message:
-                      description: Human-readable message indicating details about last transition.
-                      type: string
-                    reason:
-                      description: Unique, one-word, CamelCase reason for the condition's last transition.
-                      type: string
-                    status:
-                      description: Status is the status of the condition. Can be True, False, Unknown.
-                      type: string
-                    type:
-                      description: Type is the type of the condition.
-                      type: string
-                  type: object
-                description: Records the reason on why the backup target is unavailable.
-                nullable: true
-                type: object
-              lastSyncedAt:
-                description: The last time that the controller synced with the remote backup target.
-                format: date-time
-                nullable: true
-                type: string
-              ownerID:
-                description: The node ID on which the controller is responsible to reconcile this backup target CR.
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: false
@@ -1184,64 +888,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: BackupVolumeSpec defines the desired state of the Longhorn backup volume
-            properties:
-              syncRequestedAt:
-                description: The time to request run sync the remote backup volume.
-                format: date-time
-                nullable: true
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
-            description: BackupVolumeStatus defines the observed state of the Longhorn backup volume
-            properties:
-              backingImageChecksum:
-                description: the backing image checksum.
-                type: string
-              backingImageName:
-                description: The backing image name.
-                type: string
-              createdAt:
-                description: The backup volume creation time.
-                type: string
-              dataStored:
-                description: The backup volume block count.
-                type: string
-              labels:
-                additionalProperties:
-                  type: string
-                description: The backup volume labels.
-                nullable: true
-                type: object
-              lastBackupAt:
-                description: The latest volume backup time.
-                type: string
-              lastBackupName:
-                description: The latest volume backup name.
-                type: string
-              lastModificationTime:
-                description: The backup volume config last modification time.
-                format: date-time
-                nullable: true
-                type: string
-              lastSyncedAt:
-                description: The last time that the backup volume was synced into the cluster.
-                format: date-time
-                nullable: true
-                type: string
-              messages:
-                additionalProperties:
-                  type: string
-                description: The error messages when call longhorn engine on list or inspect backup volumes.
-                nullable: true
-                type: object
-              ownerID:
-                description: The node ID on which the controller is responsible to reconcile this backup volume CR.
-                type: string
-              size:
-                description: The backup volume size.
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: false
@@ -1402,70 +1051,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: EngineImageSpec defines the desired state of the Longhorn engine image
-            properties:
-              image:
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
-            description: EngineImageStatus defines the observed state of the Longhorn engine image
-            properties:
-              buildDate:
-                type: string
-              cliAPIMinVersion:
-                type: integer
-              cliAPIVersion:
-                type: integer
-              conditions:
-                additionalProperties:
-                  properties:
-                    lastProbeTime:
-                      description: Last time we probed the condition.
-                      type: string
-                    lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
-                      type: string
-                    message:
-                      description: Human-readable message indicating details about last transition.
-                      type: string
-                    reason:
-                      description: Unique, one-word, CamelCase reason for the condition's last transition.
-                      type: string
-                    status:
-                      description: Status is the status of the condition. Can be True, False, Unknown.
-                      type: string
-                    type:
-                      description: Type is the type of the condition.
-                      type: string
-                  type: object
-                nullable: true
-                type: object
-              controllerAPIMinVersion:
-                type: integer
-              controllerAPIVersion:
-                type: integer
-              dataFormatMinVersion:
-                type: integer
-              dataFormatVersion:
-                type: integer
-              gitCommit:
-                type: string
-              noRefSince:
-                type: string
-              nodeDeploymentMap:
-                additionalProperties:
-                  type: boolean
-                nullable: true
-                type: object
-              ownerID:
-                type: string
-              refCount:
-                type: integer
-              state:
-                type: string
-              version:
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: false
@@ -1635,211 +1223,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: EngineSpec defines the desired state of the Longhorn engine
-            properties:
-              active:
-                type: boolean
-              backupVolume:
-                type: string
-              desireState:
-                type: string
-              disableFrontend:
-                type: boolean
-              engineImage:
-                type: string
-              frontend:
-                enum:
-                - blockdev
-                - iscsi
-                - ""
-                type: string
-              logRequested:
-                type: boolean
-              nodeID:
-                type: string
-              replicaAddressMap:
-                additionalProperties:
-                  type: string
-                type: object
-              requestedBackupRestore:
-                type: string
-              requestedDataSource:
-                type: string
-              revisionCounterDisabled:
-                type: boolean
-              salvageRequested:
-                type: boolean
-              upgradedReplicaAddressMap:
-                additionalProperties:
-                  type: string
-                type: object
-              volumeName:
-                type: string
-              volumeSize:
-                format: int64
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
-            description: EngineStatus defines the observed state of the Longhorn engine
-            properties:
-              backupStatus:
-                additionalProperties:
-                  properties:
-                    backupURL:
-                      type: string
-                    error:
-                      type: string
-                    progress:
-                      type: integer
-                    replicaAddress:
-                      type: string
-                    snapshotName:
-                      type: string
-                    state:
-                      type: string
-                  type: object
-                nullable: true
-                type: object
-              cloneStatus:
-                additionalProperties:
-                  properties:
-                    error:
-                      type: string
-                    fromReplicaAddress:
-                      type: string
-                    isCloning:
-                      type: boolean
-                    progress:
-                      type: integer
-                    snapshotName:
-                      type: string
-                    state:
-                      type: string
-                  type: object
-                nullable: true
-                type: object
-              currentImage:
-                type: string
-              currentReplicaAddressMap:
-                additionalProperties:
-                  type: string
-                nullable: true
-                type: object
-              currentSize:
-                format: int64
-                type: string
-              currentState:
-                type: string
-              endpoint:
-                type: string
-              instanceManagerName:
-                type: string
-              ip:
-                type: string
-              isExpanding:
-                type: boolean
-              lastExpansionError:
-                type: string
-              lastExpansionFailedAt:
-                type: string
-              lastRestoredBackup:
-                type: string
-              logFetched:
-                type: boolean
-              ownerID:
-                type: string
-              port:
-                type: integer
-              purgeStatus:
-                additionalProperties:
-                  properties:
-                    error:
-                      type: string
-                    isPurging:
-                      type: boolean
-                    progress:
-                      type: integer
-                    state:
-                      type: string
-                  type: object
-                nullable: true
-                type: object
-              rebuildStatus:
-                additionalProperties:
-                  properties:
-                    error:
-                      type: string
-                    fromReplicaAddress:
-                      type: string
-                    isRebuilding:
-                      type: boolean
-                    progress:
-                      type: integer
-                    state:
-                      type: string
-                  type: object
-                nullable: true
-                type: object
-              replicaModeMap:
-                additionalProperties:
-                  type: string
-                nullable: true
-                type: object
-              restoreStatus:
-                additionalProperties:
-                  properties:
-                    backupURL:
-                      type: string
-                    currentRestoringBackup:
-                      type: string
-                    error:
-                      type: string
-                    filename:
-                      type: string
-                    isRestoring:
-                      type: boolean
-                    lastRestored:
-                      type: string
-                    progress:
-                      type: integer
-                    state:
-                      type: string
-                  type: object
-                nullable: true
-                type: object
-              salvageExecuted:
-                type: boolean
-              snapshots:
-                additionalProperties:
-                  properties:
-                    children:
-                      additionalProperties:
-                        type: boolean
-                      type: object
-                    created:
-                      type: string
-                    labels:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    name:
-                      type: string
-                    parent:
-                      type: string
-                    removed:
-                      type: boolean
-                    size:
-                      type: string
-                    usercreated:
-                      type: boolean
-                  type: object
-                nullable: true
-                type: object
-              snapshotsError:
-                type: string
-              started:
-                type: boolean
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: false
@@ -2146,68 +1532,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: InstanceManagerSpec defines the desired state of the Longhorn instancer manager
-            properties:
-              engineImage:
-                description: 'TODO: deprecate this field'
-                type: string
-              image:
-                type: string
-              nodeID:
-                type: string
-              type:
-                enum:
-                - engine
-                - replica
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
-            description: InstanceManagerStatus defines the observed state of the Longhorn instance manager
-            properties:
-              apiMinVersion:
-                type: integer
-              apiVersion:
-                type: integer
-              currentState:
-                type: string
-              instances:
-                additionalProperties:
-                  properties:
-                    spec:
-                      properties:
-                        name:
-                          type: string
-                      type: object
-                    status:
-                      properties:
-                        endpoint:
-                          type: string
-                        errorMsg:
-                          type: string
-                        listen:
-                          type: string
-                        portEnd:
-                          format: int32
-                          type: integer
-                        portStart:
-                          format: int32
-                          type: integer
-                        resourceVersion:
-                          format: int64
-                          type: integer
-                        state:
-                          type: string
-                        type:
-                          type: string
-                      type: object
-                  type: object
-                nullable: true
-                type: object
-              ip:
-                type: string
-              ownerID:
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: false
@@ -2367,122 +1694,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: NodeSpec defines the desired state of the Longhorn node
-            properties:
-              allowScheduling:
-                type: boolean
-              disks:
-                additionalProperties:
-                  properties:
-                    allowScheduling:
-                      type: boolean
-                    evictionRequested:
-                      type: boolean
-                    path:
-                      type: string
-                    storageReserved:
-                      format: int64
-                      type: integer
-                    tags:
-                      items:
-                        type: string
-                      type: array
-                  type: object
-                type: object
-              engineManagerCPURequest:
-                minimum: 0
-                type: integer
-              evictionRequested:
-                type: boolean
-              name:
-                type: string
-              replicaManagerCPURequest:
-                minimum: 0
-                type: integer
-              tags:
-                items:
-                  type: string
-                type: array
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
-            description: NodeStatus defines the observed state of the Longhorn node
-            properties:
-              conditions:
-                additionalProperties:
-                  properties:
-                    lastProbeTime:
-                      description: Last time we probed the condition.
-                      type: string
-                    lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
-                      type: string
-                    message:
-                      description: Human-readable message indicating details about last transition.
-                      type: string
-                    reason:
-                      description: Unique, one-word, CamelCase reason for the condition's last transition.
-                      type: string
-                    status:
-                      description: Status is the status of the condition. Can be True, False, Unknown.
-                      type: string
-                    type:
-                      description: Type is the type of the condition.
-                      type: string
-                  type: object
-                nullable: true
-                type: object
-              diskStatus:
-                additionalProperties:
-                  properties:
-                    conditions:
-                      additionalProperties:
-                        properties:
-                          lastProbeTime:
-                            description: Last time we probed the condition.
-                            type: string
-                          lastTransitionTime:
-                            description: Last time the condition transitioned from one status to another.
-                            type: string
-                          message:
-                            description: Human-readable message indicating details about last transition.
-                            type: string
-                          reason:
-                            description: Unique, one-word, CamelCase reason for the condition's last transition.
-                            type: string
-                          status:
-                            description: Status is the status of the condition. Can be True, False, Unknown.
-                            type: string
-                          type:
-                            description: Type is the type of the condition.
-                            type: string
-                        type: object
-                      nullable: true
-                      type: object
-                    diskUUID:
-                      type: string
-                    scheduledReplica:
-                      additionalProperties:
-                        format: int64
-                        type: integer
-                      nullable: true
-                      type: object
-                    storageAvailable:
-                      format: int64
-                      type: integer
-                    storageMaximum:
-                      format: int64
-                      type: integer
-                    storageScheduled:
-                      format: int64
-                      type: integer
-                  type: object
-                nullable: true
-                type: object
-              region:
-                type: string
-              zone:
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: false
@@ -2708,47 +1922,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: RecurringJobSpec defines the desired state of the Longhorn recurring job
-            properties:
-              concurrency:
-                description: The concurrency of taking the snapshot/backup.
-                minimum: 1
-                type: integer
-              cron:
-                description: The cron setting.
-                type: string
-              groups:
-                description: The recurring job group.
-                items:
-                  type: string
-                type: array
-              labels:
-                additionalProperties:
-                  type: string
-                description: The label of the snapshot/backup.
-                type: object
-              name:
-                description: The recurring job name.
-                type: string
-              retain:
-                description: The retain count of the snapshot/backup.
-                maximum: 50
-                minimum: 1
-                type: integer
-              task:
-                description: The recurring job type. Can be "snapshot" or "backup".
-                enum:
-                - snapshot
-                - backup
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
-            description: RecurringJobStatus defines the observed state of the Longhorn recurring job
-            properties:
-              ownerID:
-                description: The owner ID which is responsible to reconcile this recurring job CR.
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: false
@@ -2907,76 +2083,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: ReplicaSpec defines the desired state of the Longhorn replica
-            properties:
-              active:
-                type: boolean
-              backingImage:
-                type: string
-              baseImage:
-                description: Deprecated. Rename to BackingImage
-                type: string
-              dataDirectoryName:
-                type: string
-              dataPath:
-                description: Deprecated
-                type: string
-              desireState:
-                type: string
-              diskID:
-                type: string
-              diskPath:
-                type: string
-              engineImage:
-                type: string
-              engineName:
-                type: string
-              failedAt:
-                type: string
-              hardNodeAffinity:
-                type: string
-              healthyAt:
-                type: string
-              logRequested:
-                type: boolean
-              nodeID:
-                type: string
-              rebuildRetryCount:
-                type: integer
-              revisionCounterDisabled:
-                type: boolean
-              salvageRequested:
-                type: boolean
-              volumeName:
-                type: string
-              volumeSize:
-                format: int64
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
-            description: ReplicaStatus defines the observed state of the Longhorn replica
-            properties:
-              currentImage:
-                type: string
-              currentState:
-                type: string
-              evictionRequested:
-                type: boolean
-              instanceManagerName:
-                type: string
-              ip:
-                type: string
-              logFetched:
-                type: boolean
-              ownerID:
-                type: string
-              port:
-                type: integer
-              salvageExecuted:
-                type: boolean
-              started:
-                type: boolean
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: false
@@ -3235,21 +2344,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: ShareManagerSpec defines the desired state of the Longhorn share manager
-            properties:
-              image:
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
-            description: ShareManagerStatus defines the observed state of the Longhorn share manager
-            properties:
-              endpoint:
-                type: string
-              ownerID:
-                type: string
-              state:
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: false
@@ -3366,208 +2463,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: VolumeSpec defines the desired state of the Longhorn volume
-            properties:
-              Standby:
-                type: boolean
-              accessMode:
-                enum:
-                - rwo
-                - rwx
-                type: string
-              backingImage:
-                type: string
-              baseImage:
-                description: Deprecated. Rename to BackingImage
-                type: string
-              dataLocality:
-                enum:
-                - disabled
-                - best-effort
-                type: string
-              dataSource:
-                type: string
-              disableFrontend:
-                type: boolean
-              diskSelector:
-                items:
-                  type: string
-                type: array
-              encrypted:
-                type: boolean
-              engineImage:
-                type: string
-              fromBackup:
-                type: string
-              frontend:
-                enum:
-                - blockdev
-                - iscsi
-                - ""
-                type: string
-              lastAttachedBy:
-                type: string
-              migratable:
-                type: boolean
-              migrationNodeID:
-                type: string
-              nodeID:
-                type: string
-              nodeSelector:
-                items:
-                  type: string
-                type: array
-              numberOfReplicas:
-                minimum: 1
-                type: integer
-              recurringJobs:
-                description: Deprecated. Replaced by a separate resource named "RecurringJob"
-                items:
-                  description: 'VolumeRecurringJobSpec is a deprecated struct. TODO: Should be removed when recurringJobs gets removed from the volume       spec.'
-                  properties:
-                    concurrency:
-                      type: integer
-                    cron:
-                      type: string
-                    groups:
-                      items:
-                        type: string
-                      type: array
-                    labels:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    name:
-                      type: string
-                    retain:
-                      type: integer
-                    task:
-                      enum:
-                      - snapshot
-                      - backup
-                      type: string
-                  type: object
-                type: array
-              replicaAutoBalance:
-                enum:
-                - ignored
-                - disabled
-                - least-effort
-                - best-effort
-                type: string
-              revisionCounterDisabled:
-                type: boolean
-              size:
-                format: int64
-                type: string
-              staleReplicaTimeout:
-                type: integer
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
-            description: VolumeStatus defines the observed state of the Longhorn volume
-            properties:
-              actualSize:
-                format: int64
-                type: integer
-              cloneStatus:
-                properties:
-                  snapshot:
-                    type: string
-                  sourceVolume:
-                    type: string
-                  state:
-                    type: string
-                type: object
-              conditions:
-                additionalProperties:
-                  properties:
-                    lastProbeTime:
-                      description: Last time we probed the condition.
-                      type: string
-                    lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
-                      type: string
-                    message:
-                      description: Human-readable message indicating details about last transition.
-                      type: string
-                    reason:
-                      description: Unique, one-word, CamelCase reason for the condition's last transition.
-                      type: string
-                    status:
-                      description: Status is the status of the condition. Can be True, False, Unknown.
-                      type: string
-                    type:
-                      description: Type is the type of the condition.
-                      type: string
-                  type: object
-                nullable: true
-                type: object
-              currentImage:
-                type: string
-              currentNodeID:
-                type: string
-              expansionRequired:
-                type: boolean
-              frontendDisabled:
-                type: boolean
-              isStandby:
-                type: boolean
-              kubernetesStatus:
-                properties:
-                  lastPVCRefAt:
-                    type: string
-                  lastPodRefAt:
-                    type: string
-                  namespace:
-                    description: determine if PVC/Namespace is history or not
-                    type: string
-                  pvName:
-                    type: string
-                  pvStatus:
-                    type: string
-                  pvcName:
-                    type: string
-                  workloadsStatus:
-                    description: determine if Pod/Workload is history or not
-                    items:
-                      properties:
-                        podName:
-                          type: string
-                        podStatus:
-                          type: string
-                        workloadName:
-                          type: string
-                        workloadType:
-                          type: string
-                      type: object
-                    nullable: true
-                    type: array
-                type: object
-              lastBackup:
-                type: string
-              lastBackupAt:
-                type: string
-              lastDegradedAt:
-                type: string
-              ownerID:
-                type: string
-              pendingNodeID:
-                type: string
-              remountRequestedAt:
-                type: string
-              restoreInitiated:
-                type: boolean
-              restoreRequired:
-                type: boolean
-              robustness:
-                type: string
-              shareEndpoint:
-                type: string
-              shareState:
-                type: string
-              state:
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: false


### PR DESCRIPTION
Because we should not do any change in the previous version longhorn.io/v1beta1.
We should add the CRD structural schema from longhorn.io/v1beta2.

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>