### PR TITLE
fix: remove `privileged` from lifecycle jobs

### DIFF
--- a/uninstall/uninstall.yaml
+++ b/uninstall/uninstall.yaml
@@ -108,8 +108,6 @@ spec:
         - name: longhorn-uninstall
           image: longhornio/longhorn-manager:master-head
           imagePullPolicy: IfNotPresent
-          securityContext:
-            privileged: true
           command:
             - longhorn-manager
             - uninstall


### PR DESCRIPTION
Remove `privileged` requirement from lifecycle jobs in `uninstall/uninstall.yaml`.

Run `./scripts/generate-longhorn-yaml.sh` and nothing changed.

Ref: longhorn/longhorn#5862