### PR TITLE
Fix(cve): update Kubernetes external components

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -98,7 +98,7 @@ The `values.yaml` contains items used to tweak a deployment of this chart.
 | image.csi.livenessProbe.repository | string | `"longhornio/livenessprobe"` | Repository for the CSI liveness probe image. When unspecified, Longhorn uses the default value. |
 | image.csi.livenessProbe.tag | string | `"v2.12.0"` | Tag for the CSI liveness probe image. When unspecified, Longhorn uses the default value. |
 | image.csi.nodeDriverRegistrar.repository | string | `"longhornio/csi-node-driver-registrar"` | Repository for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value. |
-| image.csi.nodeDriverRegistrar.tag | string | `"v2.9.2"` | Tag for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value. |
+| image.csi.nodeDriverRegistrar.tag | string | `"v2.10.1"` | Tag for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value. |
 | image.csi.provisioner.repository | string | `"longhornio/csi-provisioner"` | Repository for the CSI Provisioner image. When unspecified, Longhorn uses the default value. |
 | image.csi.provisioner.tag | string | `"v4.0.1"` | Tag for the CSI Provisioner image. When unspecified, Longhorn uses the default value. |
 | image.csi.resizer.repository | string | `"longhornio/csi-resizer"` | Repository for the CSI Resizer image. When unspecified, Longhorn uses the default value. |

--- a/chart/README.md
+++ b/chart/README.md
@@ -94,7 +94,7 @@ The `values.yaml` contains items used to tweak a deployment of this chart.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | image.csi.attacher.repository | string | `"longhornio/csi-attacher"` | Repository for the CSI attacher image. When unspecified, Longhorn uses the default value. |
-| image.csi.attacher.tag | string | `"v4.5.1"` | Tag for the CSI attacher image. When unspecified, Longhorn uses the default value. |
+| image.csi.attacher.tag | string | `"v4.6.1"` | Tag for the CSI attacher image. When unspecified, Longhorn uses the default value. |
 | image.csi.livenessProbe.repository | string | `"longhornio/livenessprobe"` | Repository for the CSI liveness probe image. When unspecified, Longhorn uses the default value. |
 | image.csi.livenessProbe.tag | string | `"v2.12.0"` | Tag for the CSI liveness probe image. When unspecified, Longhorn uses the default value. |
 | image.csi.nodeDriverRegistrar.repository | string | `"longhornio/csi-node-driver-registrar"` | Repository for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value. |

--- a/chart/README.md
+++ b/chart/README.md
@@ -102,7 +102,7 @@ The `values.yaml` contains items used to tweak a deployment of this chart.
 | image.csi.provisioner.repository | string | `"longhornio/csi-provisioner"` | Repository for the CSI Provisioner image. When unspecified, Longhorn uses the default value. |
 | image.csi.provisioner.tag | string | `"v4.0.1"` | Tag for the CSI Provisioner image. When unspecified, Longhorn uses the default value. |
 | image.csi.resizer.repository | string | `"longhornio/csi-resizer"` | Repository for the CSI Resizer image. When unspecified, Longhorn uses the default value. |
-| image.csi.resizer.tag | string | `"v1.10.1"` | Tag for the CSI Resizer image. When unspecified, Longhorn uses the default value. |
+| image.csi.resizer.tag | string | `"v1.11.1"` | Tag for the CSI Resizer image. When unspecified, Longhorn uses the default value. |
 | image.csi.snapshotter.repository | string | `"longhornio/csi-snapshotter"` | Repository for the CSI Snapshotter image. When unspecified, Longhorn uses the default value. |
 | image.csi.snapshotter.tag | string | `"v7.0.2"` | Tag for the CSI Snapshotter image. When unspecified, Longhorn uses the default value. |
 | image.longhorn.backingImageManager.repository | string | `"longhornio/backing-image-manager"` | Repository for the Backing Image Manager image. When unspecified, Longhorn uses the default value. |

--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -101,7 +101,7 @@ questions:
     label: Longhorn CSI Attacher Image Repository
     group: "Longhorn CSI Driver Images"
   - variable: image.csi.attacher.tag
-    default: v4.5.1
+    default: v4.6.1
     description: "Tag for the CSI attacher image. When unspecified, Longhorn uses the default value."
     type: string
     label: Longhorn CSI Attacher Image Tag

--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -137,7 +137,7 @@ questions:
     label: Longhorn CSI Driver Resizer Image Repository
     group: "Longhorn CSI Driver Images"
   - variable: image.csi.resizer.tag
-    default: v1.10.1
+    default: v1.11.1
     description: "Tag for the CSI Resizer image. When unspecified, Longhorn uses the default value."
     type: string
     label: Longhorn CSI Driver Resizer Image Tag

