### PR TITLE
Fix bug: cannot re-run helm uninstall if the first one failed and cannot fetch logs of failed uninstalltion job

### DIFF
--- a/chart/templates/uninstall-job.yaml
+++ b/chart/templates/uninstall-job.yaml
@@ -3,7 +3,7 @@ kind: Job
 metadata:
   annotations:
     "helm.sh/hook": pre-delete
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   name: longhorn-uninstall
   namespace: {{ include "release_namespace" . }}
   labels: {{- include "longhorn.labels" . | nindent 4 }}
@@ -30,7 +30,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-      restartPolicy: OnFailure
+      restartPolicy: Never
       {{- if .Values.privateRegistry.registrySecret }}
       imagePullSecrets:
       - name: {{ .Values.privateRegistry.registrySecret }}


### PR DESCRIPTION
1. Adding `before-hook-creation` annotation value instruct Helm to remove the previous uninstallation job and before try to avoid the resource conflict https://helm.sh/docs/topics/charts_hooks/#:~:text=Description-,before%2Dhook%2Dcreation,-Delete%20the%20previous
2. Set `restartPolicy: Never` to keep the log of failed uninstallation pod so users can identify the reason that it is failing, see more https://kubernetes.io/docs/concepts/workloads/controllers/job/#:~:text=Note%3A%20If,not%20lost%20inadvertently.

longhorn/longhorn#4711