### PR TITLE
Fix wrong type of parameters in the storage class

### DIFF
--- a/chart/templates/storageclass.yaml
+++ b/chart/templates/storageclass.yaml
@@ -24,8 +24,8 @@ data:
       fsType: "{{.Values.persistence.defaultFsType}}"
       {{- end }}
       {{- if .Values.persistence.migratable }}
-      migratable: {{.Values.persistence.migratable}}
-      {{- end }}  
+      migratable: "{{.Values.persistence.migratable}}"
+      {{- end }}
       {{- if .Values.persistence.backingImage.enable }}
       backingImage: {{ .Values.persistence.backingImage.name }}
       backingImageDataSourceType: {{ .Values.persistence.backingImage.dataSourceType }}


### PR DESCRIPTION
Fix the wrong type of parameters in the storage class
    
Longhorn #3880
    
Signed-off-by: David Ko <dko@suse.com>
    
(cherry picked from commit f898dec142f1f603e95787dccca86c3e0481ff71)