### PR TITLE
Revert "Add require/automation-e2e to enhance/improvement ticket"

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: "[FEATURE] "
-labels: ["kind/enhancement", "require/automation-e2e"]
+labels: kind/enhancement
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/improvement_request.md
+++ b/.github/ISSUE_TEMPLATE/improvement_request.md
@@ -2,7 +2,7 @@
 name: Improvement request
 about: Suggest an improvement of an existing feature for this project
 title: "[IMPROVEMENT] "
-labels: ["kind/improvement", "require/automation-e2e"]
+labels: kind/improvement
 assignees: ''
 
 ---


### PR DESCRIPTION
This reverts commit 6f885bf313c05934704538a7d2f9f462b5464cd0.

Signed-off-by: David Ko <dko@suse.com>

Removing the default e2e label from enhancement and improvement issue templates is to avoid creating corresponding test issues directly when they are created/requested by users.

cc @yangchiu 