### PR TITLE
fix: remove the namespaceOverride value

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -58,9 +58,5 @@ app.kubernetes.io/version: {{ .Chart.AppVersion }}
  define the longhorn release namespace
 */ -}}
 {{- define "release_namespace" -}}
-{{- if .Values.namespaceOverride -}}
-{{- .Values.namespaceOverride -}}
-{{- else -}}
 {{- .Release.Namespace -}}
-{{- end -}}
 {{- end -}}


### PR DESCRIPTION
`namespaceOverride` in value.yaml was removed by https://github.com/longhorn/longhorn/pull/6639

Remove all `namespaceOverride` fields in the chart.

Ref: longhorn/longhorn#6527, https://github.com/longhorn/longhorn/pull/6639