### PR TITLE
Kubernetes 1.2.5 support

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: longhorn
 version: 1.4.0-dev
 appVersion: v1.4.0-dev
-kubeVersion: ">=1.18.0-0"
+kubeVersion: ">=1.21.0-0"
 description: Longhorn is a distributed block storage system for Kubernetes.
 keywords:
 - longhorn

--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -125,7 +125,7 @@ questions:
     label: Longhorn CSI Driver Resizer Image Repository
     group: "Longhorn CSI Driver Images"
   - variable: image.csi.resizer.tag
-    default: v1.2.0
+    default: v1.3.0
     description: "Specify CSI Driver Resizer image tag. Leave blank to autodetect."
     type: string
     label: Longhorn CSI Driver Resizer Image Tag
@@ -137,7 +137,7 @@ questions:
     label: Longhorn CSI Driver Snapshotter Image Repository
     group: "Longhorn CSI Driver Images"
   - variable: image.csi.snapshotter.tag
-    default: v3.0.3
+    default: v5.0.1
     description: "Specify CSI Driver Snapshotter image tag. Leave blank to autodetect."
     type: string
     label: Longhorn CSI Driver Snapshotter Image Tag

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -53,10 +53,10 @@ image:
       tag: v2.5.0
     resizer:
       repository: longhornio/csi-resizer
-      tag: v1.2.0
+      tag: v1.3.0
     snapshotter:
       repository: longhornio/csi-snapshotter
-      tag: v3.0.3
+      tag: v5.0.1
   pullPolicy: IfNotPresent
 
 service:
@@ -249,8 +249,9 @@ ingress:
   #   key:
   #   certificate:
 
-# Configure a pod security policy in the Longhorn namespace to allow privileged pods
-enablePSP: true
+#  For Kubernetes < v1.25, if your cluster enables Pod Security Policy admission controller,
+#  set this to `true` to ship longhorn-psp which allow privileged Longhorn pods to start
+enablePSP: false
 
 ## Specify override namespace, specifically this is useful for using longhorn as sub-chart
 ## and its release namespace is not the `longhorn-system`

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -1,7 +1,7 @@
 longhornio/csi-attacher:v3.4.0
 longhornio/csi-provisioner:v2.1.2
-longhornio/csi-resizer:v1.2.0
-longhornio/csi-snapshotter:v3.0.3
+longhornio/csi-resizer:v1.3.0
+longhornio/csi-snapshotter:v5.0.1
 longhornio/csi-node-driver-registrar:v2.5.0
 longhornio/backing-image-manager:v3_20220808
 longhornio/longhorn-engine:master-head

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -5,41 +5,6 @@ kind: Namespace
 metadata:
   name: longhorn-system
 ---
-# Source: longhorn/templates/psp.yaml
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: longhorn-psp
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
-spec:
-  privileged: true
-  allowPrivilegeEscalation: true
-  requiredDropCapabilities:
-  - NET_RAW
-  allowedCapabilities:
-  - SYS_ADMIN
-  hostNetwork: false
-  hostIPC: false
-  hostPID: true
-  runAsUser:
-    rule: RunAsAny
-  seLinux:
-    rule: RunAsAny
-  fsGroup:
-    rule: RunAsAny
-  supplementalGroups:
-    rule: RunAsAny
-  volumes:
-  - configMap
-  - downwardAPI
-  - emptyDir
-  - secret
-  - projected
-  - hostPath
----
 # Source: longhorn/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -3275,48 +3240,6 @@ subjects:
   name: longhorn-service-account
   namespace: longhorn-system
 ---
-# Source: longhorn/templates/psp.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: longhorn-psp-role
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
-  namespace: longhorn-system
-rules:
-- apiGroups:
-  - policy
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
-  resourceNames:
-  - longhorn-psp
----
-# Source: longhorn/templates/psp.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: longhorn-psp-binding
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.4.0-dev
-  namespace: longhorn-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: longhorn-psp-role
-subjects:
-- kind: ServiceAccount
-  name: longhorn-service-account
-  namespace: longhorn-system
-- kind: ServiceAccount
-  name: default
-  namespace: longhorn-system
----
 # Source: longhorn/templates/daemonset-sa.yaml
 apiVersion: v1
 kind: Service
@@ -3610,9 +3533,9 @@ spec:
           - name: CSI_NODE_DRIVER_REGISTRAR_IMAGE
             value: "longhornio/csi-node-driver-registrar:v2.5.0"
           - name: CSI_RESIZER_IMAGE
-            value: "longhornio/csi-resizer:v1.2.0"
+            value: "longhornio/csi-resizer:v1.3.0"
           - name: CSI_SNAPSHOTTER_IMAGE
-            value: "longhornio/csi-snapshotter:v3.0.3"
+            value: "longhornio/csi-snapshotter:v5.0.1"
       serviceAccountName: longhorn-service-account
       securityContext:
         runAsUser: 0

