### PR TITLE
chore(ghaction): fix invalid member check

### DIFF
--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -14,7 +14,7 @@ jobs:
         organization: longhorn
         GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
     - name: Add To Community Project
-      if: steps.is-longhorn-member.outputs.isTeamMember == 'false'
+      if: fromJSON(steps.is-longhorn-member.outputs.teams)[0] == null
       uses: actions/add-to-project@v0.3.0
       with:
         project-url: https://github.com/orgs/longhorn/projects/5
@@ -31,7 +31,7 @@ jobs:
         organization: longhorn
         GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
     - name: Add To QA & DevOps Project
-      if: steps.is-longhorn-member.outputs.isTeamMember == 'true'
+      if: fromJSON(steps.is-longhorn-member.outputs.teams)[0] != null
       uses: actions/add-to-project@v0.3.0
       with:
         project-url: https://github.com/orgs/longhorn/projects/4

--- a/.github/workflows/create-issue.yml
+++ b/.github/workflows/create-issue.yml
@@ -15,14 +15,14 @@ jobs:
         organization: longhorn
         GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
     - name: Get Backport Version
-      if: steps.is-longhorn-member.outputs.isTeamMember == 'true'
+      if: fromJSON(steps.is-longhorn-member.outputs.teams)[0] != null
       uses: xom9ikk/split@v1
       id: split
       with:
         string: ${{ github.event.label.name }}
         separator: /
     - name: Check if Backport Issue Exists
-      if: steps.is-longhorn-member.outputs.isTeamMember == 'true'
+      if: fromJSON(steps.is-longhorn-member.outputs.teams)[0] != null
       uses: actions-cool/issues-helper@v3
       id: if-backport-issue-exists
       with:
@@ -32,7 +32,7 @@ jobs:
         title-includes: |
           [BACKPORT][v${{ steps.split.outputs._1 }}]${{ github.event.issue.title }}
     - name: Get Milestone Object
-      if: steps.is-longhorn-member.outputs.isTeamMember == 'true' && fromJSON(steps.if-backport-issue-exists.outputs.issues)[0] == null
+      if: fromJSON(steps.is-longhorn-member.outputs.teams)[0] != null && fromJSON(steps.if-backport-issue-exists.outputs.issues)[0] == null
       uses: longhorn/bot/milestone-action@master
       id: milestone
       with:
@@ -40,7 +40,7 @@ jobs:
         repository: ${{ github.repository }}
         milestone_name: v${{ steps.split.outputs._1 }}
     - name: Get Labels
-      if: steps.is-longhorn-member.outputs.isTeamMember == 'true' && fromJSON(steps.if-backport-issue-exists.outputs.issues)[0] == null
+      if: fromJSON(steps.is-longhorn-member.outputs.teams)[0] != null && fromJSON(steps.if-backport-issue-exists.outputs.issues)[0] == null
       id: labels
       run: |
         RAW_LABELS="${{ join(github.event.issue.labels.*.name, ' ') }}"
@@ -50,7 +50,7 @@ jobs:
         echo "LABELS: $LABELS"
         echo "::set-output name=labels::$LABELS"
     - name: Create Backport Issue
-      if: steps.is-longhorn-member.outputs.isTeamMember == 'true' && fromJSON(steps.if-backport-issue-exists.outputs.issues)[0] == null
+      if: fromJSON(steps.is-longhorn-member.outputs.teams)[0] != null && fromJSON(steps.if-backport-issue-exists.outputs.issues)[0] == null
       uses: dacbd/create-issue-action@v1
       id: new-issue
       with:
@@ -63,7 +63,7 @@ jobs:
         milestone: ${{ fromJSON(steps.milestone.outputs.data).number }}
         assignees: ${{ join(github.event.issue.assignees.*.login, ', ') }}
     - name: Get Repo Id
-      if: steps.is-longhorn-member.outputs.isTeamMember == 'true' && fromJSON(steps.if-backport-issue-exists.outputs.issues)[0] == null
+      if: fromJSON(steps.is-longhorn-member.outputs.teams)[0] != null && fromJSON(steps.if-backport-issue-exists.outputs.issues)[0] == null
       uses: octokit/request-action@v2.x
       id: repo
       with:
@@ -71,7 +71,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
     - name: Add Backport Issue To Release
-      if: steps.is-longhorn-member.outputs.isTeamMember == 'true' && fromJSON(steps.if-backport-issue-exists.outputs.issues)[0] == null
+      if: fromJSON(steps.is-longhorn-member.outputs.teams)[0] != null && fromJSON(steps.if-backport-issue-exists.outputs.issues)[0] == null
       uses: longhorn/bot/add-zenhub-release-action@master
       with:
         zenhub_token: ${{ secrets.ZENHUB_TOKEN }}
@@ -91,7 +91,7 @@ jobs:
         organization: longhorn
         GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
     - name: Check if Automation Issue Exists
-      if: steps.is-longhorn-member.outputs.isTeamMember == 'true'
+      if: fromJSON(steps.is-longhorn-member.outputs.teams)[0] != null
       uses: actions-cool/issues-helper@v3
       id: if-automation-issue-exists
       with:
@@ -101,7 +101,7 @@ jobs:
         title-includes: |
           [TEST]${{ github.event.issue.title }}
     - name: Create Automation Test Issue
-      if: steps.is-longhorn-member.outputs.isTeamMember == 'true' && fromJSON(steps.if-automation-issue-exists.outputs.issues)[0] == null
+      if: fromJSON(steps.is-longhorn-member.outputs.teams)[0] != null && fromJSON(steps.if-automation-issue-exists.outputs.issues)[0] == null
       uses: dacbd/create-issue-action@v1
       with:
         token: ${{ github.token }}


### PR DESCRIPTION
https://github.com/tspascoal/get-user-teams-membership/blob/master/src/index.js#L57C1-L59C11 `isTeamMember` requires a team variable, so we should just simply check if the reporter is from the org as the original behavior.