### PR TITLE
Manually set Service ipFamilies where needed

### DIFF
--- a/chart/templates/deployment-ui.yaml
+++ b/chart/templates/deployment-ui.yaml
@@ -158,6 +158,8 @@ metadata:
   name: longhorn-frontend
   namespace: {{ include "release_namespace" . }}
 spec:
+  ipFamilies:
+  - IPv4
   {{- if eq .Values.service.ui.type "Rancher-Proxy" }}
   type: ClusterIP
   {{- else }}


### PR DESCRIPTION
This is a PR that attempts to fix issues such as https://github.com/longhorn/longhorn/issues/7019 until https://github.com/longhorn/longhorn/issues/2259 is done.

This PR is currently a draft and is waiting for feedback and thorough testing until every service is appropriately configured (unless someone knowledgeable about the current state of IPv6 support can speed things up).