### PR TITLE
Node affinity for user-deployed components

### DIFF
--- a/chart/templates/daemonset-sa.yaml
+++ b/chart/templates/daemonset-sa.yaml
@@ -122,7 +122,7 @@ spec:
         {{- end }}
       {{- end }}
       {{- if .Values.longhornManager.affinity }}
-      affinitiy:
+      affinity:
 {{ toYaml .Values.longhornManager.affinity | indent 8 }}
       {{- end }}      
       serviceAccountName: longhorn-service-account

--- a/chart/templates/daemonset-sa.yaml
+++ b/chart/templates/daemonset-sa.yaml
@@ -121,9 +121,10 @@ spec:
 {{ toYaml .Values.longhornManager.nodeSelector | indent 8 }}
         {{- end }}
       {{- end }}
-      {{- if .Values.longhornManager.affinity }}
+      {{- if .Values.longhornManager.nodeAffinity }}
       affinity:
-{{ toYaml .Values.longhornManager.affinity | indent 8 }}
+        nodeAffinity:
+{{ toYaml .Values.longhornManager.nodeAffinity | indent 10 }}
       {{- end }}      
       serviceAccountName: longhorn-service-account
   updateStrategy:

--- a/chart/templates/deployment-driver.yaml
+++ b/chart/templates/deployment-driver.yaml
@@ -113,6 +113,11 @@ spec:
 {{ toYaml .Values.longhornDriver.nodeSelector | indent 8 }}
         {{- end }}
       {{- end }}
+      {{- if .Values.longhornDriver.nodeAffinity }}
+      affinity:
+        nodeAffinity:
+{{ toYaml .Values.longhornDriver.nodeAffinity | indent 10 }}
+      {{- end }}   
       serviceAccountName: longhorn-service-account
       securityContext:
         runAsUser: 0

--- a/chart/templates/deployment-ui.yaml
+++ b/chart/templates/deployment-ui.yaml
@@ -16,6 +16,10 @@ spec:
         app: longhorn-ui
     spec:
       affinity:
+        {{- if .Values.longhornUI.nodeAffinity }}
+        nodeAffinity:
+{{ toYaml .Values.longhornUI.nodeAffinity | indent 10 }}
+        {{- end }}    
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 1

--- a/chart/templates/postupgrade-job.yaml
+++ b/chart/templates/postupgrade-job.yaml
@@ -55,6 +55,6 @@ spec:
         {{- end }}
       {{- end }}
       {{- if .Values.longhornManager.affinity }}
-      affinitiy:
+      affinity:
 {{ toYaml .Values.longhornManager.affinity | indent 8 }}
       {{- end }}      

--- a/chart/templates/postupgrade-job.yaml
+++ b/chart/templates/postupgrade-job.yaml
@@ -54,7 +54,8 @@ spec:
 {{ toYaml .Values.longhornManager.nodeSelector | indent 8 }}
         {{- end }}
       {{- end }}
-      {{- if .Values.longhornManager.affinity }}
+      {{- if .Values.longhornManager.nodeAffinity }}
       affinity:
-{{ toYaml .Values.longhornManager.affinity | indent 8 }}
+        nodeAffinity:
+{{ toYaml .Values.longhornManager.nodeAffinity | indent 10 }}
       {{- end }}      

--- a/chart/templates/preupgrade-job.yaml
+++ b/chart/templates/preupgrade-job.yaml
@@ -54,7 +54,8 @@ spec:
 {{ toYaml .Values.longhornManager.nodeSelector | indent 8 }}
         {{- end }}
       {{- end }}
-      {{- if .Values.longhornManager.affinity }}
+      {{- if .Values.longhornManager.nodeAffinity }}
       affinity:
-{{ toYaml .Values.longhornManager.affinity | indent 8 }}
+        nodeAffinity:
+{{ toYaml .Values.longhornManager.nodeAffinity | indent 10 }}
       {{- end }}

--- a/chart/templates/preupgrade-job.yaml
+++ b/chart/templates/preupgrade-job.yaml
@@ -55,6 +55,6 @@ spec:
         {{- end }}
       {{- end }}
       {{- if .Values.longhornManager.affinity }}
-      affinitiy:
+      affinity:
 {{ toYaml .Values.longhornManager.affinity | indent 8 }}
       {{- end }}

--- a/chart/templates/uninstall-job.yaml
+++ b/chart/templates/uninstall-job.yaml
@@ -55,7 +55,8 @@ spec:
 {{ toYaml .Values.longhornManager.nodeSelector | indent 8 }}
         {{- end }}
       {{- end }}
