### PR TITLE
example: Update network-policy

### DIFF
--- a/examples/network-policy/backing-image-manager-network-policy.yaml
+++ b/examples/network-policy/backing-image-manager-network-policy.yaml
@@ -20,6 +20,3 @@ spec:
     - podSelector:
         matchLabels:
           longhorn.io/component: backing-image-manager
-    - podSelector:
-        matchLabels:
-          longhorn.io/component: backing-image-data-source

--- a/examples/network-policy/instance-manager-networking.yaml
+++ b/examples/network-policy/instance-manager-networking.yaml
@@ -19,7 +19,4 @@ spec:
           longhorn.io/component: instance-manager
     - podSelector:
         matchLabels:
-          longhorn.io/component: backing-image-manager
-    - podSelector:
-        matchLabels:
           longhorn.io/component: backing-image-data-source


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/5651

Although I don't add the egress for the components, the ingress part is updated based on the latest networking doc