### PR TITLE
feat(serviceMonitor): Add multiple settings for ServiceMonitor resource.

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -254,8 +254,6 @@ For more details, see the [ocp-readme](https://github.com/longhorn/longhorn/blob
 | metrics.serviceMonitor.scrapeTimeout | `""` | Settings to change Prometheus scrape timeout. |
 | metrics.serviceMonitor.relabelings | `[]` | Settings to change Prometheus RelabelConfigs to apply to samples before scraping. |
 | metrics.serviceMonitor.metricRelabelings | `[]` | Settings to change Prometheus MetricRelabelConfigs to apply to samples before ingestion. |
-| metrics.serviceMonitor.tlsConfig | `{}` | Settings to change Prometheus ServiceMonitor tlsConfig. |
-| metrics.serviceMonitor.scheme | `""` | Settings to change Prometheus ServiceMonitor scheme. |
 | namespaceOverride | `""` | Specify override namespace, specifically this is useful for using longhorn as sub-chart and its release namespace is not the `longhorn-system`. |
 | preUpgradeChecker.jobEnabled | `true` | Setting that allows Longhorn to perform pre-upgrade checks. Disable this setting when installing Longhorn using Argo CD or other GitOps solutions. |
 | preUpgradeChecker.upgradeVersionCheck | `true` | Setting that allows Longhorn to perform upgrade version checks after starting the Longhorn Manager DaemonSet Pods. Disabling this setting also disables `preUpgradeChecker.jobEnabled`. Longhorn recommends keeping this setting enabled. |

--- a/chart/README.md
+++ b/chart/README.md
@@ -144,10 +144,10 @@ The `values.yaml` contains items used to tweak a deployment of this chart.
 | persistence.defaultClass | bool | `true` | Setting that allows you to specify the default Longhorn StorageClass. |
 | persistence.defaultClassReplicaCount | int | `3` | Replica count of the default Longhorn StorageClass. |
 | persistence.defaultDataLocality | string | `"disabled"` | Data locality of the default Longhorn StorageClass. (Options: "disabled", "best-effort") |
-| persistence.defaultFsType | string | `"ext4"` | Filesystem type of the default Longhorn StorageClass. |
-| persistence.defaultMkfsParams | string | `""` | mkfs parameters of the default Longhorn StorageClass. |
 | persistence.defaultDiskSelector.enable | bool | `false` | Setting that allows you to enable the disk selector for the default Longhorn StorageClass. |
 | persistence.defaultDiskSelector.selector | string | `""` | Disk selector for the default Longhorn StorageClass. Longhorn uses only disks with the specified tags for storing volume data. (Examples: "nvme,sata") |
+| persistence.defaultFsType | string | `"ext4"` | Filesystem type of the default Longhorn StorageClass. |
+| persistence.defaultMkfsParams | string | `""` | mkfs parameters of the default Longhorn StorageClass. |
 | persistence.defaultNodeSelector.enable | bool | `false` | Setting that allows you to enable the node selector for the default Longhorn StorageClass. |
 | persistence.defaultNodeSelector.selector | string | `""` | Node selector for the default Longhorn StorageClass. Longhorn uses only nodes with the specified tags for storing volume data. (Examples: "storage,fast") |
 | persistence.disableRevisionCounter | string | `"true"` | Setting that disables the revision counter and thereby prevents Longhorn from tracking all write operations to a volume. When salvaging a volume, Longhorn uses properties of the volume-head-xxx.img file (the last file size and the last time the file was modified) to select the replica to be used for volume recovery. |
@@ -248,12 +248,13 @@ For more details, see the [ocp-readme](https://github.com/longhorn/longhorn/blob
 | annotations | `{}` | Annotation for the Longhorn Manager DaemonSet pods. This setting is optional. |
 | enableGoCoverDir | `false` | Setting that allows Longhorn to generate code coverage profiles. |
 | enablePSP | `false` | Setting that allows you to enable pod security policies (PSPs) that allow privileged Longhorn pods to start. This setting applies only to clusters running Kubernetes 1.25 and earlier, and with the built-in Pod Security admission controller enabled. |
+| metrics.serviceMonitor.additionalLabels | `{}` | Setting that adds additional labels to the Prometheus ServiceMonitor. |
+| metrics.serviceMonitor.annotations | `{}` | Setting that adds annotations to the Prometheus ServiceMonitor. |
 | metrics.serviceMonitor.enabled | `false` | Setting that allows the creation of a Prometheus ServiceMonitor resource for Longhorn Manager components. |
-| metrics.serviceMonitor.additionalLabels | `{}` | Setting that add additional labels. |
-| metrics.serviceMonitor.interval | `30s` | Settings to change Prometheus scrape interval. |
-| metrics.serviceMonitor.scrapeTimeout | `""` | Settings to change Prometheus scrape timeout. |
-| metrics.serviceMonitor.relabelings | `[]` | Settings to change Prometheus RelabelConfigs to apply to samples before scraping. |
-| metrics.serviceMonitor.metricRelabelings | `[]` | Settings to change Prometheus MetricRelabelConfigs to apply to samples before ingestion. |
+| metrics.serviceMonitor.interval | `""` | Interval at which Prometheus scrapes the metrics from the target. |
+| metrics.serviceMonitor.metricRelabelings | `[]` | Configures the relabeling rules to apply to the samples before ingestion. See Prometheus operator documentation for format. |
+| metrics.serviceMonitor.relabelings | `[]` | Configures the relabeling rules to apply the target’s metadata labels. See Prometheus operator documentation for format. |
+| metrics.serviceMonitor.scrapeTimeout | `""` | Timeout after which Prometheus considers the scrape to be failed. |
 | namespaceOverride | `""` | Specify override namespace, specifically this is useful for using longhorn as sub-chart and its release namespace is not the `longhorn-system`. |
 | preUpgradeChecker.jobEnabled | `true` | Setting that allows Longhorn to perform pre-upgrade checks. Disable this setting when installing Longhorn using Argo CD or other GitOps solutions. |
 | preUpgradeChecker.upgradeVersionCheck | `true` | Setting that allows Longhorn to perform upgrade version checks after starting the Longhorn Manager DaemonSet Pods. Disabling this setting also disables `preUpgradeChecker.jobEnabled`. Longhorn recommends keeping this setting enabled. |

--- a/chart/README.md
+++ b/chart/README.md
@@ -249,6 +249,13 @@ For more details, see the [ocp-readme](https://github.com/longhorn/longhorn/blob
 | enableGoCoverDir | `false` | Setting that allows Longhorn to generate code coverage profiles. |
 | enablePSP | `false` | Setting that allows you to enable pod security policies (PSPs) that allow privileged Longhorn pods to start. This setting applies only to clusters running Kubernetes 1.25 and earlier, and with the built-in Pod Security admission controller enabled. |
 | metrics.serviceMonitor.enabled | `false` | Setting that allows the creation of a Prometheus ServiceMonitor resource for Longhorn Manager components. |
+| metrics.serviceMonitor.additionalLabels | `{}` | Setting that add additional labels. |
+| metrics.serviceMonitor.interval | `30s` | Settings to change Prometheus scrape interval. |
+| metrics.serviceMonitor.scrapeTimeout | `""` | Settings to change Prometheus scrape timeout. |
+| metrics.serviceMonitor.relabelings | `[]` | Settings to change Prometheus RelabelConfigs to apply to samples before scraping. |
+| metrics.serviceMonitor.metricRelabelings | `[]` | Settings to change Prometheus MetricRelabelConfigs to apply to samples before ingestion. |
+| metrics.serviceMonitor.tlsConfig | `{}` | Settings to change Prometheus ServiceMonitor tlsConfig. |
+| metrics.serviceMonitor.scheme | `""` | Settings to change Prometheus ServiceMonitor scheme. |
 | namespaceOverride | `""` | Specify override namespace, specifically this is useful for using longhorn as sub-chart and its release namespace is not the `longhorn-system`. |
 | preUpgradeChecker.jobEnabled | `true` | Setting that allows Longhorn to perform pre-upgrade checks. Disable this setting when installing Longhorn using Argo CD or other GitOps solutions. |
 | preUpgradeChecker.upgradeVersionCheck | `true` | Setting that allows Longhorn to perform upgrade version checks after starting the Longhorn Manager DaemonSet Pods. Disabling this setting also disables `preUpgradeChecker.jobEnabled`. Longhorn recommends keeping this setting enabled. |

--- a/chart/templates/servicemonitor.yaml
+++ b/chart/templates/servicemonitor.yaml
@@ -37,11 +37,4 @@ spec:
     metricRelabelings:
       {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.metrics.serviceMonitor.scheme }}
-    scheme: {{ . }}
-    {{- end }}
-    {{- with .Values.metrics.serviceMonitor.tlsConfig }}
-    tlsConfig:
-      {{- toYaml . | nindent 8 }}
-    {{- end }}
 {{- end }}

--- a/chart/templates/servicemonitor.yaml
+++ b/chart/templates/servicemonitor.yaml
@@ -7,6 +7,13 @@ metadata:
   labels:
     {{- include "longhorn.labels" . | nindent 4 }}
     name: longhorn-prometheus-servicemonitor
+    {{- with .Values.metrics.serviceMonitor.additionalLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.metrics.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -16,4 +23,25 @@ spec:
     - {{ include "release_namespace" . }}
   endpoints:
   - port: manager
+    {{- with .Values.metrics.serviceMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with .Values.metrics.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
+    {{- with .Values.metrics.serviceMonitor.relabelings }}
+    relabelings:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.metrics.serviceMonitor.scheme }}
+    scheme: {{ . }}
+    {{- end }}
+    {{- with .Values.metrics.serviceMonitor.tlsConfig }}
+    tlsConfig:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -503,10 +503,6 @@ metrics:
     relabelings: []
     # -- Settings to change Prometheus MetricRelabelConfigs to apply to samples before ingestion.
     metricRelabelings: []
-    # -- Settings to change Prometheus ServiceMonitor tlsConfig.
-    tlsConfig: {}
-    # -- Settings to change Prometheus ServiceMonitor scheme.
-    scheme: ""
 
 ## openshift settings
 openshift:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -490,7 +490,23 @@ serviceAccount:
 metrics:
   serviceMonitor:
     # -- Setting that allows the creation of a Prometheus ServiceMonitor resource for Longhorn Manager components.
-    enabled: false
+    enabled: true
+    # -- Setting that add additional labels.
+    additionalLabels: {}
+    # -- Settings that allows to add annotations.
+    annotations: {}
+    # -- Settings to change Prometheus scrape interval.
+    interval: 30s
+    # -- Settings to change Prometheus scrape timeout.
+    scrapeTimeout: ""
+    # -- Settings to change Prometheus RelabelConfigs to apply to samples before scraping.
+    relabelings: []
+    # -- Settings to change Prometheus MetricRelabelConfigs to apply to samples before ingestion.
+    metricRelabelings: []
+    # -- Settings to change Prometheus ServiceMonitor tlsConfig.
+    tlsConfig: {}
+    # -- Settings to change Prometheus ServiceMonitor scheme.
+    scheme: ""
 
 ## openshift settings
 openshift:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -490,7 +490,7 @@ serviceAccount:
 metrics:
   serviceMonitor:
     # -- Setting that allows the creation of a Prometheus ServiceMonitor resource for Longhorn Manager components.
-    enabled: true
+    enabled: false
     # -- Setting that add additional labels.
     additionalLabels: {}
     # -- Settings that allows to add annotations.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -491,17 +491,19 @@ metrics:
   serviceMonitor:
     # -- Setting that allows the creation of a Prometheus ServiceMonitor resource for Longhorn Manager components.
     enabled: false
-    # -- Setting that add additional labels.
+    # -- Setting that adds additional labels to the Prometheus ServiceMonitor.
     additionalLabels: {}
-    # -- Settings that allows to add annotations.
+    # -- Setting that adds annotations to the Prometheus ServiceMonitor.
     annotations: {}
-    # -- Settings to change Prometheus scrape interval.
+    # -- Interval at which Prometheus scrapes the metrics from the target.
     interval: 30s
-    # -- Settings to change Prometheus scrape timeout.
+    # -- Timeout after which Prometheus considers the scrape to be failed.
     scrapeTimeout: ""
-    # -- Settings to change Prometheus RelabelConfigs to apply to samples before scraping.
+    # -- Configures the relabeling rules to apply the target’s metadata labels. See Prometheus operator documentation
+    # for format.
     relabelings: []
-    # -- Settings to change Prometheus MetricRelabelConfigs to apply to samples before ingestion.
+    # -- Configures the relabeling rules to apply to the samples before ingestion. See Prometheus operator documentation
+    # for format.
     metricRelabelings: []
 
 ## openshift settings

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -496,7 +496,7 @@ metrics:
     # -- Setting that adds annotations to the Prometheus ServiceMonitor.
     annotations: {}
     # -- Interval at which Prometheus scrapes the metrics from the target.
-    interval: 30s
+    interval: ""
     # -- Timeout after which Prometheus considers the scrape to be failed.
     scrapeTimeout: ""
     # -- Configures the relabeling rules to apply the target’s metadata labels. See Prometheus operator documentation


### PR DESCRIPTION
#8142 
### What this PR does / why we need it:

This PR introduces additional settings for ServiceMonitor, primarily focusing on the incorporation of additionalLabels for custom use and annotations. I added another ServiceMonitor settings, that helps to better configure monitoring of Loghorn.

