### PR TITLE
Remove unnecessary permission

### DIFF
--- a/deploy/prerequisite/longhorn-iscsi-installation.yaml
+++ b/deploy/prerequisite/longhorn-iscsi-installation.yaml
@@ -15,7 +15,6 @@ spec:
       labels:
         app: longhorn-iscsi-installation
     spec:
-      hostNetwork: true
       hostPID: true
       initContainers:
       - name: iscsi-installation

--- a/deploy/prerequisite/longhorn-nfs-installation.yaml
+++ b/deploy/prerequisite/longhorn-nfs-installation.yaml
@@ -15,7 +15,6 @@ spec:
       labels:
         app: longhorn-nfs-installation
     spec:
-      hostNetwork: true
       hostPID: true
       initContainers:
       - name: nfs-installation


### PR DESCRIPTION
#### Proposal Change

Remove unnecessary permission. The `nsenter` only needs permissions
- `hostPID: true`
- `securityContext.privileged: true`

#### Issue

Longhorn 3549