### PR TITLE
Failed backups cleanup: update deploy YAML

### DIFF
--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -335,7 +335,7 @@ The available volume spec options are:
     description: "In minutes. This setting determines how long Longhorn will keep the backup resource that was failed. Set to 0 to disable the auto-deletion.
 Failed backups will be checked and cleaned up during backupstore polling which is controlled by **Backupstore Poll Interval** setting.
 Hence this value determines the minimal wait interval of the cleanup. And the actual cleanup interval is multiple of **Backupstore Poll Interval**.
-			Disabling **Backupstore Poll Interval** also means to disable failed backup auto-deletion."
+Disabling **Backupstore Poll Interval** also means to disable failed backup auto-deletion."
     group: "Longhorn Default Settings"
     type: int
     min: 0

--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -330,6 +330,16 @@ The available volume spec options are:
     type: int
     min: 0
     default: 300
+  - variable: defaultSettings.failedBackupTTL
+    label: Failed Backup Time to Live
+    description: "In minutes. This setting determines how long Longhorn will keep the backup resource that was failed. Set to 0 to disable the auto-deletion.
+Failed backups will be checked and cleaned up during backupstore polling which is controlled by **Backupstore Poll Interval** setting.
+Hence this value determines the minimal wait interval of the cleanup. And the actual cleanup interval is multiple of **Backupstore Poll Interval**.
+			Disabling **Backupstore Poll Interval** also means to disable failed backup auto-deletion."
+    group: "Longhorn Default Settings"
+    type: int
+    min: 0
+    default: 1440
   - variable: defaultSettings.autoSalvage
     label: Automatic salvage
     description: "If enabled, volumes will be automatically salvaged when all the replicas become faulty e.g. due to network disconnection. Longhorn will try to figure out which replica(s) are usable, then use them for the volume. By default true."

--- a/chart/templates/default-setting.yaml
+++ b/chart/templates/default-setting.yaml
@@ -20,6 +20,7 @@ data:
     {{ if not (kindIs "invalid" .Values.defaultSettings.defaultDataLocality) }}default-data-locality: {{ .Values.defaultSettings.defaultDataLocality }}{{ end }}
     {{ if not (kindIs "invalid" .Values.defaultSettings.defaultLonghornStaticStorageClass) }}default-longhorn-static-storage-class: {{ .Values.defaultSettings.defaultLonghornStaticStorageClass }}{{ end }}
     {{ if not (kindIs "invalid" .Values.defaultSettings.backupstorePollInterval) }}backupstore-poll-interval: {{ .Values.defaultSettings.backupstorePollInterval }}{{ end }}
+    {{ if not (kindIs "invalid" .Values.defaultSettings.failedBackupTTL) }}failed-backup-ttl: {{ .Values.defaultSettings.failedBackupTTL }}{{ end }}
     {{- if or (not (kindIs "invalid" .Values.defaultSettings.taintToleration)) (.Values.global.cattle.windowsCluster.enabled) }}
     taint-toleration: {{ $windowsDefaultSettingTaintToleration := list }}{{ $defaultSettingTaintToleration := list -}}
       {{- if and .Values.global.cattle.windowsCluster.enabled .Values.global.cattle.windowsCluster.defaultSetting.taintToleration -}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -108,6 +108,7 @@ defaultSettings:
   defaultReplicaCount: ~
   defaultLonghornStaticStorageClass: ~
   backupstorePollInterval: ~
+  failedBackupTTL: ~
   taintToleration: ~
   systemManagedComponentsNodeSelector: ~
   priorityClass: ~

--- a/enhancements/20220801-failed-backups-cleanup.md
+++ b/enhancements/20220801-failed-backups-cleanup.md
@@ -12,14 +12,13 @@ Longhorn will leave the failed backups behind and will not delete the backups au
 
 ### Goals
 
-- Automatic deletion of failed backups when detected.
+- Support the auto-deletion of failed backups that exceeded the TTL.
 - Support the global auto-deletion option of failed backups cleanup for users.
 - The process should not be stuck in the reconciliation of the controllers.
 
 ### Non-goals [optional]
 
 - Clean up unknown files or directories on the remote backup target.
-- Support the auto-deletion of failed backups that exceeded the TTL.
 
 ## Proposal
 
@@ -66,7 +65,7 @@ After the enhancement, Longhorn can delete the failed backups automatically afte
   - Users can check the event log to understand why the backup failed and deleted.
 
 - Via `kubectl`
-  - Users can list the failed backups if auto-deletion is disabled by `kubectl -n longhorn-system get backups`.
+  - Users can list the failed backups by `kubectl -n longhorn-system get backups` if auto-deletion is disabled.
 
 ## Design
 
@@ -74,7 +73,7 @@ After the enhancement, Longhorn can delete the failed backups automatically afte
 
 **Settings**
 
-- Add setting `failed-backup-auto-deletion`. Default value is `true`.
+- Add setting `failed-backup-ttl`. Default value is `1440` minutes and set to `0` to disable the auto-deletion.
 
 **Failed Backup**
 
@@ -88,6 +87,7 @@ After the enhancement, Longhorn can delete the failed backups automatically afte
 
 **Backup Volume controller**
 
+- Reconcile loop usually is triggered after backupstore polling which is controlled by **Backupstore Poll Interval** setting.
 - Start to get all backups in each reconcile loop
 - Tell failed backups from all backups and try to delete failed backups by default.
 - Update the backup volume CR status.
@@ -96,8 +96,8 @@ After the enhancement, Longhorn can delete the failed backups automatically afte
 
 **Integration tests**
 
-- `backups` CRs with `Error` or `Unknown` state will be removed soon by `backup_volume_controller` by default when the `backup_monitor` detects the backup failed.
-- `backups` CRs with `Error` or `Unknown` state will not be handled if `failed-backup-auto-deletion` is disabled.
+- `backups` CRs with `Error` or `Unknown` state will be removed by `backup_volume_controller` triggered by backupstore polling when the `backup_monitor` detects the backup failed.
+- `backups` CRs with `Error` or `Unknown` state will not be handled if the auto-deletion is disabled.
 
 ## Note [optional]
 


### PR DESCRIPTION
Add a new option `failed-backup-ttl` and update the LEP for failed backup cleanup.

longhorn/longhorn#3898

Signed-off-by: James Lu <james.lu@suse.com>