### PR TITLE
Add checks for kubectl failure to query nodes.

### DIFF
--- a/scripts/environment_check.sh
+++ b/scripts/environment_check.sh
@@ -233,6 +233,16 @@ check_mount_propagation() {
 check_hostname_uniqueness() {
   hostnames=$(kubectl get nodes -o jsonpath='{.items[*].status.addresses[?(@.type=="Hostname")].address}')
 
+  if [ $? -ne 0 ]; then
+    error "kubectl get nodes failed - check KUBECONFIG setup"
+    exit 1
+  fi
+
+  if [[ ! ${hostnames[@]} ]]; then
+    error "kubectl get nodes returned empty list - check KUBECONFIG setup"
+    exit 1
+  fi
+
   deduplicate_hostnames=()
   num_nodes=0
   for hostname in ${hostnames}; do


### PR DESCRIPTION
This addresses the issue #7102 - if we fail to get nodes from kubectl, the environment checking script is satisfied that every node in the empty list meets the criteria, and does not fail.
The change checks the return value from kubectl and also that the array of nodes reported is not empty.