--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -125,7 +125,7 @@ questions:
     label: Longhorn CSI Node Driver Registrar Image Repository
     group: "Longhorn CSI Driver Images"
   - variable: image.csi.nodeDriverRegistrar.tag
-    default: v2.9.2
+    default: v2.10.1
     description: "Tag for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value."
     type: string
     label: Longhorn CSI Node Driver Registrar Image Tag

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -85,7 +85,7 @@ image:
       # -- Repository for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value.
       repository: longhornio/csi-node-driver-registrar
       # -- Tag for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value.
-      tag: v2.9.2
+      tag: v2.10.1
     resizer:
       # -- Repository for the CSI Resizer image. When unspecified, Longhorn uses the default value.
       repository: longhornio/csi-resizer

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -90,7 +90,7 @@ image:
       # -- Repository for the CSI Resizer image. When unspecified, Longhorn uses the default value.
       repository: longhornio/csi-resizer
       # -- Tag for the CSI Resizer image. When unspecified, Longhorn uses the default value.
-      tag: v1.10.1
+      tag: v1.11.1
     snapshotter:
       # -- Repository for the CSI Snapshotter image. When unspecified, Longhorn uses the default value.
       repository: longhornio/csi-snapshotter

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -75,7 +75,7 @@ image:
       # -- Repository for the CSI attacher image. When unspecified, Longhorn uses the default value.
       repository: longhornio/csi-attacher
       # -- Tag for the CSI attacher image. When unspecified, Longhorn uses the default value.
-      tag: v4.5.1
+      tag: v4.6.1
     provisioner:
       # -- Repository for the CSI Provisioner image. When unspecified, Longhorn uses the default value.
       repository: longhornio/csi-provisioner

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -1,6 +1,6 @@
 longhornio/csi-attacher:v4.6.1
 longhornio/csi-provisioner:v4.0.1
-longhornio/csi-resizer:v1.10.1
+longhornio/csi-resizer:v1.11.1
 longhornio/csi-snapshotter:v7.0.2
 longhornio/csi-node-driver-registrar:v2.9.2
 longhornio/livenessprobe:v2.12.0

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -2,7 +2,7 @@ longhornio/csi-attacher:v4.6.1
 longhornio/csi-provisioner:v4.0.1
 longhornio/csi-resizer:v1.11.1
 longhornio/csi-snapshotter:v7.0.2
-longhornio/csi-node-driver-registrar:v2.9.2
+longhornio/csi-node-driver-registrar:v2.10.1
 longhornio/livenessprobe:v2.12.0
 longhornio/openshift-origin-oauth-proxy:4.15
 longhornio/backing-image-manager:master-head

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -1,4 +1,4 @@
-longhornio/csi-attacher:v4.5.1
+longhornio/csi-attacher:v4.6.1
 longhornio/csi-provisioner:v4.0.1
 longhornio/csi-resizer:v1.10.1
 longhornio/csi-snapshotter:v7.0.2

--- a/deploy/longhorn-okd.yaml
+++ b/deploy/longhorn-okd.yaml
@@ -5013,7 +5013,7 @@ spec:
           - name: CSI_NODE_DRIVER_REGISTRAR_IMAGE
             value: "longhornio/csi-node-driver-registrar:v2.9.2"
           - name: CSI_RESIZER_IMAGE
-            value: "longhornio/csi-resizer:v1.10.1"
+            value: "longhornio/csi-resizer:v1.11.1"
           - name: CSI_SNAPSHOTTER_IMAGE
             value: "longhornio/csi-snapshotter:v7.0.2"
           - name: CSI_LIVENESS_PROBE_IMAGE

--- a/deploy/longhorn-okd.yaml
+++ b/deploy/longhorn-okd.yaml
@@ -5007,7 +5007,7 @@ spec:
               fieldRef:
                 fieldPath: spec.serviceAccountName
           - name: CSI_ATTACHER_IMAGE
-            value: "longhornio/csi-attacher:v4.5.1"
+            value: "longhornio/csi-attacher:v4.6.1"
           - name: CSI_PROVISIONER_IMAGE
             value: "longhornio/csi-provisioner:v4.0.1"
           - name: CSI_NODE_DRIVER_REGISTRAR_IMAGE

--- a/deploy/longhorn-okd.yaml
+++ b/deploy/longhorn-okd.yaml
@@ -5011,7 +5011,7 @@ spec:
           - name: CSI_PROVISIONER_IMAGE
             value: "longhornio/csi-provisioner:v4.0.1"
           - name: CSI_NODE_DRIVER_REGISTRAR_IMAGE
