### PR TITLE
Add upgrade responder server helm values

### DIFF
--- a/deploy/upgrade_responder_server/README.md
+++ b/deploy/upgrade_responder_server/README.md
@@ -1,0 +1,5 @@
+This directory contains the helm values for the Longhorn upgrade responder server. 
+The values are in the file `./chart-values.yaml`.
+When you update the content of `./chart-values.yaml`, automation pipeline will update the Longhorn upgrade responder.
+
+The chart source chart is in `chart.yaml`

--- a/deploy/upgrade_responder_server/chart-values.yaml
+++ b/deploy/upgrade_responder_server/chart-values.yaml
@@ -1,0 +1,47 @@
+# Specify the name of the application that is using this Upgrade Responder server
+# This will be used to create a database named <application-name>_upgrade_responder
+# in the InfluxDB to store all data for this Upgrade Responder
+# The name must be in snake case format
+applicationName: longhorn
+
+image:
+  repository: longhornio/upgrade-responder
+  tag: longhorn-head
+  pullPolicy: Always
+
+secret:
+  name: upgrade-responder-secret
+  # Set this to false if you don't want to manage these secrets with helm
+  managed: false
+
+# This configmap contains information about the latest release
+# of the application that is using this Upgrade Responder
+configMap:
+  responseConfig: |-
+    {
+      "Versions": [
+        {
+          "Name": "v1.1.3",
+          "ReleaseDate": "2021-12-17T00:00:00Z",
+          "Tags": [
+            "stable"
+          ]
+        },
+        {
+          "Name": "v1.2.5",
+          "ReleaseDate": "2022-09-01T00:00:00Z",
+          "Tags": [
+            "stable"
+          ]
+        },
+        {
+          "Name": "v1.3.1",
+          "ReleaseDate": "2022-08-11T00:00:00Z",
+          "Tags": [
+            "latest",
+            "stable"
+          ]
+        }
+      ]
+    }
+

--- a/deploy/upgrade_responder_server/chart.yaml
+++ b/deploy/upgrade_responder_server/chart.yaml
@@ -1,0 +1,5 @@
+url: https://github.com/longhorn/upgrade-responder.git
+commit: 3c78890f5415744af1923eac01f98636ac52a113
+releaseName: longhorn-upgrade-responder
+namespace: longhorn-upgrade-responder
+


### PR DESCRIPTION
This is the first step for the pipeline to automatically update the upgrade responder server

longhorn/longhorn#4423
