### PR TITLE
Add PSP support to environment_check.sh

### DIFF
--- a/scripts/environment_check.sh
+++ b/scripts/environment_check.sh
@@ -131,7 +131,6 @@ check_dependencies() {
 
 create_ds() {
 cat <<EOF > $TEMP_DIR/environment_check.yaml
----
 kind: ServiceAccount
 apiVersion: v1
 metadata:
@@ -181,6 +180,7 @@ spec:
   volumes: ['*']
   hostNetwork: true
   hostIPC: true
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -350,4 +350,3 @@ check_multipathd
 check_mount_propagation
 
 exit 0
-


### PR DESCRIPTION
This will allow hardened cluster users (e.g. RKE2 with `cis-1.6` profile enabled) to run the environment check script painlessly.

I'm not sure if this behaviour should be on by default, so I'm willing to add a knob to turn the PSP support on or off as needed. Or maybe try to auto-detect it by asking cluster. :)