### PR TITLE
Remove longhorn-manager affinity support for now

### DIFF
--- a/chart/templates/daemonset-sa.yaml
+++ b/chart/templates/daemonset-sa.yaml
@@ -121,10 +121,6 @@ spec:
 {{ toYaml .Values.longhornManager.nodeSelector | indent 8 }}
         {{- end }}
       {{- end }}
-      {{- if .Values.longhornManager.affinity }}
-      affinitiy:
-{{ toYaml .Values.longhornManager.affinity | indent 8 }}
-      {{- end }}      
       serviceAccountName: longhorn-service-account
   updateStrategy:
     rollingUpdate:

--- a/chart/templates/postupgrade-job.yaml
+++ b/chart/templates/postupgrade-job.yaml
@@ -54,7 +54,3 @@ spec:
 {{ toYaml .Values.longhornManager.nodeSelector | indent 8 }}
         {{- end }}
       {{- end }}
-      {{- if .Values.longhornManager.affinity }}
-      affinitiy:
-{{ toYaml .Values.longhornManager.affinity | indent 8 }}
-      {{- end }}      

--- a/chart/templates/preupgrade-job.yaml
+++ b/chart/templates/preupgrade-job.yaml
@@ -54,7 +54,3 @@ spec:
 {{ toYaml .Values.longhornManager.nodeSelector | indent 8 }}
         {{- end }}
       {{- end }}
-      {{- if .Values.longhornManager.affinity }}
-      affinitiy:
-{{ toYaml .Values.longhornManager.affinity | indent 8 }}
-      {{- end }}

--- a/chart/templates/uninstall-job.yaml
+++ b/chart/templates/uninstall-job.yaml
@@ -55,7 +55,3 @@ spec:
 {{ toYaml .Values.longhornManager.nodeSelector | indent 8 }}
         {{- end }}
       {{- end }}
-      {{- if .Values.longhornManager.affinity }}
-      affinitiy:
-{{ toYaml .Values.longhornManager.affinity | indent 8 }}
-      {{- end }}      

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -187,18 +187,6 @@ longhornManager:
   ## and uncomment this example block
   #  label-key1: "label-value1"
   #  label-key2: "label-value2"
-  affinity: {}
-  ## If you want to set nodeAffinity for Longhorn Manager DaemonSet, delete the `{}` in the line above
-  ## and uncomment this example block
-  # nodeAffinity:
-  #   requiredDuringSchedulingIgnoredDuringExecution:
-  #     nodeSelectorTerms:
-  #       - matchExpressions:
-  #         - key: label-key1
-  #           operator: In
-  #           values:
-  #             - label-value1
-  #             - label-value2  
   serviceAnnotations: {}
   ## If you want to set annotations for the Longhorn Manager service, delete the `{}` in the line above
   ## and uncomment this example block

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -4150,7 +4150,7 @@ spec:
       - name: longhorn-grpc-tls
         secret:
           secretName: longhorn-grpc-tls
-          optional: true      
+          optional: true
       serviceAccountName: longhorn-service-account
   updateStrategy:
     rollingUpdate:


### PR DESCRIPTION
longhorn/longhorn#5191

For the reason outlined in https://github.com/longhorn/longhorn/issues/5191#issuecomment-1561821738, we decided to hold off on supporting affinity for all Longhorn components, including longhorn-manager. This PR reverts https://github.com/longhorn/longhorn/pull/5168 (plus an additional file longhorn-manager affinity has appeared in since then). Hopefully we can pick this back up again in v1.6.0.