### PR TITLE
Add an example that uses a generic ephemeral volume

### DIFF
--- a/examples/pod_with_gev.yaml
+++ b/examples/pod_with_gev.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: volume-test
+  namespace: default
+spec:
+  restartPolicy: Always
+  containers:
+  - name: volume-test
+    image: nginx:stable-alpine
+    imagePullPolicy: IfNotPresent
+    livenessProbe:
+      exec:
+        command:
+          - ls
+          - /data/lost+found
+      initialDelaySeconds: 5
+      periodSeconds: 5
+    volumeMounts:
+    - name: volv
+      mountPath: /data
+    ports:
+    - containerPort: 80
+  volumes:
+  - name: volv
+    ephemeral:
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          storageClassName: longhorn
+          resources:
+            requests:
+              storage: 2Gi


### PR DESCRIPTION
Longhorn 8198

#### Which issue(s) this PR fixes:

Contributes to longhorn/longhorn#8198.

#### What this PR does / why we need it:

We don't have an example that deploys a workload with a Longhorn generic ephemeral volume. This example can help us quickly experiment with and test generic ephemeral volume functionality. It just modifies `examples/pod_with_pvc.yaml` so that it uses a generic ephemeral volume instead of an explicit PVC.