### PR TITLE
Fix grammatical errors making error messages confusing

### DIFF
--- a/scripts/environment_check.sh
+++ b/scripts/environment_check.sh
@@ -313,7 +313,7 @@ check_iscsid() {
     kubectl exec ${pod} -- nsenter --mount=/proc/1/ns/mnt -- bash -c "systemctl status --no-pager iscsid.socket" > /dev/null 2>&1
       if [ $? -ne 0 ]; then
       node=$(kubectl get ${pod} --no-headers -o=custom-columns=:.spec.nodeName)
-      error "Neither iscsid.service nor iscsid.socket is not running on ${node}"
+      error "Neither iscsid.service nor iscsid.socket is running on ${node}"
       return 1
     fi
   fi
@@ -385,7 +385,7 @@ check_nfs_client() {
     fi
   done
 
-  error "NFS clients ${options[*]} should be enabled at least one."
+  error "NFS clients ${options[*]} not found. At least one should be enabled"
   return 1
 }
 


### PR DESCRIPTION
Fixed a double negative ("neither...nor...not...") 
Fixed confusing wording on NFS clients not found error

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
No issue filed

#### What this PR does / why we need it:
To have clearer error messages for iscsid and nfs clients
#### Special notes for your reviewer:
Further rephrasing of error messages in this file may be warranted to improve consistency (e.g. the mix of statements and full sentences and the inconsistency of whether messages end with a period or not) and clarity. Quick blurbs could also be added to point users in the right direction on how to fix a given error or why a certain warning may lead to issues.
These are obviously nit picky but I think well written output can go a long way to improve the usability of a project
#### Additional documentation or context
N/A