### PR TITLE
fix: add `Support Bundle Kit` image related variables in `questions.yaml`

### DIFF
--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -82,6 +82,18 @@ questions:
     type: string
     label: Longhorn Backing Image Manager Image Tag
     group: "Longhorn Images Settings"
+  - variable: image.longhorn.supportBundleKit.repository
+    default: longhornio/support-bundle-kit
+    description: "Specify Longhorn Support Bundle Kit Image Repository"
+    type: string
+    label: Longhorn Support Bundle Kit Image Repository
+    group: "Longhorn Images Settings"
+  - variable: image.longhorn.supportBundleKit.tag
+    default: v0.0.17
+    description: "Specify Longhorn Support Bundle Kit Image Tag"
+    type: string
+    label: Longhorn Support Bundle Kit Image Tag
+    group: "Longhorn Images Settings"
   - variable: image.csi.attacher.repository
     default: longhornio/csi-attacher
     description: "Specify CSI attacher image repository. Leave blank to autodetect."


### PR DESCRIPTION
Signed-off-by: Ray Chang <ray.chang@suse.com>

Due to the absence of `Support Bundle Kit` image related variables in `questions.yaml`, users cannot adjust the `Support Bundle Kit` repository name and tags on the Rancher web page.

https://github.com/rancher/charts/pull/2304
https://github.com/rancher/charts/pull/2305
