### PR TITLE
fix(environment_check): add check for globalDefault priority class.

### DIFF
--- a/scripts/environment_check.sh
+++ b/scripts/environment_check.sh
@@ -260,6 +260,14 @@ check_hostname_uniqueness() {
   info "All nodes have unique hostnames."
 }
 
+check_default_priority_class() {
+  hasDefault=$(kubectl get priorityclass -o jsonpath='{.items[*].globalDefault}' | grep true)
+
+  if [ ! -z $hasDefault ]; then
+      warn "Cluster has a global default priority class. See potential issue and solution at https://longhorn.io/kb/troubleshooting-instance-manager-pods-are-restarted-every-hour/#reason"
+  fi
+}
+
 check_nodes() {
   local name=$1
   local callback=$2
@@ -511,7 +519,10 @@ DEPENDENCIES=("kubectl" "jq" "mktemp" "sort" "printf")
 check_local_dependencies "${DEPENDENCIES[@]}"
 
 # Check the each host has a unique hostname (for RWX volume)
+# Do this first, so we also verify we have a workable KUBECONFIG.
 check_hostname_uniqueness
+
+check_default_priority_class
 
 # Create a daemonset for checking the requirements in each node
 TEMP_DIR=$(mktemp -d)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
https://github.com/longhorn/longhorn/issues/7831

#### What this PR does / why we need it:

Make the environment_check script look for an existing priority class with globalDefault=true to head off potential issues with Longhorn.

#### Special notes for your reviewer:

This is really only for backport to v1.4.x and v1.5.x. 
In 1.6.0 and later, Longhorn defines its own `longhorn-critical` priority class and ensures that system pods are set to that.

This PR is directly into `v1.5.x` to take the place of [PR 7796](https://github.com/longhorn/longhorn/pull/7796), because it really doesn't need to go into master.

#### Additional documentation or context
