### PR TITLE
exclude Kasten explicitly

### DIFF
--- a/scripts/longhorn_rancher_chart_migration.sh
+++ b/scripts/longhorn_rancher_chart_migration.sh
@@ -162,7 +162,18 @@ fi
 echo ""
 echo ""
 echo "Looking up existing Resources ..."
-RESOURCES=$(kubectl get-all --kubeconfig ${DOWNSTREAM_KUBECONFIG} --exclude AppRevision -o name -l io.cattle.field/appId=${RELEASE_NAME} 2>/dev/null | sort)
+
+
+KASTENRESOURCES=`kubectl api-resources --kubeconfig ${DOWNSTREAM_KUBECONFIG} | grep kasten`
+
+if [ -z "${KASTENRESOURCES}" ]; then
+#if kubectl api-resources --kubeconfig ${DOWNSTREAM_KUBECONFIG} | grep -q kasten; then
+  RESOURCES=$(kubectl get-all --kubeconfig ${DOWNSTREAM_KUBECONFIG} --exclude AppRevision,applications.apps.kio.kasten.io,passkeys.vault.kio.kasten.io -o name -l io.cattle.field/appId=${RELEASE_NAME} 2>/dev/null | sort)
+else
+  RESOURCES=$(kubectl get-all --kubeconfig ${DOWNSTREAM_KUBECONFIG} --exclude AppRevision -o name -l io.cattle.field/appId=${RELEASE_NAME} 2>/dev/null | sort)
+fi
+
+
 if [[ "$RESOURCES" == "No resources"* ]]; then
   RESOURCES=""
 fi


### PR DESCRIPTION
There are two ways I was thinking we could word the if.  With an external variable saving any kasten resources, then an if that checks if the variable has a value, or just running the grep in the if statement.  I'm not sure which you would prefer but looks like this script tends to the former, so I prioritized that and commented out the latter.  Tested on the customer cluster, but I made some minor changes while transposing here so still need to run some tests