### PR TITLE
Fix a typo and release longhorn v1.6.1 to upgrade responder server

### DIFF
--- a/deploy/upgrade_responder_server/chart-values.yaml
+++ b/deploy/upgrade_responder_server/chart-values.yaml
@@ -16,11 +16,11 @@ secret:
 
 resources:
   limits:
-    cpu: 600m
-    memory: 1024Mi
-  requests:
-    cpu: 300m
+    cpu: 400m
     memory: 512Mi
+  requests:
+    cpu: 200m
+    memory: 256Mi
 
 # This configmap contains information about the latest release
 # of the application that is using this Upgrade Responder
@@ -43,8 +43,15 @@ configMap:
           ]
         },
         {
-          "name": "v1.5.3",
-          "releaseDate": "2023-11-17T00:00:00Z",
+          "name": "v1.5.4",
+          "releaseDate": "2024-02-27T00:00:00Z",
+          "tags": [
+            "stable"
+          ]
+        },
+        {
+          "name": "v1.6.1",
+          "releaseDate": "2024-03-28T00:00:00Z",
           "tags": [
             "latest",
             "stable"

--- a/dev/upgrade-responder/install.sh
+++ b/dev/upgrade-responder/install.sh
@@ -4,7 +4,7 @@ UPGRADE_RESPONDER_REPO="https://github.com/longhorn/upgrade-responder.git"
 UPGRADE_RESPONDER_REPO_BRANCH="master"
 UPGRADE_RESPONDER_VALUE_YAML="upgrade-responder-value.yaml"
 UPGRADE_RESPONDER_IMAGE_REPO="longhornio/upgrade-responder"
-UPGRADE_RESPONDER_IMAGE_TAG="master-head"
+UPGRADE_RESPONDER_IMAGE_TAG="longhorn-head"
 
 INFLUXDB_URL="http://influxdb.default.svc.cluster.local:8086"
 
@@ -227,7 +227,7 @@ configMap:
         "longhornSettingV1DataEngine": {
           "dataType": "string",
           "maxLen": 200
-        }
+        },
         "longhornSettingV2DataEngine": {
           "dataType": "string",
           "maxLen": 200


### PR DESCRIPTION
We also reduced the CPU and memory request/limit because we discovered the root cause of OOMKill is not because of these values being low

longhorn/longhorn#8209
