### PR TITLE
docs(metrics): reformat serviceMonitor Helm variable descriptions

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -232,12 +232,12 @@ You can install Longhorn in an air-gapped environment with a private registry. F
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| metrics.serviceMonitor.additionalLabels | object | `{}` | Setting that adds additional labels to the Prometheus ServiceMonitor. |
-| metrics.serviceMonitor.annotations | object | `{}` | Setting that adds annotations to the Prometheus ServiceMonitor. |
+| metrics.serviceMonitor.additionalLabels | object | `{}` | Additional labels for the Prometheus ServiceMonitor resource. |
+| metrics.serviceMonitor.annotations | object | `{}` | Annotations for the Prometheus ServiceMonitor resource. |
 | metrics.serviceMonitor.enabled | bool | `false` | Setting that allows the creation of a Prometheus ServiceMonitor resource for Longhorn Manager components. |
 | metrics.serviceMonitor.interval | string | `""` | Interval at which Prometheus scrapes the metrics from the target. |
-| metrics.serviceMonitor.metricRelabelings | list | `[]` | Configures the relabeling rules to apply to the samples before ingestion. See Prometheus operator documentation for format. |
-| metrics.serviceMonitor.relabelings | list | `[]` | Configures the relabeling rules to apply the target’s metadata labels. See Prometheus operator documentation for format. |
+| metrics.serviceMonitor.metricRelabelings | list | `[]` | Configures the relabeling rules to apply to the samples before ingestion. See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.Endpoint) for formatting details. |
+| metrics.serviceMonitor.relabelings | list | `[]` | Configures the relabeling rules to apply the target’s metadata labels. See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.Endpoint) for formatting details. |
 | metrics.serviceMonitor.scrapeTimeout | string | `""` | Timeout after which Prometheus considers the scrape to be failed. |
 
 ### OS/Kubernetes Distro Settings

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -493,19 +493,21 @@ metrics:
   serviceMonitor:
     # -- Setting that allows the creation of a Prometheus ServiceMonitor resource for Longhorn Manager components.
     enabled: false
-    # -- Setting that adds additional labels to the Prometheus ServiceMonitor.
+    # -- Additional labels for the Prometheus ServiceMonitor resource.
     additionalLabels: {}
-    # -- Setting that adds annotations to the Prometheus ServiceMonitor.
+    # -- Annotations for the Prometheus ServiceMonitor resource.
     annotations: {}
     # -- Interval at which Prometheus scrapes the metrics from the target.
     interval: ""
     # -- Timeout after which Prometheus considers the scrape to be failed.
     scrapeTimeout: ""
-    # -- Configures the relabeling rules to apply the target’s metadata labels. See Prometheus operator documentation
-    # for format.
+    # -- Configures the relabeling rules to apply the target’s metadata labels. See the [Prometheus Operator
+    # documentation](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.Endpoint) for
+    # formatting details.
     relabelings: []
-    # -- Configures the relabeling rules to apply to the samples before ingestion. See Prometheus operator documentation
-    # for format.
+    # -- Configures the relabeling rules to apply to the samples before ingestion. See the [Prometheus Operator
+    # documentation](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.Endpoint) for
+    # formatting details.
     metricRelabelings: []
 
 ## openshift settings


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

longhorn/longhorn#8142

#### What this PR does / why we need it:

Final description formatting per @jillian-maroket's review of https://github.com/longhorn/website/pull/945.