-      {{- if .Values.longhornManager.affinity }}
+      {{- if .Values.longhornManager.nodeAffinity }}
       affinity:
-{{ toYaml .Values.longhornManager.affinity | indent 8 }}
+        nodeAffinity:
+{{ toYaml .Values.longhornManager.nodeAffinity | indent 10 }}
       {{- end }}      

--- a/chart/templates/uninstall-job.yaml
+++ b/chart/templates/uninstall-job.yaml
@@ -56,6 +56,6 @@ spec:
         {{- end }}
       {{- end }}
       {{- if .Values.longhornManager.affinity }}
-      affinitiy:
+      affinity:
 {{ toYaml .Values.longhornManager.affinity | indent 8 }}
       {{- end }}      

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -187,18 +187,17 @@ longhornManager:
   ## and uncomment this example block
   #   label-key1: "label-value1"
   #   label-key2: "label-value2"
-  affinity: {}
-  ## If you want to set nodeAffinity for Longhorn Manager DaemonSet, delete the `{}` in the line above
+  nodeAffinity: {}
+  ## If you want to set node affinity for Longhorn Manager DaemonSet, delete the `{}` in the line above
   ## and uncomment this example block
-  #   nodeAffinity:
-  #     requiredDuringSchedulingIgnoredDuringExecution:
-  #       nodeSelectorTerms:
-  #         - matchExpressions:
-  #           - key: label-key1
-  #             operator: In
-  #             values:
-  #               - label-value1
-  #               - label-value2  
+  #   requiredDuringSchedulingIgnoredDuringExecution:
+  #     nodeSelectorTerms:
+  #       - matchExpressions:
+  #         - key: label-key1
+  #           operator: In
+  #           values:
+  #             - label-value1
+  #             - label-value2  
   serviceAnnotations: {}
   ## If you want to set annotations for the Longhorn Manager service, delete the `{}` in the line above
   ## and uncomment this example block
@@ -219,6 +218,17 @@ longhornDriver:
   ## and uncomment this example block
   #   label-key1: "label-value1"
   #   label-key2: "label-value2"
+  nodeAffinity: {}
+  ## If you want to set node affinity for Longhorn Driver Deployer Deployment, delete the `{}` in the line above
+  ## and uncomment this example block
+  #   requiredDuringSchedulingIgnoredDuringExecution:
+  #     nodeSelectorTerms:
+  #       - matchExpressions:
+  #         - key: label-key1
+  #           operator: In
+  #           values:
+  #             - label-value1
+  #             - label-value2  
 
 longhornUI:
   replicas: 2
@@ -235,6 +245,17 @@ longhornUI:
   ## and uncomment this example block
   #   label-key1: "label-value1"
   #   label-key2: "label-value2"
+  nodeAffinity: {}
+  ## If you want to set node affinity for Longhorn UI Deployment, delete the `{}` in the line above
+  ## and uncomment this example block
+  #   requiredDuringSchedulingIgnoredDuringExecution:
+  #     nodeSelectorTerms:
+  #       - matchExpressions:
+  #         - key: label-key1
+  #           operator: In
+  #           values:
+  #             - label-value1
+  #             - label-value2  
 
 ingress:
   ## Set to true to enable ingress record generation

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -185,25 +185,25 @@ longhornManager:
   nodeSelector: {}
   ## If you want to set node selector for Longhorn Manager DaemonSet, delete the `{}` in the line above
   ## and uncomment this example block
-  #  label-key1: "label-value1"
-  #  label-key2: "label-value2"
+  #   label-key1: "label-value1"
+  #   label-key2: "label-value2"
   affinity: {}
   ## If you want to set nodeAffinity for Longhorn Manager DaemonSet, delete the `{}` in the line above
   ## and uncomment this example block
-  # nodeAffinity:
-  #   requiredDuringSchedulingIgnoredDuringExecution:
-  #     nodeSelectorTerms:
-  #       - matchExpressions:
-  #         - key: label-key1
-  #           operator: In
-  #           values:
-  #             - label-value1
-  #             - label-value2  
+  #   nodeAffinity:
+  #     requiredDuringSchedulingIgnoredDuringExecution:
+  #       nodeSelectorTerms:
+  #         - matchExpressions:
+  #           - key: label-key1
+  #             operator: In
+  #             values:
+  #               - label-value1
+  #               - label-value2  
   serviceAnnotations: {}
   ## If you want to set annotations for the Longhorn Manager service, delete the `{}` in the line above
   ## and uncomment this example block
