### PR TITLE
feat(helm): support affinity for longhornManager

### DIFF
--- a/chart/templates/daemonset-sa.yaml
+++ b/chart/templates/daemonset-sa.yaml
@@ -117,6 +117,10 @@ spec:
 {{ toYaml .Values.longhornManager.nodeSelector | indent 8 }}
         {{- end }}
       {{- end }}
+      {{- if .Values.longhornManager.affinity }}
+      affinitiy:
+{{ toYaml .Values.longhornManager.affinity | indent 8 }}
+      {{- end }}      
       serviceAccountName: longhorn-service-account
   updateStrategy:
     rollingUpdate:

--- a/chart/templates/postupgrade-job.yaml
+++ b/chart/templates/postupgrade-job.yaml
@@ -56,3 +56,7 @@ spec:
 {{ toYaml .Values.longhornManager.nodeSelector | indent 8 }}
         {{- end }}
       {{- end }}
+      {{- if .Values.longhornManager.affinity }}
+      affinitiy:
+{{ toYaml .Values.longhornManager.affinity | indent 8 }}
+      {{- end }}      

--- a/chart/templates/uninstall-job.yaml
+++ b/chart/templates/uninstall-job.yaml
@@ -57,3 +57,7 @@ spec:
 {{ toYaml .Values.longhornManager.nodeSelector | indent 8 }}
         {{- end }}
       {{- end }}
+      {{- if .Values.longhornManager.affinity }}
+      affinitiy:
+{{ toYaml .Values.longhornManager.affinity | indent 8 }}
+      {{- end }}      

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -182,6 +182,18 @@ longhornManager:
   ## and uncomment this example block
   #  label-key1: "label-value1"
   #  label-key2: "label-value2"
+  affinity: {}
+  ## If you want to set nodeAffinity for Longhorn Manager DaemonSet, delete the `{}` in the line above
+  ## and uncomment this example block
+  # nodeAffinity:
+  #   requiredDuringSchedulingIgnoredDuringExecution:
+  #     nodeSelectorTerms:
+  #       - matchExpressions:
+  #         - key: label-key1
+  #           operator: In
+  #           values:
+  #             - label-value1
+  #             - label-value2  
   serviceAnnotations: {}
   ## If you want to set annotations for the Longhorn Manager service, delete the `{}` in the line above
   ## and uncomment this example block


### PR DESCRIPTION
Similar to nodeSelector also support affinity.

- [x] Default value is empty object
- [x] Added commented example in `values.yaml`
- [x] Helm lint passes 

Signed-off-by: Sjouke de Vries <info@sdvservices.nl>