-            value: "longhornio/csi-node-driver-registrar:v2.9.2"
+            value: "longhornio/csi-node-driver-registrar:v2.10.1"
           - name: CSI_RESIZER_IMAGE
             value: "longhornio/csi-resizer:v1.11.1"
           - name: CSI_SNAPSHOTTER_IMAGE

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -4966,7 +4966,7 @@ spec:
           - name: CSI_PROVISIONER_IMAGE
             value: "longhornio/csi-provisioner:v4.0.1"
           - name: CSI_NODE_DRIVER_REGISTRAR_IMAGE
-            value: "longhornio/csi-node-driver-registrar:v2.9.2"
+            value: "longhornio/csi-node-driver-registrar:v2.10.1"
           - name: CSI_RESIZER_IMAGE
             value: "longhornio/csi-resizer:v1.11.1"
           - name: CSI_SNAPSHOTTER_IMAGE

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -4962,7 +4962,7 @@ spec:
               fieldRef:
                 fieldPath: spec.serviceAccountName
           - name: CSI_ATTACHER_IMAGE
-            value: "longhornio/csi-attacher:v4.5.1"
+            value: "longhornio/csi-attacher:v4.6.1"
           - name: CSI_PROVISIONER_IMAGE
             value: "longhornio/csi-provisioner:v4.0.1"
           - name: CSI_NODE_DRIVER_REGISTRAR_IMAGE

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -4968,7 +4968,7 @@ spec:
           - name: CSI_NODE_DRIVER_REGISTRAR_IMAGE
             value: "longhornio/csi-node-driver-registrar:v2.9.2"
           - name: CSI_RESIZER_IMAGE
-            value: "longhornio/csi-resizer:v1.10.1"
+            value: "longhornio/csi-resizer:v1.11.1"
           - name: CSI_SNAPSHOTTER_IMAGE
             value: "longhornio/csi-snapshotter:v7.0.2"
           - name: CSI_LIVENESS_PROBE_IMAGE


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#8976

#### What this PR does / why we need it:

Fix CVE issues. For:
- csi-attacher
- csi-resizer
- csi-node-driver-registrar

**csi-attacher:**

Before:
```
csi-attacher (gobinary)
=======================
Total: 3 (HIGH: 2, CRITICAL: 1)

┌──────────────────────────────────────────────────────────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬─────────────────────────────────────────────────────────────┐
│                           Library                            │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                            Title                            │
├──────────────────────────────────────────────────────────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼─────────────────────────────────────────────────────────────┤
│ go.opentelemetry.io/contrib/instrumentation/google.golang.o- │ CVE-2023-47108 │ HIGH     │ fixed  │ v0.44.0           │ 0.46.0          │ opentelemetry-go-contrib: DoS vulnerability in otelgrpc due │
│ rg/grpc/otelgrpc                                             │                │          │        │                   │                 │ to unbound cardinality metrics                              │
│                                                              │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2023-47108                  │
├──────────────────────────────────────────────────────────────┼────────────────┼──────────┤        ├───────────────────┼─────────────────┼─────────────────────────────────────────────────────────────┤
│ stdlib                                                       │ CVE-2024-24790 │ CRITICAL │        │ 1.21.5            │ 1.21.11, 1.22.4 │ golang: net/netip: Unexpected behavior from Is methods for  │
│                                                              │                │          │        │                   │                 │ IPv4-mapped IPv6 addresses                                  │
│                                                              │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24790                  │
│                                                              ├────────────────┼──────────┤        │                   ├─────────────────┼─────────────────────────────────────────────────────────────┤
│                                                              │ CVE-2023-45288 │ HIGH     │        │                   │ 1.21.9, 1.22.2  │ golang: net/http, x/net/http2: unlimited number of          │
│                                                              │                │          │        │                   │                 │ CONTINUATION frames causes DoS                              │
│                                                              │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2023-45288                  │
└──────────────────────────────────────────────────────────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴─────────────────────────────────────────────────────────────┘
```

After:
```
csi-attacher (gobinary)
=======================
Total: 1 (HIGH: 0, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                           Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-24790 │ CRITICAL │ fixed  │ 1.22.3            │ 1.21.11, 1.22.4 │ golang: net/netip: Unexpected behavior from Is methods for │
│         │                │          │        │                   │                 │ IPv4-mapped IPv6 addresses                                 │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24790                 │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴────────────────────────────────────────────────────────────┘
```

**csi-resizer**