--- a/examples/snapshot/existing_backup.yaml
+++ b/examples/snapshot/existing_backup.yaml
@@ -1,4 +1,4 @@
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotContent
 metadata:
   name: test-existing-backup

--- a/examples/snapshot/snapshot_existing.yaml
+++ b/examples/snapshot/snapshot_existing.yaml
@@ -1,4 +1,4 @@
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:
   name: test-snapshot-existing-backup

--- a/examples/snapshot/snapshot_pvc.yaml
+++ b/examples/snapshot/snapshot_pvc.yaml
@@ -1,4 +1,4 @@
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:
   name: test-snapshot-pvc

--- a/examples/snapshot/snapshotclass.yaml
+++ b/examples/snapshot/snapshotclass.yaml
@@ -1,5 +1,5 @@
 kind: VolumeSnapshotClass
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 metadata:
   name: longhorn
 driver: driver.longhorn.io

--- a/uninstall/uninstall.yaml
+++ b/uninstall/uninstall.yaml
@@ -1,38 +1,38 @@
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: longhorn-uninstall-psp
-spec:
-  privileged: true
-  allowPrivilegeEscalation: true
-  requiredDropCapabilities:
-  - NET_RAW
-  allowedCapabilities:
-  - SYS_ADMIN
-  hostNetwork: false
-  hostIPC: false
-  hostPID: true
-  runAsUser:
-    rule: RunAsAny
-  seLinux:
-    rule: RunAsAny
-  fsGroup:
-    rule: RunAsAny
-  supplementalGroups:
-    rule: RunAsAny
-  volumes:
-  - configMap
-  - downwardAPI
-  - emptyDir
-  - secret
-  - projected
-  - hostPath
----
+#apiVersion: policy/v1beta1
+#kind: PodSecurityPolicy
+#metadata:
+#  name: longhorn-uninstall-psp
+#spec:
+#  privileged: true
+#  allowPrivilegeEscalation: true
+#  requiredDropCapabilities:
+#  - NET_RAW
+#  allowedCapabilities:
+#  - SYS_ADMIN
+#  hostNetwork: false
+#  hostIPC: false
+#  hostPID: true
+#  runAsUser:
+#    rule: RunAsAny
+#  seLinux:
+#    rule: RunAsAny
+#  fsGroup:
+#    rule: RunAsAny
+#  supplementalGroups:
+#    rule: RunAsAny
+#  volumes:
+#  - configMap
+#  - downwardAPI
+#  - emptyDir
+#  - secret
+#  - projected
+#  - hostPath
+#---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: longhorn-uninstall-service-account
-  namespace: default
+  namespace: longhorn-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -71,10 +71,10 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["*"]
-  - apiGroups: ["policy"]
-    resources: ["podsecuritypolicies"]
-    verbs: ["use"]
-    resourceNames: ["longhorn-uninstall-psp"]
+  #  - apiGroups: ["policy"]
+  #    resources: ["podsecuritypolicies"]
+  #    verbs: ["use"]
+  #    resourceNames: ["longhorn-uninstall-psp"]
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
     verbs: ["get", "delete"]
@@ -90,13 +90,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: longhorn-uninstall-service-account
-    namespace: default
+    namespace: longhorn-system
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: longhorn-uninstall
-  namespace: default
+  namespace: longhorn-system
 spec:
   activeDeadlineSeconds: 900
   backoffLimit: 1
@@ -105,18 +105,18 @@ spec:
       name: longhorn-uninstall
     spec:
       containers:
-      - name: longhorn-uninstall
-        image: longhornio/longhorn-manager:master-head
-        imagePullPolicy: IfNotPresent
-        securityContext:
-          privileged: true
-        command:
-        - longhorn-manager
-        - uninstall
-        - --force
-        env:
-        - name: LONGHORN_NAMESPACE
-          value: longhorn-system
+        - name: longhorn-uninstall
+          image: longhornio/longhorn-manager:master-head
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          command:
+            - longhorn-manager
+            - uninstall
+            - --force
+          env:
+            - name: LONGHORN_NAMESPACE
+              value: longhorn-system
       restartPolicy: OnFailure
       serviceAccountName: longhorn-uninstall-service-account
 #      imagePullSecrets:


### PR DESCRIPTION
1. Set enablePSP to false by default
1. Bump K8s min version support and CSI sidecar versions 
    * Min Kubernetes version from 1.18 to 1.21 
    * longhornio/csi-resizer v1.2.0 -> v1.3.0 
    * longhornio/csi-snapshotter: v3.0.3 -> v5.0.1
1. Update CSI snapshot examples from v1beta1 to v1
1. Updating images file
1. Gnerating new longhorn.yaml from the chart for kubectl
1. Sync uninstallation manifest from longhorn/longhorn-manager repo


longhorn/longhorn#4003
longhorn/longhorn#4239
