### PR TITLE
fix(upgrade): skip upgrade path check

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -245,8 +245,9 @@ Please also refer to this document [ocp-readme](https://github.com/longhorn/long
 | annotations | `{}` | Annotations to add to the Longhorn Manager DaemonSet Pods. Optional. |
 | enableGoCoverDir | `false` | Enable this to allow Longhorn to generate code coverage profiles |
 | enablePSP | `false` | For Kubernetes < v1.25, if your cluster enables Pod Security Policy admission controller, set this to `true` to ship a built-in longhorn-psp PodSecurityPolicy which allow privileged Longhorn pods to start |
-| helmPreUpgradeCheckerJob.enabled | `true` | Setting that allows Longhorn to perform pre-upgrade checks. Disable this setting when installing Longhorn using Argo CD or other GitOps solutions. |
 | metrics.serviceMonitor.enabled | `false` | Setting that allows the creation of a Prometheus ServiceMonitor resource for Longhorn Manager components. |
+| preUpgradeChecker.jobEnabled | `true` | Setting that allows Longhorn to perform pre-upgrade checks before starting the Longhorn Manager DaemonSet Pods. Disable this setting when installing Longhorn using Argo CD or other GitOps solutions. |
+| preUpgradeChecker.upgradeVersionCheck | `true` | Setting that allows Longhorn to perform upgrade version checks after starting the Longhorn Manager DaemonSet Pods. Disabling this setting also disables `preUpgradeChecker.jobEnabled`, but it's not recommended to disable it. |
 
 ### System Default Settings
 

--- a/chart/templates/daemonset-sa.yaml
+++ b/chart/templates/daemonset-sa.yaml
@@ -45,6 +45,9 @@ spec:
         - "{{ template "registry_url" . }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}"
         - --service-account
         - longhorn-service-account
+        {{- if .Values.preUpgradeChecker.upgradeVersionCheck}}
+        - --upgrade-version-check
+        {{- end }}
         ports:
         - containerPort: 9500
           name: manager

--- a/chart/templates/preupgrade-job.yaml
+++ b/chart/templates/preupgrade-job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.helmPreUpgradeCheckerJob.enabled }}
+{{- if and .Values.preUpgradeChecker.jobEnabled .Values.preUpgradeChecker.upgradeVersionCheck}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -162,9 +162,11 @@ persistence:
   # -- Allow automatically removing snapshots during filesystem trim for Longhorn StorageClass. Options: `ignored`, `enabled`, `disabled`
   removeSnapshotsDuringFilesystemTrim: ignored
 
-helmPreUpgradeCheckerJob:
-  # -- Setting that allows Longhorn to perform pre-upgrade checks. Disable this setting when installing Longhorn using Argo CD or other GitOps solutions.
-  enabled: true
+preUpgradeChecker:
+  # -- Setting that allows Longhorn to perform pre-upgrade checks before starting the Longhorn Manager DaemonSet Pods. Disable this setting when installing Longhorn using Argo CD or other GitOps solutions.
+  jobEnabled: true
+  # -- Setting that allows Longhorn to perform upgrade version checks after starting the Longhorn Manager DaemonSet Pods. Disabling this setting also disables `preUpgradeChecker.jobEnabled`, but it's not recommended to disable it.
+  upgradeVersionCheck: true
 
 csi:
   # -- Specify kubelet root-dir. Leave blank to autodetect

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -4372,6 +4372,7 @@ spec:
         - "longhornio/longhorn-manager:master-head"
         - --service-account
         - longhorn-service-account
+        - --upgrade-version-check
         ports:
         - containerPort: 9500
           name: manager


### PR DESCRIPTION
Remove `helmPreUpgradeCheckerJob` and Add `preUpgradeChecker.jobEnabled` and `preUpgradeChecker.upgradeVersionCheck` to allow users to disable pre-upgrade checks or upgrade path enforcement checks.

Update chart/README.md and deploy/longhorn.yaml

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#7539

#### What this PR does / why we need it:

Bypass upgrade path enforcement checks.

#### Special notes for your reviewer:
