### PR TITLE
Fix app name label

### DIFF
--- a/chart/templates/daemonset-sa.yaml
+++ b/chart/templates/daemonset-sa.yaml
@@ -2,17 +2,17 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels: {{- include "longhorn.labels" . | nindent 4 }}
-    app: longhorn-manager
+    app.kubernetes.io/name: longhorn-manager
   name: longhorn-manager
   namespace: {{ include "release_namespace" . }}
 spec:
   selector:
     matchLabels:
-      app: longhorn-manager
+      app.kubernetes.io/name: longhorn-manager
   template:
     metadata:
       labels: {{- include "longhorn.labels" . | nindent 8 }}
-        app: longhorn-manager
+        app.kubernetes.io/name: longhorn-manager
       {{- with .Values.annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
@@ -130,7 +130,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels: {{- include "longhorn.labels" . | nindent 4 }}
-    app: longhorn-manager
+    app.kubernetes.io/name: longhorn-manager
   name: longhorn-backend
   namespace: {{ include "release_namespace" . }}
   {{- if .Values.longhornManager.serviceAnnotations }}
@@ -141,7 +141,7 @@ spec:
   type: {{ .Values.service.manager.type }}
   sessionAffinity: ClientIP
   selector:
-    app: longhorn-manager
+    app.kubernetes.io/name: longhorn-manager
   ports:
   - name: manager
     port: 9500

--- a/chart/templates/deployment-driver.yaml
+++ b/chart/templates/deployment-driver.yaml
@@ -4,15 +4,16 @@ metadata:
   name: longhorn-driver-deployer
   namespace: {{ include "release_namespace" . }}
   labels: {{- include "longhorn.labels" . | nindent 4 }}
+    app.kubernetes.io/name: longhorn-driver-deployer
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: longhorn-driver-deployer
+      app.kubernetes.io/name: longhorn-driver-deployer
   template:
     metadata:
       labels: {{- include "longhorn.labels" . | nindent 8 }}
-        app: longhorn-driver-deployer
+        app.kubernetes.io/name: longhorn-driver-deployer
     spec:
       initContainers:
         - name: wait-longhorn-manager

--- a/chart/templates/deployment-ui.yaml
+++ b/chart/templates/deployment-ui.yaml
@@ -61,7 +61,7 @@ spec:
             podAffinityTerm:
               labelSelector:
                 matchExpressions:
-                - key: app
+                - key: app.kubernetes.io/name
                   operator: In
                   values:
                   - longhorn-ui

--- a/chart/templates/deployment-ui.yaml
+++ b/chart/templates/deployment-ui.yaml
@@ -7,7 +7,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   labels: {{- include "longhorn.labels" . | nindent 4 }}
-    app: longhorn-ui
+    app.kubernetes.io/name: longhorn-ui
   name: {{ .Values.openshift.ui.route }}
   namespace: {{ include "release_namespace" . }}
 spec:
@@ -21,7 +21,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels: {{- include "longhorn.labels" . | nindent 4 }}
-    app: longhorn-ui
+    app.kubernetes.io/name: longhorn-ui
   name: longhorn-ui
   namespace: {{ include "release_namespace" . }}
   annotations:
@@ -32,7 +32,7 @@ spec:
     port: {{ .Values.openshift.ui.port | default 443 }}
     targetPort: {{ .Values.openshift.ui.proxy | default 8443 }}
   selector:
-    app: longhorn-ui
+    app.kubernetes.io/name: longhorn-ui
 ---
 {{- end }}
 {{- end }}
@@ -40,18 +40,18 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels: {{- include "longhorn.labels" . | nindent 4 }}
-    app: longhorn-ui
+    app.kubernetes.io/name: longhorn-ui
   name: longhorn-ui
   namespace: {{ include "release_namespace" . }}
 spec:
   replicas: {{ .Values.longhornUI.replicas }}
   selector:
     matchLabels:
-      app: longhorn-ui
+      app.kubernetes.io/name: longhorn-ui
   template:
     metadata:
       labels: {{- include "longhorn.labels" . | nindent 8 }}
-        app: longhorn-ui
+        app.kubernetes.io/name: longhorn-ui
     spec:
       serviceAccountName: longhorn-ui-service-account
       affinity:
@@ -151,7 +151,7 @@ kind: Service
 apiVersion: v1
 metadata:
   labels: {{- include "longhorn.labels" . | nindent 4 }}
-    app: longhorn-ui
+    app.kubernetes.io/name: longhorn-ui
     {{- if eq .Values.service.ui.type "Rancher-Proxy" }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
@@ -170,7 +170,7 @@ spec:
   loadBalancerSourceRanges: {{- toYaml .Values.service.ui.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
   selector:
-    app: longhorn-ui
+    app.kubernetes.io/name: longhorn-ui
   ports:
   - name: http
     port: 80

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
   name: longhorn-ingress
   namespace: {{ include "release_namespace" . }}
   labels: {{- include "longhorn.labels" . | nindent 4 }}
-    app: longhorn-ingress
+    app.kubernetes.io/name: longhorn-ingress
   annotations:
     {{- if .Values.ingress.secureBackends }}
     ingress.kubernetes.io/secure-backends: "true"

--- a/chart/templates/network-policies/backing-image-data-source-network-policy.yaml
+++ b/chart/templates/network-policies/backing-image-data-source-network-policy.yaml
@@ -14,7 +14,7 @@ spec:
   - from:
     - podSelector:
         matchLabels:
-          app: longhorn-manager
+          app.kubernetes.io/name: longhorn-manager
     - podSelector:
         matchLabels:
           longhorn.io/component: instance-manager

--- a/chart/templates/network-policies/backing-image-manager-network-policy.yaml
+++ b/chart/templates/network-policies/backing-image-manager-network-policy.yaml
@@ -14,7 +14,7 @@ spec:
   - from:
     - podSelector:
         matchLabels:
-          app: longhorn-manager
+          app.kubernetes.io/name: longhorn-manager
     - podSelector:
         matchLabels:
           longhorn.io/component: instance-manager

--- a/chart/templates/network-policies/instance-manager-networking.yaml
+++ b/chart/templates/network-policies/instance-manager-networking.yaml
@@ -14,7 +14,7 @@ spec:
   - from:
     - podSelector:
         matchLabels:
-          app: longhorn-manager
+          app.kubernetes.io/name: longhorn-manager
     - podSelector:
         matchLabels:
           longhorn.io/component: instance-manager

--- a/chart/templates/network-policies/manager-network-policy.yaml
+++ b/chart/templates/network-policies/manager-network-policy.yaml
@@ -7,20 +7,20 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: longhorn-manager
+      app.kubernetes.io/name: longhorn-manager
   policyTypes:
   - Ingress
   ingress:
   - from:
     - podSelector:
         matchLabels:
-          app: longhorn-manager
+          app.kubernetes.io/name: longhorn-manager
     - podSelector:
         matchLabels:
-          app: longhorn-ui
+          app.kubernetes.io/name: longhorn-ui
     - podSelector:
         matchLabels:
-          app: longhorn-csi-plugin
+          app.kubernetes.io/name: longhorn-csi-plugin
     - podSelector:
         matchLabels:
           longhorn.io/managed-by: longhorn-manager
@@ -31,5 +31,5 @@ spec:
           - { key: longhorn.io/job-task, operator: Exists }
     - podSelector:
         matchLabels:
-          app: longhorn-driver-deployer
+          app.kubernetes.io/name: longhorn-driver-deployer
 {{- end }}

--- a/chart/templates/network-policies/recovery-backend-network-policy.yaml
+++ b/chart/templates/network-policies/recovery-backend-network-policy.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: longhorn-manager
+      app.kubernetes.io/name: longhorn-manager
   policyTypes:
   - Ingress
   ingress:

--- a/chart/templates/network-policies/ui-frontend-network-policy.yaml
+++ b/chart/templates/network-policies/ui-frontend-network-policy.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: longhorn-ui
+      app.kubernetes.io/name: longhorn-ui
   policyTypes:
   - Ingress
   ingress:

--- a/chart/templates/network-policies/webhook-network-policy.yaml
+++ b/chart/templates/network-policies/webhook-network-policy.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: longhorn-manager
+      app.kubernetes.io/name: longhorn-manager
   policyTypes:
   - Ingress
   ingress:
@@ -23,7 +23,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: longhorn-manager
+      app.kubernetes.io/name: longhorn-manager
   policyTypes:
   - Ingress
   ingress:

--- a/chart/templates/services.yaml
+++ b/chart/templates/services.yaml
@@ -2,14 +2,14 @@ apiVersion: v1
 kind: Service
 metadata:
   labels: {{- include "longhorn.labels" . | nindent 4 }}
-    app: longhorn-conversion-webhook
+    app.kubernetes.io/name: longhorn-conversion-webhook
   name: longhorn-conversion-webhook
   namespace: {{ include "release_namespace" . }}
 spec:
   type: ClusterIP
   sessionAffinity: ClientIP
   selector:
-    app: longhorn-manager
+    app.kubernetes.io/name: longhorn-manager
   ports:
   - name: conversion-webhook
     port: 9501
@@ -19,14 +19,14 @@ apiVersion: v1
 kind: Service
 metadata:
   labels: {{- include "longhorn.labels" . | nindent 4 }}
-    app: longhorn-admission-webhook
+    app.kubernetes.io/name: longhorn-admission-webhook
   name: longhorn-admission-webhook
   namespace: {{ include "release_namespace" . }}
 spec:
   type: ClusterIP
   sessionAffinity: ClientIP
   selector:
-    app: longhorn-manager
+    app.kubernetes.io/name: longhorn-manager
   ports:
   - name: admission-webhook
     port: 9502
@@ -36,14 +36,14 @@ apiVersion: v1
 kind: Service
 metadata:
   labels: {{- include "longhorn.labels" . | nindent 4 }}
-    app: longhorn-recovery-backend
+    app.kubernetes.io/name: longhorn-recovery-backend
   name: longhorn-recovery-backend
   namespace: {{ include "release_namespace" . }}
 spec:
   type: ClusterIP
   sessionAffinity: ClientIP
   selector:
-    app: longhorn-manager
+    app.kubernetes.io/name: longhorn-manager
   ports:
   - name: recovery-backend
     port: 9503

--- a/chart/templates/tls-secrets.yaml
+++ b/chart/templates/tls-secrets.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ .name }}
   namespace: {{ include "release_namespace" $ }}
   labels: {{- include "longhorn.labels" $ | nindent 4 }}
-    app: longhorn
+    app.kubernetes.io/part-of: longhorn
 type: kubernetes.io/tls
 data:
   tls.crt: {{ .certificate | b64enc }}

--- a/scripts/environment_check.sh
+++ b/scripts/environment_check.sh
@@ -151,16 +151,16 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
-    app: longhorn-environment-check
+    app.kubernetes.io/name: longhorn-environment-check
   name: longhorn-environment-check
 spec:
   selector:
     matchLabels:
-      app: longhorn-environment-check
+      app.kubernetes.io/name: longhorn-environment-check
   template:
     metadata:
       labels:
-        app: longhorn-environment-check
+        app.kubernetes.io/name: longhorn-environment-check
     spec:
       hostPID: true
       containers:
@@ -206,7 +206,7 @@ wait_ds_ready() {
 
 check_mount_propagation() {
   local allSupported=true
-  local pods=$(kubectl -l app=longhorn-environment-check get po -o json)
+  local pods=$(kubectl -l app.kubernetes.io/name=longhorn-environment-check get po -o json)
 
   local ds=$(kubectl get ds/longhorn-environment-check -o json)
   local desiredNumberScheduled=$(echo $ds | jq .status.desiredNumberScheduled)
@@ -260,7 +260,7 @@ check_nodes() {
 
   local all_passed=true
 
-  local pods=$(kubectl get pods -o name -l app=longhorn-environment-check)
+  local pods=$(kubectl get pods -o name -l app.kubernetes.io/name=longhorn-environment-check)
   for pod in ${pods}; do
     eval "${callback} ${pod} $@"
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
According to Kubernetes docs, it's customary to use app.kubernetes.io/name instead of just app
(https://kubernetes.io/docs/reference/labels-annotations-taints/#app-kubernetes-io-name). This helps other tools (like cilium hubble) easier identify the workloads on the cluster.