### PR TITLE
fix(chart): fix livenessprobe image group name in question.yaml

### DIFF
--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -147,7 +147,7 @@ questions:
     description: "Specify CSI liveness probe image repository. Leave blank to autodetect."
     type: string
     label: Longhorn CSI Liveness Probe Image Repository
-    group: "Longhorn CSI Liveness Probe Images"
+    group: "Longhorn CSI Driver Images"
   - variable: image.csi.livenessProbe.tag
     default: v2.8.0
     description: "Specify CSI liveness probe image tag. Leave blank to autodetect."


### PR DESCRIPTION
[Longhorn 5794](https://github.com/longhorn/longhorn/issues/5794)

Signed-off-by: Ray Chang <ray.chang@suse.com>

 - Fix the upstream to make the group name should be `Longhorn CSI Driver Images` rather than `Longhorn CSI Liveness Probe Images`
https://github.com/longhorn/longhorn/blob/f57838cb7843e3589023e4f035e21b374ffd93f7/chart/questions.yaml#L150