### PR TITLE
using defaultDataPath to set host mount path

### DIFF
--- a/chart/templates/daemonset-sa.yaml
+++ b/chart/templates/daemonset-sa.yaml
@@ -99,7 +99,7 @@ spec:
           path: /proc/
       - name: longhorn
         hostPath:
-          path: /var/lib/longhorn/
+          path: {{ .Values.defaultSettings.defaultDataPath }}
       {{- if .Values.enableGoCoverDir }}
       - name: go-cover-dir
         hostPath:


### PR DESCRIPTION
My understanding of the helm chart value `defaultSettings.defaultDataPath` was to set the data path on the host. However the daemonset manifest has `/var/lib/longhorn` hardcoded, so I'm not sure how this is supposed to work.
This PR uses the value `defaultSettings.defaultDataPath` as the host volume data path. Please let me know if I've misunderstood how this is supposed to function.

For context, I'm running k3s with read only volumes for most of the root filesystem, so the helm install fails.