### PR TITLE
environment_check.sh: add check for iscsi_tcp kernel module

### DIFF
--- a/scripts/environment_check.sh
+++ b/scripts/environment_check.sh
@@ -332,6 +332,7 @@ check_iscsid() {
       return 1
     fi
   fi
+  check_kernel_module ${pod} CONFIG_ISCSI_TCP iscsi_tcp
 }
 
 check_multipathd() {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/8697

#### What this PR does / why we need it:

In case someone is trying Longhorn on a SLES/openSUSE minimal VM image, which includes `kernel-default-base` by default, which does _not_ include `iscsi_tcp`.

#### Special notes for your reviewer:

#### Additional documentation or context

With this change applied and `kernel-default-base` installed, we see the following output:

```
[INFO]  Required dependencies 'kubectl jq mktemp sort printf' are installed.
[INFO]  All nodes have unique hostnames.
[INFO]  Waiting for longhorn-environment-check pods to become ready (0/1)...
[INFO]  All longhorn-environment-check pods are ready (1/1).
[INFO]  MountPropagation is enabled
[INFO]  Checking kernel release...
[INFO]  Checking iscsid...
[ERROR] kernel module iscsi_tcp is not enabled on master
[INFO]  Checking multipathd...
[INFO]  Checking packages...
[INFO]  Checking nfs client...
[INFO]  Cleaning up longhorn-environment-check pods...
[INFO]  Cleanup completed.
```