### PR TITLE
Fix(cve): update openshift-oauth-proxy to 4.15

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -120,7 +120,7 @@ The `values.yaml` contains items used to tweak a deployment of this chart.
 | image.longhorn.ui.repository | string | `"longhornio/longhorn-ui"` | Repository for the Longhorn UI image. |
 | image.longhorn.ui.tag | string | `"master-head"` | Tag for the Longhorn UI image. |
 | image.openshift.oauthProxy.repository | string | `"longhornio/openshift-origin-oauth-proxy"` | Repository for the OAuth Proxy image. This setting applies only to OpenShift users. |
-| image.openshift.oauthProxy.tag | float | `4.14` | Tag for the OAuth Proxy image. This setting applies only to OpenShift users. Specify OCP/OKD version 4.1 or later. The latest stable version is 4.14. |
+| image.openshift.oauthProxy.tag | float | `4.15` | Tag for the OAuth Proxy image. This setting applies only to OpenShift users. Specify OCP/OKD version 4.1 or later. The latest stable version is 4.15. |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy that applies to all user-deployed Longhorn components, such as Longhorn Manager, Longhorn driver, and Longhorn UI. |
 
 ### Service Settings

--- a/chart/ocp-readme.md
+++ b/chart/ocp-readme.md
@@ -145,7 +145,7 @@ Minimum Adjustments Required
 openshift:
   oauthProxy:
     repository: quay.io/openshift/origin-oauth-proxy
-    tag: 4.14  # Use Your OCP/OKD 4.X Version, Current Stable is 4.14
+    tag: 4.15  # Use Your OCP/OKD 4.X Version, Current Stable is 4.15
 
 # defaultSettings: # Preparing nodes (Optional)
   # createDefaultDiskLabeledNodes: true

--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -173,7 +173,7 @@ questions:
     label: OpenShift OAuth Proxy Image Repository
     group: "OpenShift Images"
   - variable: image.openshift.oauthProxy.tag
-    default: 4.14
+    default: 4.15
     description: "Tag for the OAuth Proxy image. This setting applies only to OpenShift users. Specify OCP/OKD version 4.1 or later."
     type: string
     label: OpenShift OAuth Proxy Image Tag

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -105,8 +105,8 @@ image:
     oauthProxy:
       # -- Repository for the OAuth Proxy image. This setting applies only to OpenShift users.
       repository: longhornio/openshift-origin-oauth-proxy
-      # -- Tag for the OAuth Proxy image. This setting applies only to OpenShift users. Specify OCP/OKD version 4.1 or later. The latest stable version is 4.14.
-      tag: 4.14
+      # -- Tag for the OAuth Proxy image. This setting applies only to OpenShift users. Specify OCP/OKD version 4.1 or later. The latest stable version is 4.15.
+      tag: 4.15
   # -- Image pull policy that applies to all user-deployed Longhorn components, such as Longhorn Manager, Longhorn driver, and Longhorn UI.
   pullPolicy: IfNotPresent
 

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -4,7 +4,7 @@ longhornio/csi-resizer:v1.10.1
 longhornio/csi-snapshotter:v7.0.2
 longhornio/csi-node-driver-registrar:v2.9.2
 longhornio/livenessprobe:v2.12.0
-longhornio/openshift-origin-oauth-proxy:4.14
+longhornio/openshift-origin-oauth-proxy:4.15
 longhornio/backing-image-manager:master-head
 longhornio/longhorn-engine:master-head
 longhornio/longhorn-instance-manager:master-head

--- a/deploy/longhorn-okd.yaml
+++ b/deploy/longhorn-okd.yaml
@@ -5062,7 +5062,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: oauth-proxy
-        image: longhornio/openshift-origin-oauth-proxy:4.14
+        image: longhornio/openshift-origin-oauth-proxy:4.15
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8443


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#8976

#### What this PR does / why we need it:

Fix CVE issues.

