### PR TITLE
[IMPROVEMENT] Allow deployment of Prometheus ServiceMonitor with the Longhorn helm chart

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -252,6 +252,7 @@ Please also refer to this document [ocp-readme](https://github.com/longhorn/long
 |-----|---------|-------------|
 | annotations | `{}` | Annotations to add to the Longhorn Manager DaemonSet Pods. Optional. |
 | enablePSP | `false` | For Kubernetes < v1.25, if your cluster enables Pod Security Policy admission controller, set this to `true` to ship longhorn-psp which allow privileged Longhorn pods to start |
+| enableServiceMonitor | `false` | Deploy a ServiceMonitor custom resource so that the Prometheus server can discover all Longhorn manager pods and their endpoints when using the Prometheus operator
 
 ### System Default Settings
 

--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -801,6 +801,12 @@ questions:
   label: Pod Security Policy
   type: boolean
   group: "Other Settings"
+- variable: enableServiceMonitor
+  default: "false"
+  description: "Deploy a ServiceMonitor custom resource so that the Prometheus server can discover all Longhorn manager pods and their endpoints when using the Prometheus operator."
+  label: Service Monitor
+  type: boolean
+  group: "Other Settings"
 - variable: global.cattle.windowsCluster.enabled
   default: "false"
   description: "Enable this to allow Longhorn to run on the Rancher deployed Windows cluster."

--- a/chart/templates/servicemonitor.yaml
+++ b/chart/templates/servicemonitor.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.enableServiceMonitor }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: longhorn-prometheus-servicemonitor
+  namespace: {{ include "release_namespace" . }}
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: longhorn-manager
+  namespaceSelector:
+    matchNames:
+    - {{ include "release_namespace" . }}
+  endpoints:
+  - port: manager
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -460,6 +460,10 @@ ingress:
 # set this to `true` to ship longhorn-psp which allow privileged Longhorn pods to start
 enablePSP: false
 
+# Deploy a ServiceMonitor custom resource so that the Prometheus server can discover all
+# Longhorn manager pods and their endpoints when using the Prometheus operator
+enableServiceMonitor: false
+
 # -- Annotations to add to the Longhorn Manager DaemonSet Pods. Optional.
 annotations: {}
 


### PR DESCRIPTION
When deploying Longhorn with helm, to enable metric collection we have to manually apply a ServiceMonitor object. This object is fairly simple so we add a value in the Longhorn helm chart to include it. The value is `false` by default.

- Closes https://github.com/longhorn/longhorn/issues/7041