### PR TITLE
Deploy network policies to the configured namespace

### DIFF
--- a/chart/templates/network-policies/backing-image-data-source-network-policy.yaml
+++ b/chart/templates/network-policies/backing-image-data-source-network-policy.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: backing-image-data-source
-  namespace: longhorn-system
+  namespace: {{ include "release_namespace" . }}
 spec:
   podSelector:
     matchLabels:

--- a/chart/templates/network-policies/backing-image-manager-network-policy.yaml
+++ b/chart/templates/network-policies/backing-image-manager-network-policy.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: backing-image-manager
-  namespace: longhorn-system
+  namespace: {{ include "release_namespace" . }}
 spec:
   podSelector:
     matchLabels:

--- a/chart/templates/network-policies/instance-manager-networking.yaml
+++ b/chart/templates/network-policies/instance-manager-networking.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: instance-manager
-  namespace: longhorn-system
+  namespace: {{ include "release_namespace" . }}
 spec:
   podSelector:
     matchLabels:

--- a/chart/templates/network-policies/manager-network-policy.yaml
+++ b/chart/templates/network-policies/manager-network-policy.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: longhorn-manager
-  namespace: longhorn-system
+  namespace: {{ include "release_namespace" . }}
 spec:
   podSelector:
     matchLabels:

--- a/chart/templates/network-policies/recovery-backend-network-policy.yaml
+++ b/chart/templates/network-policies/recovery-backend-network-policy.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: longhorn-recovery-backend
-  namespace: longhorn-system
+  namespace: {{ include "release_namespace" . }}
 spec:
   podSelector:
     matchLabels:

--- a/chart/templates/network-policies/ui-frontend-network-policy.yaml
+++ b/chart/templates/network-policies/ui-frontend-network-policy.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: longhorn-ui-frontend
-  namespace: longhorn-system
+  namespace: {{ include "release_namespace" . }}
 spec:
   podSelector:
     matchLabels:

--- a/chart/templates/network-policies/webhook-network-policy.yaml
+++ b/chart/templates/network-policies/webhook-network-policy.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: longhorn-conversion-webhook
-  namespace: longhorn-system
+  namespace: {{ include "release_namespace" . }}
 spec:
   podSelector:
     matchLabels:
@@ -19,7 +19,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: longhorn-admission-webhook
-  namespace: longhorn-system
+  namespace: {{ include "release_namespace" . }}
 spec:
   podSelector:
     matchLabels:


### PR DESCRIPTION
The Helm chart's network policy objects were all hardcoded to deploy to the `longhorn-system` namespace rather than supporting the user-provided namespace like the rest of the objects.