### PR TITLE
Made environment_check.sh POSIX compliant

### DIFF
--- a/scripts/environment_check.sh
+++ b/scripts/environment_check.sh
@@ -322,12 +322,12 @@ check_nfs_client_kernel_support() {
 
     for pod in ${pods}; do
       node=$(kubectl get ${pod} --no-headers -o=custom-columns=:.spec.nodeName)
-      res=$(kubectl exec -t $pod -- nsenter --mount=/proc/1/ns/mnt -- bash -c "grep -E \"^# ${config} is not set\" /boot/config-$(uname -r)" > /dev/null 2>&1)
+      res=$(kubectl exec -t $pod -- nsenter --mount=/proc/1/ns/mnt -- bash -c "grep -E \"^# ${config} is not set\" /boot/config-\$(uname -r)" > /dev/null 2>&1)
       if [[ $? == 0 ]]; then
         all_found=false
         nodes["${node}"]="${node}"
       else
-        res=$(kubectl exec -t $pod -- nsenter --mount=/proc/1/ns/mnt -- bash -c "grep -E \"^${config}=\" /boot/config-$(uname -r)" > /dev/null 2>&1)
+        res=$(kubectl exec -t $pod -- nsenter --mount=/proc/1/ns/mnt -- bash -c "grep -E \"^${config}=\" /boot/config-\$(uname -r)" > /dev/null 2>&1)
         if [[ $? != 0 ]]; then
           all_found=false
           warn "Unable to check kernel config ${config} on node ${node}"

--- a/scripts/environment_check.sh
+++ b/scripts/environment_check.sh
@@ -109,9 +109,9 @@ detect_node_os()
 {
   local pod="$1"
 
-  OS=`kubectl exec -i $pod -- nsenter --mount=/proc/1/ns/mnt -- bash -c 'grep -E "^ID_LIKE=" /etc/os-release | cut -d= -f2'`
+  OS=$(kubectl exec -i $pod -- nsenter --mount=/proc/1/ns/mnt -- bash -c 'grep -E "^ID_LIKE=" /etc/os-release | cut -d= -f2')
   if [[ -z "${OS}" ]]; then
-    OS=`kubectl exec -i $pod -- nsenter --mount=/proc/1/ns/mnt -- bash -c 'grep -E "^ID=" /etc/os-release | cut -d= -f2'`
+    OS=$(kubectl exec -i $pod -- nsenter --mount=/proc/1/ns/mnt -- bash -c 'grep -E "^ID=" /etc/os-release | cut -d= -f2')
   fi
   echo "$OS"
 }
@@ -229,7 +229,7 @@ check_package_installed() {
   local all_found=true
 
   for pod in ${pods}; do
-    OS=`detect_node_os $pod`
+    OS=$(detect_node_os $pod)
     if [ x"$OS" == x"" ]; then
       error "Unable to detect OS on node $node."
       exit 2
@@ -243,7 +243,7 @@ check_package_installed() {
       kubectl exec -i $pod -- nsenter --mount=/proc/1/ns/mnt -- timeout 30 bash -c "$CHECK_CMD $package" > /dev/null 2>&1
       if [ $? != 0 ]; then
         all_found=false
-        node=`kubectl get ${pod} --no-headers -o=custom-columns=:.spec.nodeName`
+        node=$(kubectl get ${pod} --no-headers -o=custom-columns=:.spec.nodeName)
         error "$package is not found in $node."
       fi
     done
@@ -283,7 +283,7 @@ check_multipathd() {
     kubectl exec -t $pod -- nsenter --mount=/proc/1/ns/mnt -- bash -c "systemctl status --no-pager multipathd.service" > /dev/null 2>&1
     if [ $? = 0 ]; then
       all_not_found=false
-      node=`kubectl get ${pod} --no-headers -o=custom-columns=:.spec.nodeName`
+      node=$(kubectl get ${pod} --no-headers -o=custom-columns=:.spec.nodeName)
       warn "multipathd is running on $node."
     fi
   done
@@ -302,7 +302,7 @@ check_iscsid() {
 
     if [ $? != 0 ]; then
       all_found=false
-      node=`kubectl get ${pod} --no-headers -o=custom-columns=:.spec.nodeName`
+      node=$(kubectl get ${pod} --no-headers -o=custom-columns=:.spec.nodeName)
       error "iscsid is not running on $node."
     fi
   done
@@ -321,13 +321,13 @@ check_nfs_client_kernel_support() {
     declare -A nodes=()
 
     for pod in ${pods}; do
-      node=`kubectl get ${pod} --no-headers -o=custom-columns=:.spec.nodeName`
-      res=`kubectl exec -t $pod -- nsenter --mount=/proc/1/ns/mnt -- bash -c "grep -E \"^# ${config} is not set\" /boot/config-$(uname -r)" > /dev/null 2>&1`
+      node=$(kubectl get ${pod} --no-headers -o=custom-columns=:.spec.nodeName)
+      res=$(kubectl exec -t $pod -- nsenter --mount=/proc/1/ns/mnt -- bash -c "grep -E \"^# ${config} is not set\" /boot/config-$(uname -r)" > /dev/null 2>&1)
       if [[ $? == 0 ]]; then
         all_found=false
         nodes["${node}"]="${node}"
       else
-        res=`kubectl exec -t $pod -- nsenter --mount=/proc/1/ns/mnt -- bash -c "grep -E \"^${config}=\" /boot/config-$(uname -r)" > /dev/null 2>&1`
+        res=$(kubectl exec -t $pod -- nsenter --mount=/proc/1/ns/mnt -- bash -c "grep -E \"^${config}=\" /boot/config-$(uname -r)" > /dev/null 2>&1)
         if [[ $? != 0 ]]; then
           all_found=false
           warn "Unable to check kernel config ${config} on node ${node}"


### PR DESCRIPTION
Replaced all instances of backtick command substitution with $()-command substitution. 
This also fixes https://github.com/longhorn/longhorn/issues/5304 