### PR TITLE
Allow to add annotations on the serviceAccount managed by the helm chart

### DIFF
--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -4,3 +4,7 @@ metadata:
   name: longhorn-service-account
   namespace: {{ include "release_namespace" . }}
   labels: {{- include "longhorn.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -227,3 +227,7 @@ namespaceOverride: ""
 
 # Annotations to add to the Longhorn Manager DaemonSet Pods. Optional.
 annotations: {}
+
+serviceAccount:
+  # Annotations to add to the service account
+  annotations: {}


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/3929