### PR TITLE
fix(environment_check): add check for globalDefault priority class.

### DIFF
--- a/scripts/environment_check.sh
+++ b/scripts/environment_check.sh
@@ -260,6 +260,18 @@ check_hostname_uniqueness() {
   info "All nodes have unique hostnames."
 }
 
+check_default_priority_class() {
+  hasDefault=$(kubectl get priorityclass -o jsonpath='{.items[*].globalDefault}' | grep true)
+
+  if [ ! -z $hasDefault ]; then
+      # See https://longhorn.io/kb/troubleshooting-instance-manager-pods-are-restarted-every-hour/#reason
+      warn "Cluster has a global default priority class."
+      return 1
+  fi
+
+  info "Cluster has no global default priority class."
+}
+
 check_nodes() {
   local name=$1
   local callback=$2
@@ -511,7 +523,10 @@ DEPENDENCIES=("kubectl" "jq" "mktemp" "sort" "printf")
 check_local_dependencies "${DEPENDENCIES[@]}"
 
 # Check the each host has a unique hostname (for RWX volume)
+# Do this first, so we also verify we have a workable KUBECONFIG.
 check_hostname_uniqueness
+
+check_default_priority_class
 
 # Create a daemonset for checking the requirements in each node
 TEMP_DIR=$(mktemp -d)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://jira.suse.com/browse/SURE-7492

#### What this PR does / why we need it:

Make the environment_check script look for an existing priority class with globalDefault=true to head off this issue and https://github.com/longhorn/longhorn/issues/2820.

#### Special notes for your reviewer:

This is really only for backport to v1.4.x and v1.5.x.  In 1.6.0 and later, Longhorn defines its own `longhorn-critical` priority class and ensures that system pods are set to that.

#### Additional documentation or context
