### PR TITLE
Add value to output manager logs to json format

### DIFF
--- a/chart/templates/daemonset-sa.yaml
+++ b/chart/templates/daemonset-sa.yaml
@@ -31,6 +31,9 @@ spec:
         command:
         - longhorn-manager
         - -d
+        {{- if eq .Values.longhornManager.log.format "json" }}
+        - -j
+        {{- end }}
         - daemon
         - --engine-image
         - "{{ template "registry_url" . }}{{ .Values.image.longhorn.engine.repository }}:{{ .Values.image.longhorn.engine.tag }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -125,6 +125,9 @@ privateRegistry:
   registrySecret: ~
 
 longhornManager:
+  log:
+    ## Allowed values are `plain` or `json`.
+    format: plain
   priorityClass: ~
   tolerations: []
   ## If you want to set tolerations for Longhorn Manager DaemonSet, delete the `[]` in the line above


### PR DESCRIPTION
As stated above I miss a flag to set logs output format to json which was implemented in longhorn/longhorn-manager#605.