### PR TITLE
[Backport v1.3.x] For Longhorn <1.4.0 is restricted to only be installed in the k8s environment below 1.25

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: longhorn
 version: 1.3.2-rc1
 appVersion: v1.3.2-rc1
-kubeVersion: ">=1.18.0-0"
+kubeVersion: ">=1.18.0-0 <1.25.0-0"
 description: Longhorn is a distributed block storage system for Kubernetes.
 keywords:
 - longhorn


### PR DESCRIPTION
[Longhorn 4525](https://github.com/longhorn/longhorn/issues/4525)

Signed-off-by: Ray Chang <ray.chang@suse.com>