-  #  annotation-key1: "annotation-value1"
-  #  annotation-key2: "annotation-value2"
+  #   annotation-key1: "annotation-value1"
+  #   annotation-key2: "annotation-value2"
 
 longhornDriver:
   priorityClass: ~
@@ -217,8 +217,8 @@ longhornDriver:
   nodeSelector: {}
   ## If you want to set node selector for Longhorn Driver Deployer Deployment, delete the `{}` in the line above
   ## and uncomment this example block
-  #  label-key1: "label-value1"
-  #  label-key2: "label-value2"
+  #   label-key1: "label-value1"
+  #   label-key2: "label-value2"
 
 longhornUI:
   replicas: 2
@@ -233,8 +233,8 @@ longhornUI:
   nodeSelector: {}
   ## If you want to set node selector for Longhorn UI Deployment, delete the `{}` in the line above
   ## and uncomment this example block
-  #  label-key1: "label-value1"
-  #  label-key2: "label-value2"
+  #   label-key1: "label-value1"
+  #   label-key2: "label-value2"
 
 ingress:
   ## Set to true to enable ingress record generation
@@ -268,8 +268,8 @@ ingress:
   ##
   ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
   annotations:
-  #  kubernetes.io/ingress.class: nginx
-  #  kubernetes.io/tls-acme: true
+  #   kubernetes.io/ingress.class: nginx
+  #   kubernetes.io/tls-acme: true
 
   secrets:
   ## If you're providing your own certificates, please use this to add the certificates as secrets

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -236,54 +236,6 @@ longhornUI:
   #  label-key1: "label-value1"
   #  label-key2: "label-value2"
 
-longhornConversionWebhook:
-  replicas: 2
-  priorityClass: ~
-  tolerations: []
-  ## If you want to set tolerations for Longhorn conversion webhook Deployment, delete the `[]` in the line above
-  ## and uncomment this example block
-  # - key: "key"
-  #   operator: "Equal"
-  #   value: "value"
-  #   effect: "NoSchedule"
-  nodeSelector: {}
-  ## If you want to set node selector for Longhorn conversion webhook Deployment, delete the `{}` in the line above
-  ## and uncomment this example block
-  #  label-key1: "label-value1"
-  #  label-key2: "label-value2"
-
-longhornAdmissionWebhook:
-  replicas: 2
-  priorityClass: ~
-  tolerations: []
-  ## If you want to set tolerations for Longhorn admission webhook Deployment, delete the `[]` in the line above
-  ## and uncomment this example block
-  # - key: "key"
-  #   operator: "Equal"
-  #   value: "value"
-  #   effect: "NoSchedule"
-  nodeSelector: {}
-  ## If you want to set node selector for Longhorn admission webhook Deployment, delete the `{}` in the line above
-  ## and uncomment this example block
-  #  label-key1: "label-value1"
-  #  label-key2: "label-value2"
-
-longhornRecoveryBackend:
-  replicas: 2
-  priorityClass: ~
-  tolerations: []
-  ## If you want to set tolerations for Longhorn recovery backend Deployment, delete the `[]` in the line above
-  ## and uncomment this example block
-  # - key: "key"
-  #   operator: "Equal"
-  #   value: "value"
-  #   effect: "NoSchedule"
-  nodeSelector: {}
-  ## If you want to set node selector for Longhorn recovery backend Deployment, delete the `{}` in the line above
-  ## and uncomment this example block
-  #  label-key1: "label-value1"
-  #  label-key2: "label-value2"
-
 ingress:
   ## Set to true to enable ingress record generation
   enabled: false


### PR DESCRIPTION
#5191 

The previous work done in https://github.com/longhorn/longhorn/pull/5168 contained a typo that rendered it ineffective. In addition, it broadly supported affinity in general. This PR:

- Fixes the typo.
- Narrows down to NodeAffinity because:
    - It simplifies the longhorn-ui case, in which we already have a PodAntiAffinity and now we don't have to merge a user-specified value and our default value.
    - IMO NodeAffinity is what we want to be specifying for a storage system (it doesn't make sense to try to schedule the storage system to be on the same node as or avoid arbitrary workloads).
- Enabled NodeAffinity on all user-deployed components. 

There is a HUGE caveat here. Even though user-deployed components are limited by node affinity, system-deployed components are not. We must discuss this before merging.

- [ ] Resolve https://github.com/longhorn/longhorn/issues/5191#issuecomment-1561821738