### PR TITLE
feat(csi metrics): enable csi sidecar metrics

### DIFF
--- a/chart/templates/services.yaml
+++ b/chart/templates/services.yaml
@@ -45,3 +45,67 @@ spec:
   - name: recovery-backend
     port: 9503
     targetPort: recov-backend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+    app: longhorn-csi-attacher
+  name: longhorn-csi-attacher
+  namespace: {{ include "release_namespace" . }}
+spec:
+  type: ClusterIP
+  selector:
+    app: csi-attacher
+  ports:
+  - name: csi-attacher
+    port: 8000
+    targetPort: csi-attacher
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+    app: longhorn-csi-provisioner
+  name: longhorn-csi-provisioner
+  namespace: {{ include "release_namespace" . }}
+spec:
+  type: ClusterIP
+  selector:
+    app: csi-provisioner
+  ports:
+  - name: csi-provisioner
+    port: 8000
+    targetPort: csi-provisioner
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+    app: longhorn-csi-resizer
+  name: longhorn-csi-resizer
+  namespace: {{ include "release_namespace" . }}
+spec:
+  type: ClusterIP
+  selector:
+    app: csi-resizer
+  ports:
+  - name: csi-resizer
+    port: 8000
+    targetPort: csi-resizer
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+    app: longhorn-csi-snapshotter
+  name: longhorn-csi-snapshotter
+  namespace: {{ include "release_namespace" . }}
+spec:
+  type: ClusterIP
+  selector:
+    app: csi-snapshotter
+  ports:
+  - name: csi-snapshotter
+    port: 8000
+    targetPort: csi-snapshotter

--- a/deploy/longhorn-okd.yaml
+++ b/deploy/longhorn-okd.yaml
@@ -4863,6 +4863,86 @@ spec:
     port: 9503
     targetPort: recov-backend
 ---
+# Source: longhorn/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.6.0-dev
+    app: longhorn-csi-attacher
+  name: longhorn-csi-attacher
+  namespace: longhorn-system
+spec:
+  type: ClusterIP
+  selector:
+    app: csi-attacher
+  ports:
+  - name: csi-attacher
+    port: 8000
+    targetPort: csi-attacher
+---
+# Source: longhorn/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.6.0-dev
+    app: longhorn-csi-provisioner
+  name: longhorn-csi-provisioner
+  namespace: longhorn-system
+spec:
+  type: ClusterIP
+  selector:
+    app: csi-provisioner
+  ports:
+  - name: csi-provisioner
+    port: 8000
+    targetPort: csi-provisioner
+---
+# Source: longhorn/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.6.0-dev
+    app: longhorn-csi-resizer
+  name: longhorn-csi-resizer
+  namespace: longhorn-system
+spec:
+  type: ClusterIP
+  selector:
+    app: csi-resizer
+  ports:
+  - name: csi-resizer
+    port: 8000
+    targetPort: csi-resizer
+---
+# Source: longhorn/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.6.0-dev
+    app: longhorn-csi-snapshotter
+  name: longhorn-csi-snapshotter
+  namespace: longhorn-system
+spec:
+  type: ClusterIP
+  selector:
+    app: csi-snapshotter
+  ports:
+  - name: csi-snapshotter
+    port: 8000
+    targetPort: csi-snapshotter
+---
 # Source: longhorn/templates/daemonset-sa.yaml
 apiVersion: apps/v1
 kind: DaemonSet

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -4800,6 +4800,86 @@ spec:
     port: 9503
     targetPort: recov-backend
 ---
+# Source: longhorn/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.6.0-dev
+    app: longhorn-csi-attacher
+  name: longhorn-csi-attacher
+  namespace: longhorn-system
+spec:
+  type: ClusterIP
+  selector:
+    app: csi-attacher
+  ports:
+  - name: csi-attacher
+    port: 8000
+    targetPort: csi-attacher
+---
+# Source: longhorn/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.6.0-dev
+    app: longhorn-csi-provisioner
+  name: longhorn-csi-provisioner
+  namespace: longhorn-system
+spec:
+  type: ClusterIP
+  selector:
+    app: csi-provisioner
+  ports:
+  - name: csi-provisioner
+    port: 8000
+    targetPort: csi-provisioner
+---
+# Source: longhorn/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.6.0-dev
+    app: longhorn-csi-resizer
+  name: longhorn-csi-resizer
+  namespace: longhorn-system
+spec:
+  type: ClusterIP
+  selector:
+    app: csi-resizer
+  ports:
+  - name: csi-resizer
+    port: 8000
+    targetPort: csi-resizer
+---
+# Source: longhorn/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.6.0-dev
+    app: longhorn-csi-snapshotter
+  name: longhorn-csi-snapshotter
+  namespace: longhorn-system
+spec:
+  type: ClusterIP
+  selector:
+    app: csi-snapshotter
+  ports:
+  - name: csi-snapshotter
+    port: 8000
+    targetPort: csi-snapshotter
+---
 # Source: longhorn/templates/daemonset-sa.yaml
 apiVersion: apps/v1
 kind: DaemonSet
@@ -4938,18 +5018,18 @@ spec:
     spec:
       initContainers:
         - name: wait-longhorn-manager
-          image: longhornio/longhorn-manager:master-head
+          image: jackfantasy/longhorn-manager:csi_metrics
           command: ['sh', '-c', 'while [ $(curl -m 1 -s -o /dev/null -w "%{http_code}" http://longhorn-backend:9500/v1) != "200" ]; do echo waiting; sleep 2; done']
       containers:
         - name: longhorn-driver-deployer
-          image: longhornio/longhorn-manager:master-head
+          image: jackfantasy/longhorn-manager:csi_metrics
           imagePullPolicy: IfNotPresent
           command:
           - longhorn-manager
           - -d
           - deploy-driver
           - --manager-image
-          - "longhornio/longhorn-manager:master-head"
+          - "jackfantasy/longhorn-manager:csi_metrics"
           - --manager-url
           - http://longhorn-backend:9500/v1
           env:


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/7938

enable csi sidecar metrics on port 8000
- csi-attacher
- csi-provisioner
- csi-resizer
- csi-snapshotter

Add k8s service to allow user to access the metrics through service.

cc @PhanLe1010 