### PR TITLE
docs(metrics): move Helm values to a separate section in README.md

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -228,6 +228,18 @@ You can install Longhorn in an air-gapped environment with a private registry. F
 | privateRegistry.registryUrl | URL of a private registry. When unspecified, Longhorn uses the default system registry. |
 | privateRegistry.registryUser | User account used for authenticating with a private registry. |
 
+### Metrics Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| metrics.serviceMonitor.additionalLabels | object | `{}` | Setting that adds additional labels to the Prometheus ServiceMonitor. |
+| metrics.serviceMonitor.annotations | object | `{}` | Setting that adds annotations to the Prometheus ServiceMonitor. |
+| metrics.serviceMonitor.enabled | bool | `false` | Setting that allows the creation of a Prometheus ServiceMonitor resource for Longhorn Manager components. |
+| metrics.serviceMonitor.interval | string | `""` | Interval at which Prometheus scrapes the metrics from the target. |
+| metrics.serviceMonitor.metricRelabelings | list | `[]` | Configures the relabeling rules to apply to the samples before ingestion. See Prometheus operator documentation for format. |
+| metrics.serviceMonitor.relabelings | list | `[]` | Configures the relabeling rules to apply the target’s metadata labels. See Prometheus operator documentation for format. |
+| metrics.serviceMonitor.scrapeTimeout | string | `""` | Timeout after which Prometheus considers the scrape to be failed. |
+
 ### OS/Kubernetes Distro Settings
 
 #### OpenShift Settings
@@ -248,13 +260,6 @@ For more details, see the [ocp-readme](https://github.com/longhorn/longhorn/blob
 | annotations | `{}` | Annotation for the Longhorn Manager DaemonSet pods. This setting is optional. |
 | enableGoCoverDir | `false` | Setting that allows Longhorn to generate code coverage profiles. |
 | enablePSP | `false` | Setting that allows you to enable pod security policies (PSPs) that allow privileged Longhorn pods to start. This setting applies only to clusters running Kubernetes 1.25 and earlier, and with the built-in Pod Security admission controller enabled. |
-| metrics.serviceMonitor.additionalLabels | `{}` | Setting that adds additional labels to the Prometheus ServiceMonitor. |
-| metrics.serviceMonitor.annotations | `{}` | Setting that adds annotations to the Prometheus ServiceMonitor. |
-| metrics.serviceMonitor.enabled | `false` | Setting that allows the creation of a Prometheus ServiceMonitor resource for Longhorn Manager components. |
-| metrics.serviceMonitor.interval | `""` | Interval at which Prometheus scrapes the metrics from the target. |
-| metrics.serviceMonitor.metricRelabelings | `[]` | Configures the relabeling rules to apply to the samples before ingestion. See Prometheus operator documentation for format. |
-| metrics.serviceMonitor.relabelings | `[]` | Configures the relabeling rules to apply the target’s metadata labels. See Prometheus operator documentation for format. |
-| metrics.serviceMonitor.scrapeTimeout | `""` | Timeout after which Prometheus considers the scrape to be failed. |
 | namespaceOverride | `""` | Specify override namespace, specifically this is useful for using longhorn as sub-chart and its release namespace is not the `longhorn-system`. |
 | preUpgradeChecker.jobEnabled | `true` | Setting that allows Longhorn to perform pre-upgrade checks. Disable this setting when installing Longhorn using Argo CD or other GitOps solutions. |
 | preUpgradeChecker.upgradeVersionCheck | `true` | Setting that allows Longhorn to perform upgrade version checks after starting the Longhorn Manager DaemonSet Pods. Disabling this setting also disables `preUpgradeChecker.jobEnabled`. Longhorn recommends keeping this setting enabled. |

--- a/chart/README.md.gotmpl
+++ b/chart/README.md.gotmpl
@@ -187,6 +187,16 @@ You can install Longhorn in an air-gapped environment with a private registry. F
   {{- end }}
 {{- end }}
 
+### Metrics Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+{{- range .Values }}
+  {{- if hasPrefix "metrics" .Key }}
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+  {{- end }}
+{{- end }}
+
 ### OS/Kubernetes Distro Settings
 
 #### OpenShift Settings
@@ -217,6 +227,7 @@ For more details, see the [ocp-readme](https://github.com/longhorn/longhorn/blob
   (hasPrefix "longhornUI" .Key)
   (hasPrefix "privateRegistry" .Key)
   (hasPrefix "ingress" .Key)
+  (hasPrefix "metrics" .Key)
   (hasPrefix "openshift" .Key)
   (hasPrefix "global" .Key)) }}
 | {{ .Key }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

This is an addon for longhorn/longhorn#8142 that doesn't affect functionality.

#### What this PR does / why we need it:

It's weird to have so many metrics/serviceMonitor settings in `Other Settings` instead of in their own group.
