### PR TITLE
fix: check environment when doing pre-upgrade with Helm

### DIFF
--- a/chart/templates/preupgrade-job.yaml
+++ b/chart/templates/preupgrade-job.yaml
@@ -20,14 +20,23 @@ spec:
       - name: longhorn-pre-upgrade
         image: {{ template "registry_url" . }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext:
+          privileged: true
         command:
         - longhorn-manager
         - pre-upgrade
+        volumeMounts:
+        - name: proc
+          mountPath: /host/proc/
         env:
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+      volumes:
+      - name: proc
+        hostPath:
+          path: /proc/
       restartPolicy: OnFailure
       {{- if .Values.privateRegistry.registrySecret }}
       imagePullSecrets:


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#7571

#### What this PR does / why we need it:

Check if the environment settings are achieved when doing pre-upgrade job with Helm, ref: [environment_check.sh](https://github.com/longhorn/longhorn/blob/master/scripts/environment_check.sh)

#### Special notes for your reviewer:

#### Additional documentation or context
