### PR TITLE
OKD / OCP 4.14

### DIFF
--- a/chart/ocp-readme.md
+++ b/chart/ocp-readme.md
@@ -54,7 +54,7 @@ Main changes and tasks for OCP are:
   - 4.13.0-0.okd-2023-05-03-001308 - 4.13.0-0.okd-2023-08-18-135805:
     - Tested, No Known Issues
 - 4.14 / 1.27:
-  - 4.14.0-0.okd-2023-08-12-022330 - 4.14.0-0.okd-2023-08-12-022330:
+  - 4.14.0-0.okd-2023-08-12-022330 - 4.14.0-0.okd-2023-10-28-073550:
     - Tested, No Known Issues
 
 ## Preparing Nodes (Optional)
@@ -145,7 +145,7 @@ Minimum Adjustments Required
 openshift:
   oauthProxy:
     repository: quay.io/openshift/origin-oauth-proxy
-    tag: 4.13  # Use Your OCP/OKD 4.X Version, Current Stable is 4.13
+    tag: 4.14  # Use Your OCP/OKD 4.X Version, Current Stable is 4.14
 
 # defaultSettings: # Preparing nodes (Optional)
   # createDefaultDiskLabeledNodes: true

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -101,8 +101,8 @@ image:
     oauthProxy:
       # -- For openshift user. Specify oauth proxy image repository
       repository: quay.io/openshift/origin-oauth-proxy
-      # -- For openshift user. Specify oauth proxy image tag. Note: Use your OCP/OKD 4.X Version, Current Stable is 4.13
-      tag: 4.13
+      # -- For openshift user. Specify oauth proxy image tag. Note: Use your OCP/OKD 4.X Version, Current Stable is 4.14
+      tag: 4.14
   # -- Image pull policy which applies to all user deployed Longhorn Components. e.g, Longhorn manager, Longhorn driver, Longhorn UI
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
OpenShift 4.14 was released into Stable 2023/10/28


REF: 
- https://github.com/okd-project/okd/releases/tag/4.14.0-0.okd-2023-10-28-073550



Pics:

<img width="306" alt="Screenshot 2023-10-31 at 9 53 27 AM" src="https://github.com/longhorn/longhorn/assets/21159051/b00ef400-c7a2-49bd-a91c-6a4d224b13d2">
<img width="1894" alt="Screenshot 2023-10-31 at 9 52 49 AM" src="https://github.com/longhorn/longhorn/assets/21159051/3c26b3bc-f037-4804-954c-4f186937f152">
<img width="960" alt="Screenshot 2023-10-31 at 9 52 37 AM" src="https://github.com/longhorn/longhorn/assets/21159051/34482ec2-348e-4aeb-af0d-dc319c9a54c3">
<img width="1903" alt="Screenshot 2023-10-31 at 9 52 22 AM" src="https://github.com/longhorn/longhorn/assets/21159051/bf4d53e6-b9d2-415f-850c-37f7a408f39e">
<img width="1916" alt="Screenshot 2023-10-31 at 9 51 28 AM" src="https://github.com/longhorn/longhorn/assets/21159051/c66e5785-e0de-4311-88d6-e2a4a6c00752">
<img width="1473" alt="Screenshot 2023-10-31 at 9 51 11 AM" src="https://github.com/longhorn/longhorn/assets/21159051/ef4cc917-eda2-44fd-a537-a8fe0d3a501a">
