### PR TITLE
chart: fix the conditions of Rancher deployed Windows Cluster

### DIFF
--- a/chart/templates/default-setting.yaml
+++ b/chart/templates/default-setting.yaml
@@ -20,7 +20,7 @@ data:
     {{ if not (kindIs "invalid" .Values.defaultSettings.defaultDataLocality) }}default-data-locality: {{ .Values.defaultSettings.defaultDataLocality }}{{ end }}
     {{ if not (kindIs "invalid" .Values.defaultSettings.defaultLonghornStaticStorageClass) }}default-longhorn-static-storage-class: {{ .Values.defaultSettings.defaultLonghornStaticStorageClass }}{{ end }}
     {{ if not (kindIs "invalid" .Values.defaultSettings.backupstorePollInterval) }}backupstore-poll-interval: {{ .Values.defaultSettings.backupstorePollInterval }}{{ end }}
-    {{- if or (not (kindIs "invalid" .Values.defaultSettings.taintToleration)) (not (kindIs "invalid" .Values.global.cattle.windowsCluster.enabled)) }}
+    {{- if or (not (kindIs "invalid" .Values.defaultSettings.taintToleration)) (.Values.global.cattle.windowsCluster.enabled) }}
     taint-toleration: {{ $windowsDefaultSettingTaintToleration := list }}{{ $defaultSettingTaintToleration := list -}}
       {{- if and .Values.global.cattle.windowsCluster.enabled .Values.global.cattle.windowsCluster.defaultSetting.taintToleration -}}
         {{- $windowsDefaultSettingTaintToleration = .Values.global.cattle.windowsCluster.defaultSetting.taintToleration -}}
@@ -30,7 +30,7 @@ data:
       {{- end -}}
       {{- $taintToleration := list $windowsDefaultSettingTaintToleration $defaultSettingTaintToleration }}{{ join ";" (compact $taintToleration) -}}
     {{- end }}
-    {{- if or (not (kindIs "invalid" .Values.defaultSettings.systemManagedComponentsNodeSelector)) (not (kindIs "invalid" .Values.global.cattle.windowsCluster.enabled)) }}
+    {{- if or (not (kindIs "invalid" .Values.defaultSettings.systemManagedComponentsNodeSelector)) (.Values.global.cattle.windowsCluster.enabled) }}
     system-managed-components-node-selector: {{ $windowsDefaultSettingNodeSelector := list }}{{ $defaultSettingNodeSelector := list -}}
       {{- if and .Values.global.cattle.windowsCluster.enabled .Values.global.cattle.windowsCluster.defaultSetting.systemManagedComponentsNodeSelector -}}
         {{ $windowsDefaultSettingNodeSelector = .Values.global.cattle.windowsCluster.defaultSetting.systemManagedComponentsNodeSelector -}}

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -1178,6 +1178,7 @@ metadata:
     longhorn-manager: ""
   name: engineimages.longhorn.io
 spec:
+  preserveUnknownFields: false
   conversion:
     strategy: Webhook
     webhook:
@@ -1860,6 +1861,7 @@ metadata:
     longhorn-manager: ""
   name: nodes.longhorn.io
 spec:
+  preserveUnknownFields: false
   conversion:
     strategy: Webhook
     webhook:
@@ -2874,6 +2876,7 @@ metadata:
     longhorn-manager: ""
   name: volumes.longhorn.io
 spec:
+  preserveUnknownFields: false
   conversion:
     strategy: Webhook
     webhook:


### PR DESCRIPTION
Pervious commit will make the `taint-toleration` and `system-managed-components-node-selector` empty in the generated longhorn.yaml if windowsCluster is disabled. It will override the two fields fields with empty values mistakenly during upgrade.

[Longhorn 4289](https://github.com/longhorn/longhorn/issues/4289)
[Longhorn 4246](https://github.com/longhorn/longhorn/pull/4246)

Signed-off-by: Derek Su <derek.su@suse.com>