### PR TITLE
[Backport v1.2.x] For Longhorn <1.4.0 is restricted to only be installed in the k8s environment below 1.25

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: longhorn
 version: 1.2.5
 appVersion: v1.2.5
-kubeVersion: ">=1.18.0-0"
+kubeVersion: ">=1.18.0-0 <1.25.0-0"
 description: Longhorn is a distributed block storage system for Kubernetes.
 keywords:
 - longhorn


### PR DESCRIPTION
[Longhorn 4664](https://github.com/longhorn/longhorn/issues/4664)

Signed-off-by: Ray Chang <ray.chang@suse.com>