### PR TITLE
spdk: use 1024 MiB huge pages by default

### DIFF
--- a/deploy/prerequisite/longhorn-spdk-setup.yaml
+++ b/deploy/prerequisite/longhorn-spdk-setup.yaml
@@ -33,7 +33,7 @@ spec:
         - name: SPDK_OPTION
           value: ""
         - name: HUGEMEM
-          value: "2048"
+          value: "1024"
         - name: PCI_ALLOWED
           value: "none"
         - name: DRIVER_OVERRIDE


### PR DESCRIPTION
Forgot updating the HUGEMEM in https://github.com/longhorn/longhorn/pull/6040/files