### PR TITLE
feat: Add defaultDiskSelector option to chart

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -146,6 +146,8 @@ The `values.yaml` contains items used to tweak a deployment of this chart.
 | persistence.defaultMkfsParams | string | `""` | mkfs parameters of the default Longhorn StorageClass. |
 | persistence.defaultNodeSelector.enable | bool | `false` | Setting that allows you to enable the node selector for the default Longhorn StorageClass. |
 | persistence.defaultNodeSelector.selector | string | `""` | Node selector for the default Longhorn StorageClass. Longhorn uses only nodes with the specified tags for storing volume data. (Examples: "storage,fast") |
+| persistence.defaultDiskSelector.enable | bool | `false` | Setting that allows you to enable the node selector for the default Longhorn StorageClass. |
+| persistence.defaultDiskSelector.selector | string | `""` | Disk selector for the default Longhorn StorageClass. Longhorn uses only disk with the specified tags for storing volume data. (Examples: "ssd") |
 | persistence.migratable | bool | `false` | Setting that allows you to enable live migration of a Longhorn volume from one node to another. |
 | persistence.nfsOptions | string | `""` | Set NFS mount options for Longhorn StorageClass for RWX volumes |
 | persistence.reclaimPolicy | string | `"Delete"` | Reclaim policy that provides instructions for handling of a volume after its claim is released. (Options: "Retain", "Delete") |

--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -798,6 +798,20 @@ questions:
     group: "Longhorn Storage Class Settings"
     type: string
     default:
+- variable: persistence.defaultDiskSelector.enable
+  description: "Setting that allows you to enable the disk selector for the default Longhorn StorageClass."
+  group: "Longhorn Storage Class Settings"
+  label: Enable Storage Class Disk Selector
+  type: boolean
+  default: false
+  show_subquestion_if: true
+  subquestions:
+  - variable: persistence.defaultDiskSelector.selector
+    label: Storage Class Disk Selector
+    description: 'Disk selector for the default Longhorn StorageClass. Longhorn uses only disks with the specified tags for storing volume data. (Examples: "ssd")'
+    group: "Longhorn Storage Class Settings"
+    type: string
+    default:
 - variable: persistence.backingImage.enable
   description: "Setting that allows you to use a backing image in a Longhorn StorageClass."
   group: "Longhorn Storage Class Settings"

--- a/chart/templates/storageclass.yaml
+++ b/chart/templates/storageclass.yaml
@@ -45,6 +45,9 @@ data:
       {{- if .Values.persistence.defaultNodeSelector.enable }}
       nodeSelector: "{{ .Values.persistence.defaultNodeSelector.selector }}"
       {{- end }}
+      {{- if .Values.persistence.defaultDiskSelector.enable }}
+      diskSelector: "{{ .Values.persistence.defaultDiskSelector.selector }}"
+      {{- end }}
       {{- if .Values.persistence.removeSnapshotsDuringFilesystemTrim }}
       unmapMarkSnapChainRemoved: "{{ .Values.persistence.removeSnapshotsDuringFilesystemTrim }}"
       {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -159,6 +159,11 @@ persistence:
     enable: false
     # -- Node selector for the default Longhorn StorageClass. Longhorn uses only nodes with the specified tags for storing volume data. (Examples: "storage,fast")
     selector: ""
+  defaultDiskSelector:
+    # -- Setting that allows you to enable the disk selector for the default Longhorn StorageClass.
+    enable: false
+    # -- Disk selector for the default Longhorn StorageClass. Longhorn uses only disks with the specified tags for storing volume data. (Examples: "sdd")
+    selector: ""
   # -- Setting that allows you to enable automatic snapshot removal during filesystem trim for a Longhorn StorageClass. (Options: "ignored", "enabled", "disabled")
   removeSnapshotsDuringFilesystemTrim: ignored
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Similar to what is available for nodeSelector, this adds also the diskSelector for the default storage class created from the chart.

#### Special notes for your reviewer:

First time contributor here, did I miss anything process-wise? Do I need to update the change log, or is that automated?

#### Additional documentation or context
