### PR TITLE
Bump CSI sidecars v1.4

### DIFF
--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -113,7 +113,7 @@ questions:
     label: Longhorn CSI Provisioner Image Repository
     group: "Longhorn CSI Driver Images"
   - variable: image.csi.provisioner.tag
-    default: v2.1.2
+    default: v2.2.2
     description: "Specify CSI provisioner image tag. Leave blank to autodetect."
     type: string
     label: Longhorn CSI Provisioner Image Tag

--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -101,7 +101,7 @@ questions:
     label: Longhorn CSI Attacher Image Repository
     group: "Longhorn CSI Driver Images"
   - variable: image.csi.attacher.tag
-    default: v3.4.0
+    default: v4.2.0
     description: "Specify CSI attacher image tag. Leave blank to autodetect."
     type: string
     label: Longhorn CSI Attacher Image Tag
@@ -125,7 +125,7 @@ questions:
     label: Longhorn CSI Node Driver Registrar Image Repository
     group: "Longhorn CSI Driver Images"
   - variable: image.csi.nodeDriverRegistrar.tag
-    default: v2.5.0
+    default: v2.7.0
     description: "Specify CSI Node Driver Registrar image tag. Leave blank to autodetect."
     type: string
     label: Longhorn CSI Node Driver Registrar Image Tag
@@ -137,7 +137,7 @@ questions:
     label: Longhorn CSI Driver Resizer Image Repository
     group: "Longhorn CSI Driver Images"
   - variable: image.csi.resizer.tag
-    default: v1.3.0
+    default: v1.7.0
     description: "Specify CSI Driver Resizer image tag. Leave blank to autodetect."
     type: string
     label: Longhorn CSI Driver Resizer Image Tag
@@ -161,7 +161,7 @@ questions:
     label: Longhorn CSI Liveness Probe Image Repository
     group: "Longhorn CSI Driver Images"
   - variable: image.csi.livenessProbe.tag
-    default: v2.8.0
+    default: v2.9.0
     description: "Specify CSI liveness probe image tag. Leave blank to autodetect."
     type: string
     label: Longhorn CSI Liveness Probe Image Tag

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -47,22 +47,22 @@ image:
   csi:
     attacher:
       repository: longhornio/csi-attacher
-      tag: v3.4.0
+      tag: v4.2.0
     provisioner:
       repository: longhornio/csi-provisioner
       tag: v2.1.2
     nodeDriverRegistrar:
       repository: longhornio/csi-node-driver-registrar
-      tag: v2.5.0
+      tag: v2.7.0
     resizer:
       repository: longhornio/csi-resizer
-      tag: v1.3.0
+      tag: v1.7.0
     snapshotter:
       repository: longhornio/csi-snapshotter
       tag: v5.0.1
     livenessProbe:
       repository: longhornio/livenessprobe
-      tag: v2.8.0
+      tag: v2.9.0
   pullPolicy: IfNotPresent
 
 service:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -50,7 +50,7 @@ image:
       tag: v4.2.0
     provisioner:
       repository: longhornio/csi-provisioner
-      tag: v2.1.2
+      tag: v2.2.2
     nodeDriverRegistrar:
       repository: longhornio/csi-node-driver-registrar
       tag: v2.7.0

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -1,9 +1,9 @@
-longhornio/csi-attacher:v3.4.0
+longhornio/csi-attacher:v4.2.0
 longhornio/csi-provisioner:v2.1.2
-longhornio/csi-resizer:v1.3.0
+longhornio/csi-resizer:v1.7.0
 longhornio/csi-snapshotter:v5.0.1
-longhornio/csi-node-driver-registrar:v2.5.0
-longhornio/livenessprobe:v2.8.0
+longhornio/csi-node-driver-registrar:v2.7.0
+longhornio/livenessprobe:v2.9.0
 longhornio/backing-image-manager:v1.4.1
 longhornio/longhorn-engine:v1.4.1
 longhornio/longhorn-instance-manager:v1.4.1

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -1,5 +1,5 @@
 longhornio/csi-attacher:v4.2.0
-longhornio/csi-provisioner:v2.1.2
+longhornio/csi-provisioner:v2.2.2
 longhornio/csi-resizer:v1.7.0
 longhornio/csi-snapshotter:v5.0.1
 longhornio/csi-node-driver-registrar:v2.7.0

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -2269,7 +2269,7 @@ spec:
       jsonPath: .spec.groups
       name: Groups
       type: string
-    - description: Should be one of "snapshot", "snapshot-force-create", "snapshot-cleanup", "snapshot-delete", "backup" or "backup-force-create".
+    - description: Should be one of "snapshot", "snapshot-force-create", "snapshot-cleanup", "snapshot-delete", "backup" or "backup-force-create"
       jsonPath: .spec.task
       name: Task
       type: string
@@ -4006,17 +4006,17 @@ spec:
               fieldRef:
                 fieldPath: spec.serviceAccountName
           - name: CSI_ATTACHER_IMAGE
-            value: "longhornio/csi-attacher:v3.4.0"
+            value: "longhornio/csi-attacher:v4.2.0"
           - name: CSI_PROVISIONER_IMAGE
             value: "longhornio/csi-provisioner:v2.1.2"
           - name: CSI_NODE_DRIVER_REGISTRAR_IMAGE
-            value: "longhornio/csi-node-driver-registrar:v2.5.0"
+            value: "longhornio/csi-node-driver-registrar:v2.7.0"
           - name: CSI_RESIZER_IMAGE
-            value: "longhornio/csi-resizer:v1.3.0"
+            value: "longhornio/csi-resizer:v1.7.0"
           - name: CSI_SNAPSHOTTER_IMAGE
             value: "longhornio/csi-snapshotter:v5.0.1"
           - name: CSI_LIVENESS_PROBE_IMAGE
-            value: "longhornio/livenessprobe:v2.8.0"
+            value: "longhornio/livenessprobe:v2.9.0"
       serviceAccountName: longhorn-service-account
       securityContext:
         runAsUser: 0

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -4008,7 +4008,7 @@ spec:
           - name: CSI_ATTACHER_IMAGE
             value: "longhornio/csi-attacher:v4.2.0"
           - name: CSI_PROVISIONER_IMAGE
-            value: "longhornio/csi-provisioner:v2.1.2"
+            value: "longhornio/csi-provisioner:v2.2.2"
           - name: CSI_NODE_DRIVER_REGISTRAR_IMAGE
             value: "longhornio/csi-node-driver-registrar:v2.7.0"
           - name: CSI_RESIZER_IMAGE


### PR DESCRIPTION
#5672 

Mostly the same as #5725 except it doesn't bump external-provisioner and external-snapshotter beyond the v1beta1 VolumeSnapshot API.