### PR TITLE
Bump CSI sidecars v1.5

### DIFF
--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -113,7 +113,7 @@ questions:
     label: Longhorn CSI Provisioner Image Repository
     group: "Longhorn CSI Driver Images"
   - variable: image.csi.provisioner.tag
-    default: v2.1.2
+    default: v3.4.1
     description: "Specify CSI provisioner image tag. Leave blank to autodetect."
     type: string
     label: Longhorn CSI Provisioner Image Tag
@@ -149,7 +149,7 @@ questions:
     label: Longhorn CSI Driver Snapshotter Image Repository
     group: "Longhorn CSI Driver Images"
   - variable: image.csi.snapshotter.tag
-    default: v5.0.1
+    default: v6.2.1
     description: "Specify CSI Driver Snapshotter image tag. Leave blank to autodetect."
     type: string
     label: Longhorn CSI Driver Snapshotter Image Tag

--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -101,7 +101,7 @@ questions:
     label: Longhorn CSI Attacher Image Repository
     group: "Longhorn CSI Driver Images"
   - variable: image.csi.attacher.tag
-    default: v3.4.0
+    default: v4.2.0
     description: "Specify CSI attacher image tag. Leave blank to autodetect."
     type: string
     label: Longhorn CSI Attacher Image Tag
@@ -125,7 +125,7 @@ questions:
     label: Longhorn CSI Node Driver Registrar Image Repository
     group: "Longhorn CSI Driver Images"
   - variable: image.csi.nodeDriverRegistrar.tag
-    default: v2.5.0
+    default: v2.7.0
     description: "Specify CSI Node Driver Registrar image tag. Leave blank to autodetect."
     type: string
     label: Longhorn CSI Node Driver Registrar Image Tag
@@ -137,7 +137,7 @@ questions:
     label: Longhorn CSI Driver Resizer Image Repository
     group: "Longhorn CSI Driver Images"
   - variable: image.csi.resizer.tag
-    default: v1.3.0
+    default: v1.7.0
     description: "Specify CSI Driver Resizer image tag. Leave blank to autodetect."
     type: string
     label: Longhorn CSI Driver Resizer Image Tag
@@ -161,7 +161,7 @@ questions:
     label: Longhorn CSI Liveness Probe Image Repository
     group: "Longhorn CSI Driver Images"
   - variable: image.csi.livenessProbe.tag
-    default: v2.8.0
+    default: v2.9.0
     description: "Specify CSI liveness probe image tag. Leave blank to autodetect."
     type: string
     label: Longhorn CSI Liveness Probe Image Tag

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -50,7 +50,7 @@ image:
       tag: v4.2.0
     provisioner:
       repository: longhornio/csi-provisioner
-      tag: v2.1.2
+      tag: v3.4.1
     nodeDriverRegistrar:
       repository: longhornio/csi-node-driver-registrar
       tag: v2.7.0
@@ -59,7 +59,7 @@ image:
       tag: v1.7.0
     snapshotter:
       repository: longhornio/csi-snapshotter
-      tag: v5.0.1
+      tag: v6.2.1
     livenessProbe:
       repository: longhornio/livenessprobe
       tag: v2.9.0

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -47,22 +47,22 @@ image:
   csi:
     attacher:
       repository: longhornio/csi-attacher
-      tag: v3.4.0
+      tag: v4.2.0
     provisioner:
       repository: longhornio/csi-provisioner
       tag: v2.1.2
     nodeDriverRegistrar:
       repository: longhornio/csi-node-driver-registrar
-      tag: v2.5.0
+      tag: v2.7.0
     resizer:
       repository: longhornio/csi-resizer
-      tag: v1.3.0
+      tag: v1.7.0
     snapshotter:
       repository: longhornio/csi-snapshotter
       tag: v5.0.1
     livenessProbe:
       repository: longhornio/livenessprobe
-      tag: v2.8.0
+      tag: v2.9.0
   pullPolicy: IfNotPresent
 
 service:

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -1,9 +1,9 @@
-longhornio/csi-attacher:v3.4.0
+longhornio/csi-attacher:v4.2.0
 longhornio/csi-provisioner:v2.1.2
-longhornio/csi-resizer:v1.3.0
+longhornio/csi-resizer:v1.7.0
 longhornio/csi-snapshotter:v5.0.1
