### PR TITLE
feat(RWX HA) - add an enabling setting, and make service selectors dynamically settable.

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -300,6 +300,7 @@ During installation, you can either allow Longhorn to use the default system set
 | defaultSettings.disableRevisionCounter | Setting that disables the revision counter and thereby prevents Longhorn from tracking all write operations to a volume. When salvaging a volume, Longhorn uses properties of the "volume-head-xxx.img" file (the last file size and the last time the file was modified) to select the replica to be used for volume recovery. This setting applies only to volumes created using the Longhorn UI. |
 | defaultSettings.disableSchedulingOnCordonedNode | Setting that prevents Longhorn Manager from scheduling replicas on a cordoned Kubernetes node. This setting is enabled by default. |
 | defaultSettings.disableSnapshotPurge | Setting that temporarily prevents all attempts to purge volume snapshots. |
+| defaultSettings.enableShareManagerFastFailover | Turn on logic to detect and move RWX volumes quickly on node failure. |
 | defaultSettings.engineReplicaTimeout | Timeout between the Longhorn Engine and replicas. Specify a value between "8" and "30" seconds. The default value is "8". |
 | defaultSettings.failedBackupTTL | Number of minutes that Longhorn keeps a failed backup resource. When the value is "0", automatic deletion is disabled. |
 | defaultSettings.fastReplicaRebuildEnabled | Setting that allows fast rebuilding of replicas using the checksum of snapshot disk files. Before enabling this setting, you must set the snapshot-data-integrity value to "enable" or "fast-check". |

--- a/chart/README.md
+++ b/chart/README.md
@@ -300,7 +300,7 @@ During installation, you can either allow Longhorn to use the default system set
 | defaultSettings.disableRevisionCounter | Setting that disables the revision counter and thereby prevents Longhorn from tracking all write operations to a volume. When salvaging a volume, Longhorn uses properties of the "volume-head-xxx.img" file (the last file size and the last time the file was modified) to select the replica to be used for volume recovery. This setting applies only to volumes created using the Longhorn UI. |
 | defaultSettings.disableSchedulingOnCordonedNode | Setting that prevents Longhorn Manager from scheduling replicas on a cordoned Kubernetes node. This setting is enabled by default. |
 | defaultSettings.disableSnapshotPurge | Setting that temporarily prevents all attempts to purge volume snapshots. |
-| defaultSettings.enableShareManagerFastFailover | Turn on logic to detect and move RWX volumes quickly on node failure. |
+| defaultSettings.rwxVolumeFastFailover | Turn on logic to detect and move RWX volumes quickly on node failure. |
 | defaultSettings.engineReplicaTimeout | Timeout between the Longhorn Engine and replicas. Specify a value between "8" and "30" seconds. The default value is "8". |
 | defaultSettings.failedBackupTTL | Number of minutes that Longhorn keeps a failed backup resource. When the value is "0", automatic deletion is disabled. |
 | defaultSettings.fastReplicaRebuildEnabled | Setting that allows fast rebuilding of replicas using the checksum of snapshot disk files. Before enabling this setting, you must set the snapshot-data-integrity value to "enable" or "fast-check". |

--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -753,8 +753,8 @@ questions:
   group: "Longhorn Default Settings"
   type: boolean
   default: false
-- variable: defaultSettings.enableShareManagerFastFailover
-  label: Enable Share Manager Fast Failover (Experimental)
+- variable: defaultSettings.rwxVolumeFastFailover
+  label: RWX Volume Fast Failover (Experimental)
   description: "Turn on logic to detect and move RWX volumes quickly on node failure."
   group: "Longhorn Default Settings"
   type: boolean

--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -753,6 +753,12 @@ questions:
   group: "Longhorn Default Settings"
   type: boolean
   default: false
+- variable: defaultSettings.enableShareManagerFastFailover
+  label: Enable Share Manager Fast Failover (Experimental)
+  description: "Turn on logic to detect and move RWX volumes quickly on node failure."
+  group: "Longhorn Default Settings"
+  type: boolean
+  default: false
 - variable: persistence.defaultClass
   default: "true"
   description: "Setting that allows you to specify the default Longhorn StorageClass."

--- a/chart/templates/daemonset-sa.yaml
+++ b/chart/templates/daemonset-sa.yaml
@@ -77,6 +77,10 @@ spec:
           mountPath: /go-cover-dir/
         {{- end }}
         env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/chart/templates/default-setting.yaml
+++ b/chart/templates/default-setting.yaml
@@ -242,6 +242,6 @@ data:
     {{- if not (kindIs "invalid" .Values.defaultSettings.autoCleanupSnapshotWhenDeleteBackup) }}
     auto-cleanup-when-delete-backup: {{ .Values.defaultSettings.autoCleanupSnapshotWhenDeleteBackup }}
     {{- end }}
-    {{- if not (kindIs "invalid" .Values.defaultSettings.enableShareManagerFastFailover) }}
-    enable-share-manager-fast-failover: {{ .Values.defaultSettings.enableShareManagerFastFailover}}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.rwxVolumeFastFailover) }}
+    rwx-volume-fast-failover: {{ .Values.defaultSettings.rwxVolumeFastFailover}}
     {{- end }}

--- a/chart/templates/default-setting.yaml
+++ b/chart/templates/default-setting.yaml
@@ -242,3 +242,6 @@ data:
     {{- if not (kindIs "invalid" .Values.defaultSettings.autoCleanupSnapshotWhenDeleteBackup) }}
     auto-cleanup-when-delete-backup: {{ .Values.defaultSettings.autoCleanupSnapshotWhenDeleteBackup }}
     {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.enableShareManagerFastFailover) }}