Before:
```
longhornio/openshift-origin-oauth-proxy:4.14 (redhat 8.6)
=========================================================
Total: 25 (HIGH: 25, CRITICAL: 0)

┌────────────────────────┬────────────────┬──────────┬────────┬──────────────────────┬──────────────────────┬──────────────────────────────────────────────────────────────┐
│        Library         │ Vulnerability  │ Severity │ Status │  Installed Version   │    Fixed Version     │                            Title                             │
├────────────────────────┼────────────────┼──────────┼────────┼──────────────────────┼──────────────────────┼──────────────────────────────────────────────────────────────┤
│ bind-libs              │ CVE-2023-4408  │ HIGH     │ fixed  │ 32:9.11.36-3.el8_6.5 │ 32:9.11.36-3.el8_6.7 │ bind9: Parsing large DNS messages may cause excessive CPU    │
│                        │                │          │        │                      │                      │ load                                                         │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-4408                    │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-50387 │          │        │                      │                      │ bind9: KeyTrap - Extreme CPU consumption in DNSSEC validator │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-50387                   │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-50868 │          │        │                      │                      │ bind9: Preparing an NSEC3 closest encloser proof can exhaust │
│                        │                │          │        │                      │                      │ CPU resources                                                │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-50868                   │
├────────────────────────┼────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│ bind-libs-lite         │ CVE-2023-4408  │          │        │                      │                      │ bind9: Parsing large DNS messages may cause excessive CPU    │
│                        │                │          │        │                      │                      │ load                                                         │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-4408                    │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-50387 │          │        │                      │                      │ bind9: KeyTrap - Extreme CPU consumption in DNSSEC validator │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-50387                   │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-50868 │          │        │                      │                      │ bind9: Preparing an NSEC3 closest encloser proof can exhaust │
│                        │                │          │        │                      │                      │ CPU resources                                                │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-50868                   │
├────────────────────────┼────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│ bind-license           │ CVE-2023-4408  │          │        │                      │                      │ bind9: Parsing large DNS messages may cause excessive CPU    │
│                        │                │          │        │                      │                      │ load                                                         │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-4408                    │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-50387 │          │        │                      │                      │ bind9: KeyTrap - Extreme CPU consumption in DNSSEC validator │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-50387                   │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-50868 │          │        │                      │                      │ bind9: Preparing an NSEC3 closest encloser proof can exhaust │
│                        │                │          │        │                      │                      │ CPU resources                                                │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-50868                   │
├────────────────────────┼────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│ bind-utils             │ CVE-2023-4408  │          │        │                      │                      │ bind9: Parsing large DNS messages may cause excessive CPU    │
│                        │                │          │        │                      │                      │ load                                                         │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-4408                    │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-50387 │          │        │                      │                      │ bind9: KeyTrap - Extreme CPU consumption in DNSSEC validator │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-50387                   │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-50868 │          │        │                      │                      │ bind9: Preparing an NSEC3 closest encloser proof can exhaust │
│                        │                │          │        │                      │                      │ CPU resources                                                │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-50868                   │
├────────────────────────┼────────────────┤          │        ├──────────────────────┼──────────────────────┼──────────────────────────────────────────────────────────────┤
│ glibc                  │ CVE-2024-2961  │          │        │ 2.28-189.6.el8_6     │ 2.28-189.10.el8_6    │ glibc: Out of bounds write in iconv may lead to remote       │
│                        │                │          │        │                      │                      │ code...                                                      │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2024-2961                    │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2024-33599 │          │        │                      │                      │ glibc: stack-based buffer overflow in netgroup cache         │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2024-33599                   │
├────────────────────────┼────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│ glibc-common           │ CVE-2024-2961  │          │        │                      │                      │ glibc: Out of bounds write in iconv may lead to remote       │
│                        │                │          │        │                      │                      │ code...                                                      │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2024-2961                    │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2024-33599 │          │        │                      │                      │ glibc: stack-based buffer overflow in netgroup cache         │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2024-33599                   │
├────────────────────────┼────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│ glibc-gconv-extra      │ CVE-2024-2961  │          │        │                      │                      │ glibc: Out of bounds write in iconv may lead to remote       │
│                        │                │          │        │                      │                      │ code...                                                      │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2024-2961                    │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2024-33599 │          │        │                      │                      │ glibc: stack-based buffer overflow in netgroup cache         │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2024-33599                   │
├────────────────────────┼────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│ glibc-langpack-en      │ CVE-2024-2961  │          │        │                      │                      │ glibc: Out of bounds write in iconv may lead to remote       │
│                        │                │          │        │                      │                      │ code...                                                      │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2024-2961                    │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2024-33599 │          │        │                      │                      │ glibc: stack-based buffer overflow in netgroup cache         │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2024-33599                   │
├────────────────────────┼────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│ glibc-minimal-langpack │ CVE-2024-2961  │          │        │                      │                      │ glibc: Out of bounds write in iconv may lead to remote       │
│                        │                │          │        │                      │                      │ code...                                                      │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2024-2961                    │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2024-33599 │          │        │                      │                      │ glibc: stack-based buffer overflow in netgroup cache         │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2024-33599                   │
├────────────────────────┼────────────────┤          │        ├──────────────────────┼──────────────────────┼──────────────────────────────────────────────────────────────┤
│ python3-bind           │ CVE-2023-4408  │          │        │ 32:9.11.36-3.el8_6.5 │ 32:9.11.36-3.el8_6.7 │ bind9: Parsing large DNS messages may cause excessive CPU    │
│                        │                │          │        │                      │                      │ load                                                         │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-4408                    │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-50387 │          │        │                      │                      │ bind9: KeyTrap - Extreme CPU consumption in DNSSEC validator │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-50387                   │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-50868 │          │        │                      │                      │ bind9: Preparing an NSEC3 closest encloser proof can exhaust │
│                        │                │          │        │                      │                      │ CPU resources                                                │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-50868                   │
└────────────────────────┴────────────────┴──────────┴────────┴──────────────────────┴──────────────────────┴──────────────────────────────────────────────────────────────┘

usr/bin/oauth-proxy (gobinary)
==============================
Total: 6 (HIGH: 5, CRITICAL: 1)

┌──────────────────────────────────────────────────────────────┬─────────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────────┬─────────────────────────────────────────────────────────────┐
│                           Library                            │    Vulnerability    │ Severity │ Status │ Installed Version │          Fixed Version           │                            Title                            │
├──────────────────────────────────────────────────────────────┼─────────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│ go.opentelemetry.io/contrib/instrumentation/google.golang.o- │ CVE-2023-47108      │ HIGH     │ fixed  │ v0.35.0           │ 0.46.0                           │ opentelemetry-go-contrib: DoS vulnerability in otelgrpc due │
│ rg/grpc/otelgrpc                                             │                     │          │        │                   │                                  │ to unbound cardinality metrics                              │
│                                                              │                     │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-47108                  │
├──────────────────────────────────────────────────────────────┼─────────────────────┤          │        ├───────────────────┼──────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│ go.opentelemetry.io/contrib/instrumentation/net/http/otelht- │ CVE-2023-45142      │          │        │ v0.35.1           │ 0.44.0                           │ opentelemetry: DoS vulnerability in otelhttp                │
│ tp                                                           │                     │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-45142                  │
├──────────────────────────────────────────────────────────────┼─────────────────────┤          │        ├───────────────────┼──────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│ google.golang.org/grpc                                       │ GHSA-m425-mq94-257g │          │        │ v1.51.0           │ 1.56.3, 1.57.1, 1.58.3           │ gRPC-Go HTTP/2 Rapid Reset vulnerability                    │
│                                                              │                     │          │        │                   │                                  │ https://github.com/advisories/GHSA-m425-mq94-257g           │
├──────────────────────────────────────────────────────────────┼─────────────────────┼──────────┤        ├───────────────────┼──────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│ stdlib                                                       │ CVE-2024-24790      │ CRITICAL │        │ 1.20.10           │ 1.21.11, 1.22.4                  │ golang: net/netip: Unexpected behavior from Is methods for  │
│                                                              │                     │          │        │                   │                                  │ IPv4-mapped IPv6 addresses                                  │
│                                                              │                     │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2024-24790                  │
│                                                              ├─────────────────────┼──────────┤        │                   ├──────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│                                                              │ CVE-2023-45283      │ HIGH     │        │                   │ 1.20.11, 1.21.4, 1.20.12, 1.21.5 │ The filepath package does not recognize paths with a \??\   │
│                                                              │                     │          │        │                   │                                  │ prefix as...                                                │
│                                                              │                     │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-45283                  │
│                                                              ├─────────────────────┤          │        │                   ├──────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│                                                              │ CVE-2023-45288      │          │        │                   │ 1.21.9, 1.22.2                   │ golang: net/http, x/net/http2: unlimited number of          │
│                                                              │                     │          │        │                   │                                  │ CONTINUATION frames causes DoS                              │
│                                                              │                     │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-45288                  │
└──────────────────────────────────────────────────────────────┴─────────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────────┴─────────────────────────────────────────────────────────────┘
```

