### PR TITLE
Add Gentoo support to environment_check.sh

### DIFF
--- a/scripts/environment_check.sh
+++ b/scripts/environment_check.sh
@@ -97,6 +97,10 @@ set_packages_and_check_cmd()
     CHECK_CMD='pacman -Q'
     PACKAGES=(nfs-utils open-iscsi)
     ;;
+  *"gentoo"* )
+    CHECK_CMD='qlist -I'
+    PACKAGES=(net-fs/nfs-utils sys-block/open-iscsi)
+    ;;
   *)
     CHECK_CMD=''
     PACKAGES=()


### PR DESCRIPTION
This addition will allow Gentoo users to run this script and get sensible error messages in case they forgot to install required packages.

Signed-off-by: Serge Tkatchouk <sp1j3t@gmail.com>
(cherry picked from commit c1b93f5531958e583be5a1375b56db48cc52127e)