### PR TITLE
Use livenessprobe version with upstream fix

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -94,7 +94,7 @@ The `values.yaml` contains items used to tweak a deployment of this chart.
 | image.csi.attacher.repository | string | `"longhornio/csi-attacher"` | Repository for the CSI attacher image. When unspecified, Longhorn uses the default value. |
 | image.csi.attacher.tag | string | `"v4.4.2"` | Tag for the CSI attacher image. When unspecified, Longhorn uses the default value. |
 | image.csi.livenessProbe.repository | string | `"longhornio/livenessprobe"` | Repository for the CSI liveness probe image. When unspecified, Longhorn uses the default value. |
-| image.csi.livenessProbe.tag | string | `"v2.11.0"` | Tag for the CSI liveness probe image. When unspecified, Longhorn uses the default value. |
+| image.csi.livenessProbe.tag | string | `"v2.12.0"` | Tag for the CSI liveness probe image. When unspecified, Longhorn uses the default value. |
 | image.csi.nodeDriverRegistrar.repository | string | `"longhornio/csi-node-driver-registrar"` | Repository for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value. |
 | image.csi.nodeDriverRegistrar.tag | string | `"v2.9.2"` | Tag for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value. |
 | image.csi.provisioner.repository | string | `"longhornio/csi-provisioner"` | Repository for the CSI Provisioner image. When unspecified, Longhorn uses the default value. |

--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -161,7 +161,7 @@ questions:
     label: Longhorn CSI Liveness Probe Image Repository
     group: "Longhorn CSI Driver Images"
   - variable: image.csi.livenessProbe.tag
-    default: v2.11.0
+    default: v2.12.0
     description: "Tag for the CSI liveness probe image. When unspecified, Longhorn uses the default value."
     type: string
     label: Longhorn CSI Liveness Probe Image Tag

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -96,7 +96,7 @@ image:
       # -- Repository for the CSI liveness probe image. When unspecified, Longhorn uses the default value.
       repository: longhornio/livenessprobe
       # -- Tag for the CSI liveness probe image. When unspecified, Longhorn uses the default value.
-      tag: v2.11.0
+      tag: v2.12.0
   openshift:
     oauthProxy:
       # -- Repository for the OAuth Proxy image. This setting applies only to OpenShift users.

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -3,7 +3,7 @@ longhornio/csi-provisioner:v3.6.2
 longhornio/csi-resizer:v1.9.2
 longhornio/csi-snapshotter:v6.3.2
 longhornio/csi-node-driver-registrar:v2.9.2
-longhornio/livenessprobe:v2.11.0
+longhornio/livenessprobe:v2.12.0
 longhornio/backing-image-manager:master-head
 longhornio/longhorn-engine:master-head
 longhornio/longhorn-instance-manager:master-head

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -4493,7 +4493,7 @@ spec:
           - name: CSI_SNAPSHOTTER_IMAGE
             value: "longhornio/csi-snapshotter:v6.3.2"
           - name: CSI_LIVENESS_PROBE_IMAGE
-            value: "longhornio/livenessprobe:v2.11.0"
+            value: "longhornio/livenessprobe:v2.12.0"
       priorityClassName: "longhorn-critical"
       serviceAccountName: longhorn-service-account
       securityContext:


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

longhorn/longhorn#7428

#### What this PR does / why we need it:

This version of livenessprobe will not allow us to get stuck like in https://github.com/longhorn/longhorn/issues/7116. By upgrading to it, we can revert the changes associated with that ticket.

https://github.com/kubernetes-csi/livenessprobe/issues/236