### PR TITLE
Update k8s.gcr.io to registry.k8s.io

### DIFF
--- a/deploy/prerequisite/longhorn-cifs-installation.yaml
+++ b/deploy/prerequisite/longhorn-cifs-installation.yaml
@@ -31,6 +31,6 @@ spec:
           privileged: true
       containers:
       - name: sleep
-        image: k8s.gcr.io/pause:3.1
+        image: registry.k8s.io/pause:3.1
   updateStrategy:
     type: RollingUpdate

--- a/deploy/prerequisite/longhorn-iscsi-installation.yaml
+++ b/deploy/prerequisite/longhorn-iscsi-installation.yaml
@@ -31,6 +31,6 @@ spec:
           privileged: true
       containers:
       - name: sleep
-        image: k8s.gcr.io/pause:3.1
+        image: registry.k8s.io/pause:3.1
   updateStrategy:
     type: RollingUpdate

--- a/deploy/prerequisite/longhorn-nfs-installation.yaml
+++ b/deploy/prerequisite/longhorn-nfs-installation.yaml
@@ -31,6 +31,6 @@ spec:
           privileged: true
       containers:
       - name: sleep
-        image: k8s.gcr.io/pause:3.1
+        image: registry.k8s.io/pause:3.1
   updateStrategy:
     type: RollingUpdate

--- a/examples/statefulset.yaml
+++ b/examples/statefulset.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: nginx
-        image: k8s.gcr.io/nginx-slim:0.8
+        image: registry.k8s.io/nginx-slim:0.8
         livenessProbe:
           exec:
             command:


### PR DESCRIPTION
This PR updates `k8s.gcr.io` to `registry.k8s.io`

Part of https://github.com/kubernetes/k8s.io/issues/4780