### PR TITLE
chore(image): update support-bundle-kit to v0.0.38

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -116,7 +116,7 @@ The `values.yaml` contains items used to tweak a deployment of this chart.
 | image.longhorn.shareManager.repository | string | `"longhornio/longhorn-share-manager"` | Repository for the Longhorn Share Manager image. |
 | image.longhorn.shareManager.tag | string | `"master-head"` | Tag for the Longhorn Share Manager image. |
 | image.longhorn.supportBundleKit.repository | string | `"longhornio/support-bundle-kit"` | Repository for the Longhorn Support Bundle Manager image. |
-| image.longhorn.supportBundleKit.tag | string | `"v0.0.37"` | Tag for the Longhorn Support Bundle Manager image. |
+| image.longhorn.supportBundleKit.tag | string | `"v0.0.38"` | Tag for the Longhorn Support Bundle Manager image. |
 | image.longhorn.ui.repository | string | `"longhornio/longhorn-ui"` | Repository for the Longhorn UI image. |
 | image.longhorn.ui.tag | string | `"master-head"` | Tag for the Longhorn UI image. |
 | image.openshift.oauthProxy.repository | string | `"longhornio/openshift-origin-oauth-proxy"` | Repository for the OAuth Proxy image. This setting applies only to OpenShift users. |

--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -89,7 +89,7 @@ questions:
     label: Longhorn Support Bundle Kit Image Repository
     group: "Longhorn Images Settings"
   - variable: image.longhorn.supportBundleKit.tag
-    default: v0.0.37
+    default: v0.0.38
     description: "Tag for the Longhorn Support Bundle Manager image."
     type: string
     label: Longhorn Support Bundle Kit Image Tag

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -69,7 +69,7 @@ image:
       # -- Repository for the Longhorn Support Bundle Manager image.
       repository: longhornio/support-bundle-kit
       # -- Tag for the Longhorn Support Bundle Manager image.
-      tag: v0.0.37
+      tag: v0.0.38
   csi:
     attacher:
       # -- Repository for the CSI attacher image. When unspecified, Longhorn uses the default value.

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -11,4 +11,4 @@ longhornio/longhorn-instance-manager:master-head
 longhornio/longhorn-manager:master-head
 longhornio/longhorn-share-manager:master-head
 longhornio/longhorn-ui:master-head
-longhornio/support-bundle-kit:v0.0.37
+longhornio/support-bundle-kit:v0.0.38

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -4425,7 +4425,7 @@ spec:
         - --backing-image-manager-image
         - "longhornio/backing-image-manager:master-head"
         - --support-bundle-manager-image
-        - "longhornio/support-bundle-kit:v0.0.37"
+        - "longhornio/support-bundle-kit:v0.0.38"
         - --manager-image
         - "longhornio/longhorn-manager:master-head"
         - --service-account


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#8623

#### What this PR does / why we need it:

Update support-bundle image to support node bundle collection timeout.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context
- https://github.com/rancher/support-bundle-kit/pull/109
- https://github.com/rancher/support-bundle-kit/releases/tag/v0.0.38
- [longhornio/support-bundle-kit:v0.0.38](https://hub.docker.com/layers/longhornio/support-bundle-kit/v0.0.38/images/sha256-773ce8484b905c4df36c3b68a7614d4f1326888a4c30c761463983e190457199?context=explore)