### PR TITLE
chore(engineimage): add a new k8s column.

### DIFF
--- a/chart/templates/crds.yaml
+++ b/chart/templates/crds.yaml
@@ -1244,6 +1244,10 @@ spec:
     subresources:
       status: {}
   - additionalPrinterColumns:
+    - description: Compatibility of the engine image
+      jsonPath: .status.incompatible
+      name: Incompatible
+      type: boolean
     - description: State of the engine image
       jsonPath: .status.state
       name: State

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -1370,6 +1370,10 @@ spec:
     subresources:
       status: {}
   - additionalPrinterColumns:
+    - description: Compatibility of the engine image
+      jsonPath: .status.incompatible
+      name: Incompatible
+      type: boolean
     - description: State of the engine image
       jsonPath: .status.state
       name: State


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#7683, longhorn/longhorn#7539

#### What this PR does / why we need it:

Add a new k8s column `INCOMPATIBLE` for resource `EngineImage`.

#### Special notes for your reviewer:

#### Additional documentation or context