Before:
```
longhornio/csi-resizer:v1.10.1 (debian 11.9)
============================================
Total: 0 (HIGH: 0, CRITICAL: 0)


csi-resizer (gobinary)
======================
Total: 3 (HIGH: 2, CRITICAL: 1)

┌──────────────────────────────────────────────────────────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬─────────────────────────────────────────────────────────────┐
│                           Library                            │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                            Title                            │
├──────────────────────────────────────────────────────────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼─────────────────────────────────────────────────────────────┤
│ go.opentelemetry.io/contrib/instrumentation/google.golang.o- │ CVE-2023-47108 │ HIGH     │ fixed  │ v0.44.0           │ 0.46.0          │ opentelemetry-go-contrib: DoS vulnerability in otelgrpc due │
│ rg/grpc/otelgrpc                                             │                │          │        │                   │                 │ to unbound cardinality metrics                              │
│                                                              │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2023-47108                  │
├──────────────────────────────────────────────────────────────┼────────────────┼──────────┤        ├───────────────────┼─────────────────┼─────────────────────────────────────────────────────────────┤
│ stdlib                                                       │ CVE-2024-24790 │ CRITICAL │        │ 1.21.5            │ 1.21.11, 1.22.4 │ golang: net/netip: Unexpected behavior from Is methods for  │
│                                                              │                │          │        │                   │                 │ IPv4-mapped IPv6 addresses                                  │
│                                                              │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24790                  │
│                                                              ├────────────────┼──────────┤        │                   ├─────────────────┼─────────────────────────────────────────────────────────────┤
│                                                              │ CVE-2023-45288 │ HIGH     │        │                   │ 1.21.9, 1.22.2  │ golang: net/http, x/net/http2: unlimited number of          │
│                                                              │                │          │        │                   │                 │ CONTINUATION frames causes DoS                              │
│                                                              │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2023-45288                  │
└──────────────────────────────────────────────────────────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴─────────────────────────────────────────────────────────────┘
```

After:
```
longhornio/csi-resizer:v1.11.1 (debian 12.5)
============================================
Total: 0 (HIGH: 0, CRITICAL: 0)

2024-07-18T07:59:16Z	WARN	Using severities from other vendors for some vulnerabilities. Read https://aquasecurity.github.io/trivy/v0.53/docs/scanner/vulnerability#severity-selection for details.

csi-resizer (gobinary)
======================
Total: 1 (HIGH: 0, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                           Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-24790 │ CRITICAL │ fixed  │ 1.22.3            │ 1.21.11, 1.22.4 │ golang: net/netip: Unexpected behavior from Is methods for │
│         │                │          │        │                   │                 │ IPv4-mapped IPv6 addresses                                 │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24790                 │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴────────────────────────────────────────────────────────────┘
```

**csi-node-driver-registrar**

Before: 
```
longhornio/csi-node-driver-registrar:v2.9.2 (debian 11.8)
=========================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


csi-node-driver-registrar (gobinary)
====================================
Total: 4 (HIGH: 3, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────────┬──────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │          Fixed Version           │                            Title                             │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-24790 │ CRITICAL │ fixed  │ 1.20.5            │ 1.21.11, 1.22.4                  │ golang: net/netip: Unexpected behavior from Is methods for   │
│         │                │          │        │                   │                                  │ IPv4-mapped IPv6 addresses                                   │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2024-24790                   │
│         ├────────────────┼──────────┤        │                   ├──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2023-39325 │ HIGH     │        │                   │ 1.20.10, 1.21.3                  │ golang: net/http, x/net/http2: rapid stream resets can cause │
│         │                │          │        │                   │                                  │ excessive work (CVE-2023-44487)                              │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-39325                   │
│         ├────────────────┤          │        │                   ├──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2023-45283 │          │        │                   │ 1.20.11, 1.21.4, 1.20.12, 1.21.5 │ The filepath package does not recognize paths with a \??\    │
│         │                │          │        │                   │                                  │ prefix as...                                                 │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-45283                   │
│         ├────────────────┤          │        │                   ├──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2023-45288 │          │        │                   │ 1.21.9, 1.22.2                   │ golang: net/http, x/net/http2: unlimited number of           │
│         │                │          │        │                   │                                  │ CONTINUATION frames causes DoS                               │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-45288                   │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────────┴──────────────────────────────────────────────────────────────┘
```

After:
```
longhornio/csi-node-driver-registrar:v2.10.1 (debian 11.9)
==========================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


csi-node-driver-registrar (gobinary)
====================================
Total: 2 (HIGH: 1, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                           Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-24790 │ CRITICAL │ fixed  │ 1.21.5            │ 1.21.11, 1.22.4 │ golang: net/netip: Unexpected behavior from Is methods for │
│         │                │          │        │                   │                 │ IPv4-mapped IPv6 addresses                                 │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24790                 │
│         ├────────────────┼──────────┤        │                   ├─────────────────┼────────────────────────────────────────────────────────────┤
│         │ CVE-2023-45288 │ HIGH     │        │                   │ 1.21.9, 1.22.2  │ golang: net/http, x/net/http2: unlimited number of         │
│         │                │          │        │                   │                 │ CONTINUATION frames causes DoS                             │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2023-45288                 │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴────────────────────────────────────────────────────────────┘
```

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

`None`
