### PR TITLE
Remove sessionAffinity ClientIP from services

### DIFF
--- a/chart/templates/daemonset-sa.yaml
+++ b/chart/templates/daemonset-sa.yaml
@@ -156,7 +156,6 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.manager.type }}
-  sessionAffinity: ClientIP
   selector:
     app: longhorn-manager
   ports:

--- a/chart/templates/services.yaml
+++ b/chart/templates/services.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: {{ include "release_namespace" . }}
 spec:
   type: ClusterIP
-  sessionAffinity: ClientIP
   selector:
     app: longhorn-manager
   ports:
@@ -24,7 +23,6 @@ metadata:
   namespace: {{ include "release_namespace" . }}
 spec:
   type: ClusterIP
-  sessionAffinity: ClientIP
   selector:
     app: longhorn-manager
   ports:
@@ -41,7 +39,6 @@ metadata:
   namespace: {{ include "release_namespace" . }}
 spec:
   type: ClusterIP
-  sessionAffinity: ClientIP
   selector:
     app: longhorn-manager
   ports:

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -4208,7 +4208,6 @@ metadata:
   namespace: longhorn-system
 spec:
   type: ClusterIP
-  sessionAffinity: ClientIP
   selector:
     app: longhorn-manager
   ports:
@@ -4250,7 +4249,6 @@ metadata:
   namespace: longhorn-system
 spec:
   type: ClusterIP
-  sessionAffinity: ClientIP
   selector:
     app: longhorn-manager
   ports:
@@ -4271,7 +4269,6 @@ metadata:
   namespace: longhorn-system
 spec:
   type: ClusterIP
-  sessionAffinity: ClientIP
   selector:
     app: longhorn-manager
   ports:
@@ -4292,7 +4289,6 @@ metadata:
   namespace: longhorn-system
 spec:
   type: ClusterIP
-  sessionAffinity: ClientIP
   selector:
     app: longhorn-manager
   ports:


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue #7399

#### What this PR does / why we need it:

Remove `sessionAffinity: ClientIP` from Longhorn services. See #7399 for justification.

#### Special notes for your reviewer:

We could optionally introduce a Helm variable that controls the value of `sessionAffinity` for the Longhorn services that previously used `sessionAffinity: ClientIP`. If we did this, I would argue for making `None` the default, with the option to change back to `ClientIP` if desired. However:

1. I cannot identify any situation in which we should be using `sessionAffinity: ClientIP`,
2. More Helm variables makes Longhorn deployment more difficult to understand.

I'm curious whether reviewers agree.