### PR TITLE
Make InstanceProcessStatus.Conditions nullable

### DIFF
--- a/chart/templates/crds.yaml
+++ b/chart/templates/crds.yaml
@@ -1871,6 +1871,7 @@ spec:
                         conditions:
                           additionalProperties:
                             type: boolean
+                          nullable: true
                           type: object
                         endpoint:
                           type: string
@@ -1913,6 +1914,7 @@ spec:
                         conditions:
                           additionalProperties:
                             type: boolean
+                          nullable: true
                           type: object
                         endpoint:
                           type: string
@@ -1955,6 +1957,7 @@ spec:
                         conditions:
                           additionalProperties:
                             type: boolean
+                          nullable: true
                           type: object
                         endpoint:
                           type: string

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -1991,6 +1991,7 @@ spec:
                         conditions:
                           additionalProperties:
                             type: boolean
+                          nullable: true
                           type: object
                         endpoint:
                           type: string
@@ -2033,6 +2034,7 @@ spec:
                         conditions:
                           additionalProperties:
                             type: boolean
+                          nullable: true
                           type: object
                         endpoint:
                           type: string
@@ -2075,6 +2077,7 @@ spec:
                         conditions:
                           additionalProperties:
                             type: boolean
+                          nullable: true
                           type: object
                         endpoint:
                           type: string


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

longhorn/longhorn#7887

#### What this PR does / why we need it:

Make the InstanceProcessStatus.Conditions CRD field nullable (like the other status CRD fields that are maps). See the linked issue for context.
