### PR TITLE
fix: remove `privileged` from lifecycle jobs

### DIFF
--- a/chart/templates/postupgrade-job.yaml
+++ b/chart/templates/postupgrade-job.yaml
@@ -19,8 +19,6 @@ spec:
       - name: longhorn-post-upgrade
         image: {{ template "registry_url" . }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        securityContext:
-          privileged: true
         command:
         - longhorn-manager
         - post-upgrade

--- a/chart/templates/uninstall-job.yaml
+++ b/chart/templates/uninstall-job.yaml
@@ -19,8 +19,6 @@ spec:
       - name: longhorn-uninstall
         image: {{ template "registry_url" . }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        securityContext:
-          privileged: true
         command:
         - longhorn-manager
         - uninstall


### PR DESCRIPTION
Remove `privileged` requirement from lifecycle jobs `post-upgrade` and `uninstall`.

Ref: longhorn/longhorn#5862