### PR TITLE
Retrofit of ability to expose migratable paraemter in the longhorn he…

### DIFF
--- a/chart/templates/storageclass.yaml
+++ b/chart/templates/storageclass.yaml
@@ -24,7 +24,7 @@ data:
       fsType: "{{.Values.persistence.defaultFsType}}"
       {{- end }}
       {{- if .Values.persistence.migratable }}
-      migratable: "{{.Values.persistence.migratable}}"
+      migratable: {{.Values.persistence.migratable}}
       {{- end }}  
       {{- if .Values.persistence.backingImage.enable }}
       backingImage: {{ .Values.persistence.backingImage.name }}

--- a/chart/templates/storageclass.yaml
+++ b/chart/templates/storageclass.yaml
@@ -23,6 +23,9 @@ data:
       {{- if .Values.persistence.defaultFsType }}
       fsType: "{{.Values.persistence.defaultFsType}}"
       {{- end }}
+      {{- if .Values.persistence.migratable }}
+      migratable: "{{.Values.persistence.migratable}}"
+      {{- end }}  
       {{- if .Values.persistence.backingImage.enable }}
       backingImage: {{ .Values.persistence.backingImage.name }}
       backingImageDataSourceType: {{ .Values.persistence.backingImage.dataSourceType }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -56,6 +56,7 @@ persistence:
   defaultFsType: ext4
   defaultClassReplicaCount: 3
   reclaimPolicy: Delete
+  migratable: false
   recurringJobSelector:
     enable: false
     jobList: []


### PR DESCRIPTION
This PR is related to: https://github.com/longhorn/longhorn/issues/3880 and exposes the storage class "migratable" in the helm chart.

This should help address: https://github.com/harvester/harvester/issues/2088

Same as PR# 3881 but for v1.2.x