+    enable-share-manager-fast-failover: {{ .Values.defaultSettings.enableShareManagerFastFailover}}
+    {{- end }}

--- a/chart/templates/network-policies/recovery-backend-network-policy.yaml
+++ b/chart/templates/network-policies/recovery-backend-network-policy.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: longhorn-manager
+      longhorn.io/recovery-backend: longhorn-recovery-backend
   policyTypes:
   - Ingress
   ingress:

--- a/chart/templates/network-policies/webhook-network-policy.yaml
+++ b/chart/templates/network-policies/webhook-network-policy.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: longhorn-manager
+      longhorn.io/conversion-webhook: longhorn-conversion-webhook
   policyTypes:
   - Ingress
   ingress:
@@ -23,7 +23,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: longhorn-manager
+      longhorn.io/admission-webhook: longhorn-admission-webhook
   policyTypes:
   - Ingress
   ingress:

--- a/chart/templates/services.yaml
+++ b/chart/templates/services.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    app: longhorn-manager
+    longhorn.io/conversion-webhook: longhorn-conversion-webhook
   ports:
   - name: conversion-webhook
     port: 9501
@@ -24,7 +24,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    app: longhorn-manager
+    longhorn.io/admission-webhook: longhorn-admission-webhook
   ports:
   - name: admission-webhook
     port: 9502
@@ -40,7 +40,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    app: longhorn-manager
+    longhorn.io/recovery-backend: longhorn-recovery-backend
   ports:
   - name: recovery-backend
     port: 9503

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -344,7 +344,7 @@ defaultSettings:
   # -- Setting that automatically cleans up the snapshot when the backup is deleted.
   autoCleanupSnapshotWhenDeleteBackup: ~
   # -- Turn on logic to detect and move RWX volumes quickly on node failure.
-  enableShareManagerFastFailover: ~
+  rwxVolumeFastFailover: ~
 
 privateRegistry:
   # -- Setting that allows you to create a private registry secret.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -343,6 +343,8 @@ defaultSettings:
   freezeFilesystemForSnapshot: ~
   # -- Setting that automatically cleans up the snapshot when the backup is deleted.
   autoCleanupSnapshotWhenDeleteBackup: ~
+  # -- Turn on logic to detect and move RWX volumes quickly on node failure.
+  enableShareManagerFastFailover: ~
 
 privateRegistry:
   # -- Setting that allows you to create a private registry secret.

--- a/deploy/longhorn-okd.yaml
+++ b/deploy/longhorn-okd.yaml
@@ -4817,7 +4817,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    app: longhorn-manager
+    longhorn.io/conversion-webhook: longhorn-conversion-webhook
   ports:
   - name: conversion-webhook
     port: 9501
@@ -4837,7 +4837,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    app: longhorn-manager
+    longhorn.io/admission-webhook: longhorn-admission-webhook
   ports:
   - name: admission-webhook
     port: 9502
@@ -4857,7 +4857,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    app: longhorn-manager
+    longhorn.io/recovery-backend: longhorn-recovery-backend
   ports:
   - name: recovery-backend
     port: 9503
@@ -4936,6 +4936,10 @@ spec:
         - name: longhorn-grpc-tls
           mountPath: /tls-files/
         env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -4754,7 +4754,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    app: longhorn-manager
+    longhorn.io/conversion-webhook: longhorn-conversion-webhook
   ports:
   - name: conversion-webhook
     port: 9501
@@ -4774,7 +4774,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    app: longhorn-manager
+    longhorn.io/admission-webhook: longhorn-admission-webhook
   ports:
   - name: admission-webhook
     port: 9502
@@ -4794,7 +4794,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    app: longhorn-manager
+    longhorn.io/recovery-backend: longhorn-recovery-backend
   ports:
   - name: recovery-backend
     port: 9503
@@ -4873,6 +4873,10 @@ spec:
         - name: longhorn-grpc-tls
           mountPath: /tls-files/
         env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/examples/network-policy/recovery-backend-network-policy.yaml
+++ b/examples/network-policy/recovery-backend-network-policy.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: longhorn-manager
+      longhorn.io/recovery-backend: longhorn-recovery-backend
   policyTypes:
   - Ingress
   ingress:

--- a/examples/network-policy/webhook-network-policy.yaml
+++ b/examples/network-policy/webhook-network-policy.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: longhorn-manager
+      longhorn.io/conversion-webhook: longhorn-conversion-webhook
   policyTypes:
   - Ingress
   ingress:
@@ -22,7 +22,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: longhorn-manager
+      longhorn.io/admission-webhook: longhorn-admission-webhook
   policyTypes:
   - Ingress
   ingress:


### PR DESCRIPTION
…hooks.

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #8803 

#### What this PR does / why we need it:

This customizes the node selector used by the two webhooks to allow individual control of which nodes might be assigned the service, as has been done for RWX HA.  See #6205, for instance.

It now also has the chart documentation for the setting `enable-share-manager-fast-failover`.

#### Special notes for your reviewer:

This PR **must** be accompanied by https://github.com/longhorn/longhorn-manager/pull/2920 or the webhooks will never be accessible (the endpoint slices will remain empty).
(Now https://github.com/longhorn/longhorn-manager/pull/2811).

#### Additional documentation or context
