### PR TITLE
Allow to set NFS mount options for storageclass via values.yaml in helm chart

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -147,6 +147,7 @@ The `values.yaml` contains items used to tweak a deployment of this chart.
 | persistence.defaultNodeSelector.enable | bool | `false` | Enable Node selector for Longhorn StorageClass |
 | persistence.defaultNodeSelector.selector | string | `""` | This selector enables only certain nodes having these tags to be used for the volume. E.g. `"storage,fast"` |
 | persistence.migratable | bool | `false` | Set volume migratable for Longhorn StorageClass |
+| persistence.nfsOptions | string | `""` | Set NFS mount options for Longhorn StorageClass for RWX volumes |
 | persistence.reclaimPolicy | string | `"Delete"` | Define reclaim policy. Options: `Retain`, `Delete` |
 | persistence.recurringJobSelector.enable | bool | `false` | Enable recurring job selector for Longhorn StorageClass |
 | persistence.recurringJobSelector.jobList | list | `[]` | Recurring job selector list for Longhorn StorageClass. Please be careful of quotes of input. E.g., `[{"name":"backup", "isGroup":true}]` |

--- a/chart/templates/storageclass.yaml
+++ b/chart/templates/storageclass.yaml
@@ -29,6 +29,9 @@ data:
       {{- if .Values.persistence.migratable }}
       migratable: "{{ .Values.persistence.migratable }}"
       {{- end }}    
+      {{- if .Values.persistence.nfsOptions }}
+      nfsOptions: "{{ .Values.persistence.nfsOptions }}"
+      {{- end }}    
       {{- if .Values.persistence.backingImage.enable }}
       backingImage: {{ .Values.persistence.backingImage.name }}
       backingImageDataSourceType: {{ .Values.persistence.backingImage.dataSourceType }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -133,6 +133,8 @@ persistence:
   reclaimPolicy: Delete
   # -- Set volume migratable for Longhorn StorageClass
   migratable: false
+  # -- Set NFS mount options for Longhorn StorageClass for RWX volumes
+  nfsOptions: ""
   recurringJobSelector:
     # -- Enable recurring job selector for Longhorn StorageClass
     enable: false


### PR DESCRIPTION
Added the `persistence.nfsOptions` value

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
- Issue #7351