### PR TITLE
feat(chart): Added defaultDiskSelector to default storageClass

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -146,6 +146,8 @@ The `values.yaml` contains items used to tweak a deployment of this chart.
 | persistence.defaultDataLocality | string | `"disabled"` | Data locality of the default Longhorn StorageClass. (Options: "disabled", "best-effort") |
 | persistence.defaultFsType | string | `"ext4"` | Filesystem type of the default Longhorn StorageClass. |
 | persistence.defaultMkfsParams | string | `""` | mkfs parameters of the default Longhorn StorageClass. |
+| persistence.defaultDiskSelector.enable | bool | `false` | Setting that allows you to enable the disk selector for the default Longhorn StorageClass. |
+| persistence.defaultDiskSelector.selector | string | `""` | Disk selector for the default Longhorn StorageClass. Longhorn uses only disks with the specified tags for storing volume data. (Examples: "nvme,sata") |
 | persistence.defaultNodeSelector.enable | bool | `false` | Setting that allows you to enable the node selector for the default Longhorn StorageClass. |
 | persistence.defaultNodeSelector.selector | string | `""` | Node selector for the default Longhorn StorageClass. Longhorn uses only nodes with the specified tags for storing volume data. (Examples: "storage,fast") |
 | persistence.disableRevisionCounter | string | `"true"` | Setting that disables the revision counter and thereby prevents Longhorn from tracking all write operations to a volume. When salvaging a volume, Longhorn uses properties of the volume-head-xxx.img file (the last file size and the last time the file was modified) to select the replica to be used for volume recovery. |

--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -811,6 +811,20 @@ questions:
     group: "Longhorn Storage Class Settings"
     type: string
     default:
+- variable: persistence.defaultDiskSelector.enable
+  description: "Setting that allows you to enable the disk selector for the default Longhorn StorageClass."
+  group: "Longhorn Storage Class Settings"
+  label: Enable Storage Class Disk Selector
+  type: boolean
+  default: false
+  show_subquestion_if: true
+  subquestions:
+    - variable: persistence.defaultDiskSelector.selector
+      label: Storage Class Disk Selector
+      description: 'Disk selector for the default Longhorn StorageClass. Longhorn uses only disks with the specified tags for storing volume data. (Examples: "nvme,sata")'
+      group: "Longhorn Storage Class Settings"
+      type: string
+      default:
 - variable: persistence.defaultNodeSelector.enable
   description: "Setting that allows you to enable the node selector for the default Longhorn StorageClass."
   group: "Longhorn Storage Class Settings"

--- a/chart/templates/storageclass.yaml
+++ b/chart/templates/storageclass.yaml
@@ -42,6 +42,9 @@ data:
       recurringJobSelector: '{{ .Values.persistence.recurringJobSelector.jobList }}'
       {{- end }}
       dataLocality: {{ .Values.persistence.defaultDataLocality | quote }}
+      {{- if .Values.persistence.defaultDiskSelector.enable }}
+      diskSelector: "{{ .Values.persistence.defaultDiskSelector.selector }}"
+      {{- end }}
       {{- if .Values.persistence.defaultNodeSelector.enable }}
       nodeSelector: "{{ .Values.persistence.defaultNodeSelector.selector }}"
       {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -160,6 +160,11 @@ persistence:
     dataSourceParameters: ~
     # -- Expected SHA-512 checksum of a backing image used in a Longhorn StorageClass.
     expectedChecksum: ~
+  defaultDiskSelector:
+    # -- Setting that allows you to enable the disk selector for the default Longhorn StorageClass.
+    enable: false
+    # -- Disk selector for the default Longhorn StorageClass. Longhorn uses only disks with the specified tags for storing volume data. (Examples: "nvme,sata")
+    selector: ""
   defaultNodeSelector:
     # -- Setting that allows you to enable the node selector for the default Longhorn StorageClass.
     enable: false


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue #

#### What this PR does / why we need it:
Added an option 'defaultDiskSelector' on default storage class to enable the disk selector. 

#### Special notes for your reviewer:

#### Additional documentation or context
https://github.com/longhorn/charts/pull/162