### PR TITLE
Bump backing-image-manager image to v3_20220318

### DIFF
--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -77,7 +77,7 @@ questions:
     label: Longhorn Backing Image Manager Image Repository
     group: "Longhorn Images Settings"
   - variable: image.longhorn.backingImageManager.tag
-    default: v2_20210820
+    default: v3_20220318
     description: "Specify Longhorn Backing Image Manager Image Tag"
     type: string
     label: Longhorn Backing Image Manager Image Tag

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -24,7 +24,7 @@ image:
       tag: v1_20211020
     backingImageManager:
       repository: longhornio/backing-image-manager
-      tag: v2_20210820
+      tag: v3_20220318
   csi:
     attacher:
       repository: longhornio/csi-attacher

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -3,7 +3,7 @@ longhornio/csi-provisioner:v2.1.2
 longhornio/csi-resizer:v1.2.0
 longhornio/csi-snapshotter:v3.0.3
 longhornio/csi-node-driver-registrar:v2.3.0
-longhornio/backing-image-manager:v2_20210820
+longhornio/backing-image-manager:v3_20220318
 longhornio/longhorn-engine:master-head
 longhornio/longhorn-instance-manager:v1_20220303
 longhornio/longhorn-manager:master-head

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -3257,7 +3257,7 @@ spec:
         - --share-manager-image
         - "longhornio/longhorn-share-manager:v1_20211020"
         - --backing-image-manager-image
-        - "longhornio/backing-image-manager:v2_20210820"
+        - "longhornio/backing-image-manager:v3_20220318"
         - --manager-image
         - "longhornio/longhorn-manager:master-head"
         - --service-account


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/3343

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>