### PR TITLE
Annotation for service LonghornManager will be configurable.

### DIFF
--- a/chart/templates/daemonset-sa.yaml
+++ b/chart/templates/daemonset-sa.yaml
@@ -117,6 +117,10 @@ metadata:
     app: longhorn-manager
   name: longhorn-backend
   namespace: {{ include "release_namespace" . }}
+  {{- if .Values.longhornManager.serviceAnnotations }}
+  annotations:
+{{ toYaml .Values.longhornManager.serviceAnnotations | indent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.manager.type }}
   sessionAffinity: ClientIP

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -142,7 +142,7 @@ longhornManager:
   #  label-key1: "label-value1"
   #  label-key2: "label-value2"
   serviceAnnotations: {}
-  ## If you want to set annotations for the Longhorn Manager delete the `{}` in the line above
+  ## If you want to set annotations for the Longhorn Manager service, delete the `{}` in the line above
   ## and uncomment this example block
   #  annotation-key1: "annotation-value1"
   #  annotation-key2: "annotation-value2"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -141,6 +141,11 @@ longhornManager:
   ## and uncomment this example block
   #  label-key1: "label-value1"
   #  label-key2: "label-value2"
+  serviceAnnotations: {}
+  ## If you want to set annotations for the Longhorn Manager delete the `{}` in the line above
+  ## and uncomment this example block
+  #  annotation-key1: "annotation-value1"
+  #  annotation-key2: "annotation-value2"
 
 longhornDriver:
   priorityClass: ~


### PR DESCRIPTION
I found that there is no possibility to add those annotations to the Longhorn Manager service via helm-chart:
```
  prometheus.io/scrape: 'true'
  prometheus.io/port: '9500'
  prometheus.io/path: '/metrics'
```
So, here it is.