### PR TITLE
[BACKPORT][1.3.x] chore(ui): modify Affinity of UI

### DIFF
--- a/chart/templates/deployment-ui.yaml
+++ b/chart/templates/deployment-ui.yaml
@@ -15,6 +15,18 @@ spec:
       labels: {{- include "longhorn.labels" . | nindent 8 }}
         app: longhorn-ui
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - longhorn-ui
+              topologyKey: kubernetes.io/hostname
       containers:
       - name: longhorn-ui
         image: {{ template "registry_url" . }}{{ .Values.image.longhorn.ui.repository }}:{{ .Values.image.longhorn.ui.tag }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -183,7 +183,7 @@ longhornDriver:
   #  label-key2: "label-value2"
 
 longhornUI:
-  replicas: 1
+  replicas: 2
   priorityClass: ~
   tolerations: []
   ## If you want to set tolerations for Longhorn UI Deployment, delete the `[]` in the line above

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -3610,7 +3610,7 @@ metadata:
   name: longhorn-ui
   namespace: longhorn-system
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: longhorn-ui
@@ -3622,6 +3622,18 @@ spec:
         app.kubernetes.io/version: v1.3.2
         app: longhorn-ui
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - longhorn-ui
+              topologyKey: kubernetes.io/hostname
       containers:
       - name: longhorn-ui
         image: longhornio/longhorn-ui:v1.3.2


### PR DESCRIPTION
Backport to 1.3.x
Change the number of the replica from 1 to 2 for helm chart and deploy.yaml

https://github.com/longhorn/longhorn/issues/4987