### PR TITLE
feat(dr-volume) forcibly avtivate a DR volume

### DIFF
--- a/chart/templates/crds.yaml
+++ b/chart/templates/crds.yaml
@@ -3432,6 +3432,8 @@ spec:
                 type: string
               expansionRequired:
                 type: boolean
+              forciblyActivating:
+                type: boolean
               frontendDisabled:
                 type: boolean
               isStandby:

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -3580,6 +3580,8 @@ spec:
                 type: string
               expansionRequired:
                 type: boolean
+              forciblyActivating:
+                type: boolean
               frontendDisabled:
                 type: boolean
               isStandby:


### PR DESCRIPTION
Add a volume status parameter to support forcibly activating a DR volume as long as there is a ready replica.

Ref: longhorn/longhorn#1512