### PR TITLE
fix(scripts): Add CIFS credentials options to restore-backup-to-file

### DIFF
--- a/scripts/restore-backup-to-file.sh
+++ b/scripts/restore-backup-to-file.sh
@@ -19,6 +19,8 @@ usage () {
    echo "  -v, --version                (Required) Longhorn version, e.g., v1.3.2"
    echo "      --aws-access-key         (Optional) AWS credentials access key"
    echo "      --aws-secret-access-key  (Optional) AWS credentials access secret key"
+   echo "      --cifs-username          (Optional) CIFS credentials username"
+   echo "      --cifs-password          (Optional) CIFS credentials password"
    echo "  -b, --backing-file           (Optional) backing image. e.g., /tmp/backingfile.qcow2"
    echo "  -h, --help                   Usage message"
 }
@@ -39,6 +41,16 @@ while [[ "$#" -gt 0 ]]; do
     ;;
     --aws-secret-access-key)
     aws_secret_access_key="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    --cifs-username)
+    cifs_username="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    --cifs-password)
+    cifs_password="$2"
     shift # past argument
     shift # past value
     ;;
@@ -92,7 +104,10 @@ fi
 if [[ "${backup_url}" =~ ^[Ss]3 ]]; then
   CUSTOMIZED_ARGS="-e AWS_ACCESS_KEY_ID="${aws_access_key}" -e AWS_SECRET_ACCESS_KEY="${aws_secret_access_key}" "
 else
-  CUSTOMIZED_ARGS="--cap-add SYS_ADMIN --security-opt apparmor:unconfined"
+  CUSTOMIZED_ARGS="--cap-add SYS_ADMIN --security-opt apparmor:unconfined --cap-add DAC_READ_SEARCH"
+fi
+if [[ "${backup_url}" =~ ^cifs ]]; then
+  CUSTOMIZED_ARGS+=" -e CIFS_USERNAME=${cifs_username} -e CIFS_PASSWORD=${cifs_password} "
 fi
 
 # Start restoring a backup to an image file. 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
No opened issue

#### What this PR does / why we need it:
When using `scripts/restore-backup-to-file.sh` script with **cifs** backend, no credentials can be passed to engine container.

This results in error when trying to mount cifs share:

```
time="2024-03-05T14:35:16Z" level=fatal msg="Error running restore to file command" func=cmd.RestoreToFileCmd.func1 file="restore_to_file.go:66" error="cannot mount CIFS share backup/backup, options [soft]: mount failed: exit status 1\nMounting command: mount\nMounting arguments: -t cifs -o soft,<masked>,<masked> //backup/backup /var/lib/longhorn-backupstore-mounts/backup/backup\nOutput: username specified with no parameter\n"
```

As CIFS mounting implemented in `longhorn/backupstore`:
https://github.com/longhorn/backupstore/blob/3a87ee02df77adcf3dda56a64bda196803b1e96b/util/util.go#L353C1-L366C2

CIFS credentials are passed to mount driver by specifying `CIFS_USERNAME` and `CIFS_PASSWORD` environment variables.

#### Change
`--cifs-username` and `--cifs-password` options added to `scripts/restore-backup-to-file.sh` script and passed as environment variables to container.

**Exemple**: 
```
bash restore-backup-to-file.sh --backup-url "cifs://backup/backup?backup=backup-0ce20285b2b34c90&volume=pvc-285d0eb0-317e-48be-980d-203b62a6d8c3" --output-file my-volume.raw --output-format raw --version v1.5.3 --cifs-username myUsername --cifs-password myPassword
```

#### Special notes for your reviewer:

#### Additional documentation or context

Longhorn/website repository being modified to match changes
