### PR TITLE
fix: update the supportBundleKit image description

### DIFF
--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -84,13 +84,13 @@ questions:
     group: "Longhorn Images Settings"
   - variable: image.longhorn.supportBundleKit.repository
     default: longhornio/support-bundle-kit
-    description: "Specify Longhorn Support Bundle Kit Image Repository"
+    description: "Specify Longhorn Support Bundle Manager Image Repository"
     type: string
     label: Longhorn Support Bundle Kit Image Repository
     group: "Longhorn Images Settings"
   - variable: image.longhorn.supportBundleKit.tag
     default: v0.0.17
-    description: "Specify Longhorn Support Bundle Kit Image Tag"
+    description: "Specify Longhorn Support Bundle Manager Image Tag"
     type: string
     label: Longhorn Support Bundle Kit Image Tag
     group: "Longhorn Images Settings"


### PR DESCRIPTION
Signed-off-by: Ray Chang <ray.chang@suse.com>

Update the supportBundleKit image description as `Longhorn Support Bundle Manager Image`
ref. https://github.com/longhorn/longhorn/pull/5264#discussion_r1067656511