### PR TITLE
Add missing webhook RBAC rule for uninstaller

### DIFF
--- a/chart/templates/clusterrole.yaml
+++ b/chart/templates/clusterrole.yaml
@@ -53,4 +53,4 @@ rules:
   verbs: ["list", "watch"]
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
-  verbs: ["list", "create", "patch"]
+  verbs: ["get", "list", "create", "patch", "delete"]

--- a/uninstall/uninstall.yaml
+++ b/uninstall/uninstall.yaml
@@ -73,6 +73,9 @@ rules:
     resources: ["podsecuritypolicies"]
     verbs: ["use"]
     resourceNames: ["longhorn-uninstall-psp"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+    verbs: ["get", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
While testing for [#2034](https://github.com/longhorn/longhorn/issues/2034), noticed some webhook RBAC rules are missing.

https://github.com/longhorn/longhorn-manager/commit/ed4a2c4170849fc9fdfd490ff233e6558bf31757