### PR TITLE
chore: correct pre upgrade pod name

### DIFF
--- a/chart/templates/preupgrade-job.yaml
+++ b/chart/templates/preupgrade-job.yaml
@@ -16,7 +16,7 @@ spec:
       labels: {{- include "longhorn.labels" . | nindent 8 }}
     spec:
       containers:
-      - name: longhorn-post-upgrade
+      - name: longhorn-pre-upgrade
         image: {{ template "registry_url" . }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:


### PR DESCRIPTION
Correct `pre-upgrade job` pod name.

Ref: longhorn/longhorn#5131, https://github.com/longhorn/longhorn/pull/5567