### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/create-issue.yml
+++ b/.github/workflows/create-issue.yml
@@ -48,7 +48,7 @@ jobs:
         echo "RAW LABELS: $RAW_LABELS"
         LABELS=$(echo "$RAW_LABELS" | sed -r 's/\s*backport\S+//g' | sed -r 's/\s*require\/auto-e2e-test//g' | xargs | sed 's/ /, /g')
         echo "LABELS: $LABELS"
-        echo "::set-output name=labels::$LABELS"
+        echo "labels=$LABELS" >> $GITHUB_OUTPUT
     - name: Create Backport Issue
       if: fromJSON(steps.is-longhorn-member.outputs.teams)[0] != null && fromJSON(steps.if-backport-issue-exists.outputs.issues)[0] == null
       uses: dacbd/create-issue-action@v1


### PR DESCRIPTION
## Description

Update `.github/workflows/create-issue.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
echo "::set-output name=labels::$LABELS"
```

**TO-BE**

```yaml
echo "labels=$LABELS" >> $GITHUB_OUTPUT
```