### PR TITLE
feat: use existent priority-class when upgrading

### DIFF
--- a/chart/templates/default-setting.yaml
+++ b/chart/templates/default-setting.yaml
@@ -45,7 +45,15 @@ data:
       {{- end -}}
       {{- $nodeSelector := list $windowsDefaultSettingNodeSelector $defaultSettingNodeSelector }}{{ join ";" (compact $nodeSelector) -}}
     {{- end }}
-    {{ if not (kindIs "invalid" .Values.defaultSettings.priorityClass) }}priority-class: {{ .Values.defaultSettings.priorityClass }}{{ end }}
+    {{- if .Release.IsInstall -}}
+      {{- if not (kindIs "invalid" .Values.defaultSettings.priorityClass) }}
+    priority-class: {{ .Values.defaultSettings.priorityClass }}
+      {{- end }}
+    {{- else if .Release.IsUpgrade -}}
+      {{- if ne (lookup "longhorn.io/v1beta2" "Setting" "longhorn-system" "priority-class").value "" }}
+    priority-class: {{ (lookup "longhorn.io/v1beta2" "Setting" "longhorn-system" "priority-class").value }}
+      {{- end }}
+    {{- end -}}
     {{ if not (kindIs "invalid" .Values.defaultSettings.autoSalvage) }}auto-salvage: {{ .Values.defaultSettings.autoSalvage }}{{ end }}
     {{ if not (kindIs "invalid" .Values.defaultSettings.autoDeletePodWhenVolumeDetachedUnexpectedly) }}auto-delete-pod-when-volume-detached-unexpectedly: {{ .Values.defaultSettings.autoDeletePodWhenVolumeDetachedUnexpectedly }}{{ end }}
     {{ if not (kindIs "invalid" .Values.defaultSettings.disableSchedulingOnCordonedNode) }}disable-scheduling-on-cordoned-node: {{ .Values.defaultSettings.disableSchedulingOnCordonedNode }}{{ end }}


### PR DESCRIPTION
If users give a different `priorityClass` in `values.yaml`, the `longhorn-default-setting` configmap will be updated. If there is no attached volume in the environment, `priority-class` setting will be updated, and all LH pods will be redeployed. This behavior may surprise users. I update the chart to ignore the `priorityClass` value when it's upgrading. It's better to let users update the filed through the dashboard.

Issue: https://github.com/harvester/harvester/issues/3756