### PR TITLE
Fix `removeSnapshotsDuringFilesystemTrim` not being used in helm chart

### DIFF
--- a/chart/templates/storageclass.yaml
+++ b/chart/templates/storageclass.yaml
@@ -45,3 +45,6 @@ data:
       {{- if .Values.persistence.defaultNodeSelector.enable }}
       nodeSelector: "{{ .Values.persistence.defaultNodeSelector.selector }}"
       {{- end }}
+      {{- if .Values.persistence.removeSnapshotsDuringFilesystemTrim }}
+      unmapMarkSnapChainRemoved: "{{ .Values.persistence.removeSnapshotsDuringFilesystemTrim }}"
+      {{- end }}

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -5,6 +5,20 @@ kind: Namespace
 metadata:
   name: longhorn-system
 ---
+# Source: longhorn/templates/priorityclass.yaml
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: "longhorn-critical"
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.6.0-dev
+description: "Ensure Longhorn pods have the highest priority to prevent any unexpected eviction by the Kubernetes scheduler under node pressure"
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+value: 1000000000
+---
 # Source: longhorn/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -80,6 +94,7 @@ data:
       fromBackup: ""
       fsType: "ext4"
       dataLocality: "disabled"
+      unmapMarkSnapChainRemoved: "ignored"
 ---
 # Source: longhorn/templates/crds.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -4566,17 +4581,3 @@ spec:
 ---
 # Source: longhorn/templates/validate-psp-install.yaml
 #
----
-# Source: longhorn/templates/priorityclass.yaml
-apiVersion: scheduling.k8s.io/v1
-kind: PriorityClass
-metadata:
-  name: "longhorn-critical"
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.6.0-dev
-description: "Ensure Longhorn pods have the highest priority to prevent any unexpected eviction by the Kubernetes scheduler under node pressure"
-globalDefault: false
-preemptionPolicy: PreemptLowerPriority
-value: 1000000000


### PR DESCRIPTION
Also ran `./scripts/generate-longhorn-yaml.sh`

#### Which issue(s) this PR fixes:
Issue https://github.com/longhorn/longhorn/issues/7909