After:
```
longhornio/openshift-origin-oauth-proxy:4.15 (redhat 9.2)
=========================================================
Total: 8 (HIGH: 8, CRITICAL: 0)

┌────────────────────────┬────────────────┬──────────┬────────┬───────────────────┬──────────────────┬────────────────────────────────────────────────────────┐
│        Library         │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version   │                         Title                          │
├────────────────────────┼────────────────┼──────────┼────────┼───────────────────┼──────────────────┼────────────────────────────────────────────────────────┤
│ glibc                  │ CVE-2024-2961  │ HIGH     │ fixed  │ 2.34-60.el9_2.7   │ 2.34-60.el9_2.14 │ glibc: Out of bounds write in iconv may lead to remote │
│                        │                │          │        │                   │                  │ code...                                                │
│                        │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2024-2961              │
│                        ├────────────────┤          │        │                   │                  ├────────────────────────────────────────────────────────┤
│                        │ CVE-2024-33599 │          │        │                   │                  │ glibc: stack-based buffer overflow in netgroup cache   │
│                        │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2024-33599             │
├────────────────────────┼────────────────┤          │        │                   │                  ├────────────────────────────────────────────────────────┤
│ glibc-common           │ CVE-2024-2961  │          │        │                   │                  │ glibc: Out of bounds write in iconv may lead to remote │
│                        │                │          │        │                   │                  │ code...                                                │
│                        │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2024-2961              │
│                        ├────────────────┤          │        │                   │                  ├────────────────────────────────────────────────────────┤
│                        │ CVE-2024-33599 │          │        │                   │                  │ glibc: stack-based buffer overflow in netgroup cache   │
│                        │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2024-33599             │
├────────────────────────┼────────────────┤          │        │                   │                  ├────────────────────────────────────────────────────────┤
│ glibc-langpack-en      │ CVE-2024-2961  │          │        │                   │                  │ glibc: Out of bounds write in iconv may lead to remote │
│                        │                │          │        │                   │                  │ code...                                                │
│                        │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2024-2961              │
│                        ├────────────────┤          │        │                   │                  ├────────────────────────────────────────────────────────┤
│                        │ CVE-2024-33599 │          │        │                   │                  │ glibc: stack-based buffer overflow in netgroup cache   │
│                        │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2024-33599             │
├────────────────────────┼────────────────┤          │        │                   │                  ├────────────────────────────────────────────────────────┤
│ glibc-minimal-langpack │ CVE-2024-2961  │          │        │                   │                  │ glibc: Out of bounds write in iconv may lead to remote │
│                        │                │          │        │                   │                  │ code...                                                │
│                        │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2024-2961              │
│                        ├────────────────┤          │        │                   │                  ├────────────────────────────────────────────────────────┤
│                        │ CVE-2024-33599 │          │        │                   │                  │ glibc: stack-based buffer overflow in netgroup cache   │
│                        │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2024-33599             │
└────────────────────────┴────────────────┴──────────┴────────┴───────────────────┴──────────────────┴────────────────────────────────────────────────────────┘

usr/bin/oauth-proxy (gobinary)
==============================
Total: 6 (HIGH: 5, CRITICAL: 1)

┌──────────────────────────────────────────────────────────────┬─────────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────────┬─────────────────────────────────────────────────────────────┐
│                           Library                            │    Vulnerability    │ Severity │ Status │ Installed Version │          Fixed Version           │                            Title                            │
├──────────────────────────────────────────────────────────────┼─────────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│ go.opentelemetry.io/contrib/instrumentation/google.golang.o- │ CVE-2023-47108      │ HIGH     │ fixed  │ v0.35.0           │ 0.46.0                           │ opentelemetry-go-contrib: DoS vulnerability in otelgrpc due │
│ rg/grpc/otelgrpc                                             │                     │          │        │                   │                                  │ to unbound cardinality metrics                              │
│                                                              │                     │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-47108                  │
├──────────────────────────────────────────────────────────────┼─────────────────────┤          │        ├───────────────────┼──────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│ go.opentelemetry.io/contrib/instrumentation/net/http/otelht- │ CVE-2023-45142      │          │        │ v0.35.1           │ 0.44.0                           │ opentelemetry: DoS vulnerability in otelhttp                │
│ tp                                                           │                     │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-45142                  │
├──────────────────────────────────────────────────────────────┼─────────────────────┤          │        ├───────────────────┼──────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│ google.golang.org/grpc                                       │ GHSA-m425-mq94-257g │          │        │ v1.51.0           │ 1.56.3, 1.57.1, 1.58.3           │ gRPC-Go HTTP/2 Rapid Reset vulnerability                    │
│                                                              │                     │          │        │                   │                                  │ https://github.com/advisories/GHSA-m425-mq94-257g           │
├──────────────────────────────────────────────────────────────┼─────────────────────┼──────────┤        ├───────────────────┼──────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│ stdlib                                                       │ CVE-2024-24790      │ CRITICAL │        │ 1.20.10           │ 1.21.11, 1.22.4                  │ golang: net/netip: Unexpected behavior from Is methods for  │
│                                                              │                     │          │        │                   │                                  │ IPv4-mapped IPv6 addresses                                  │
│                                                              │                     │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2024-24790                  │
│                                                              ├─────────────────────┼──────────┤        │                   ├──────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│                                                              │ CVE-2023-45283      │ HIGH     │        │                   │ 1.20.11, 1.21.4, 1.20.12, 1.21.5 │ The filepath package does not recognize paths with a \??\   │
│                                                              │                     │          │        │                   │                                  │ prefix as...                                                │
│                                                              │                     │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-45283                  │
│                                                              ├─────────────────────┤          │        │                   ├──────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│                                                              │ CVE-2023-45288      │          │        │                   │ 1.21.9, 1.22.2                   │ golang: net/http, x/net/http2: unlimited number of          │
│                                                              │                     │          │        │                   │                                  │ CONTINUATION frames causes DoS                              │
│                                                              │                     │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-45288                  │
└──────────────────────────────────────────────────────────────┴─────────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────────┴─────────────────────────────────────────────────────────────┘
```

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

https://github.com/longhorn/longhorn/issues/8976#issuecomment-2230147085