-longhornio/csi-node-driver-registrar:v2.5.0
-longhornio/livenessprobe:v2.8.0
+longhornio/csi-node-driver-registrar:v2.7.0
+longhornio/livenessprobe:v2.9.0
 longhornio/backing-image-manager:master-head
 longhornio/longhorn-engine:master-head
 longhornio/longhorn-instance-manager:master-head

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -1,7 +1,7 @@
 longhornio/csi-attacher:v4.2.0
-longhornio/csi-provisioner:v2.1.2
+longhornio/csi-provisioner:v3.4.1
 longhornio/csi-resizer:v1.7.0
-longhornio/csi-snapshotter:v5.0.1
+longhornio/csi-snapshotter:v6.2.1
 longhornio/csi-node-driver-registrar:v2.7.0
 longhornio/livenessprobe:v2.9.0
 longhornio/backing-image-manager:master-head

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -2272,7 +2272,7 @@ spec:
       jsonPath: .spec.groups
       name: Groups
       type: string
-    - description: Should be one of "snapshot", "snapshot-force-create", "snapshot-cleanup", "snapshot-delete", "backup" or "backup-force-create".
+    - description: Should be one of "snapshot", "snapshot-force-create", "snapshot-cleanup", "snapshot-delete", "backup" or "backup-force-create"
       jsonPath: .spec.task
       name: Task
       type: string
@@ -4015,17 +4015,17 @@ spec:
               fieldRef:
                 fieldPath: spec.serviceAccountName
           - name: CSI_ATTACHER_IMAGE
-            value: "longhornio/csi-attacher:v3.4.0"
+            value: "longhornio/csi-attacher:v4.2.0"
           - name: CSI_PROVISIONER_IMAGE
             value: "longhornio/csi-provisioner:v2.1.2"
           - name: CSI_NODE_DRIVER_REGISTRAR_IMAGE
-            value: "longhornio/csi-node-driver-registrar:v2.5.0"
+            value: "longhornio/csi-node-driver-registrar:v2.7.0"
           - name: CSI_RESIZER_IMAGE
-            value: "longhornio/csi-resizer:v1.3.0"
+            value: "longhornio/csi-resizer:v1.7.0"
           - name: CSI_SNAPSHOTTER_IMAGE
             value: "longhornio/csi-snapshotter:v5.0.1"
           - name: CSI_LIVENESS_PROBE_IMAGE
-            value: "longhornio/livenessprobe:v2.8.0"
+            value: "longhornio/livenessprobe:v2.9.0"
       serviceAccountName: longhorn-service-account
       securityContext:
         runAsUser: 0

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -4017,13 +4017,13 @@ spec:
           - name: CSI_ATTACHER_IMAGE
             value: "longhornio/csi-attacher:v4.2.0"
           - name: CSI_PROVISIONER_IMAGE
-            value: "longhornio/csi-provisioner:v2.1.2"
+            value: "longhornio/csi-provisioner:v3.4.1"
           - name: CSI_NODE_DRIVER_REGISTRAR_IMAGE
             value: "longhornio/csi-node-driver-registrar:v2.7.0"
           - name: CSI_RESIZER_IMAGE
             value: "longhornio/csi-resizer:v1.7.0"
           - name: CSI_SNAPSHOTTER_IMAGE
-            value: "longhornio/csi-snapshotter:v5.0.1"
+            value: "longhornio/csi-snapshotter:v6.2.1"
           - name: CSI_LIVENESS_PROBE_IMAGE
             value: "longhornio/livenessprobe:v2.9.0"
       serviceAccountName: longhorn-service-account


### PR DESCRIPTION
#5672

We can't move to these versions of external-provisioner and external-snapshotter in Longhorn < v1.5, as they no longer support the v1beta1 VolumeSnapshot API. We deprecated its use in Longhorn v1.4 (https://github.com/longhorn/longhorn/blob/master/CHANGELOG/CHANGELOG-1.4.0.md#deprecation--incompatibilities). I will create separate PRs to bump sidecar versions in the v1.4.x and v1.3.x branches without these components.

We may need a CHANGELOG notice in v1.5 that v1beta1 VolumeSnapshot functionality is completely gone.

EDIT: This comment was previously (incorrectly) missing the "<" sign.