### PR TITLE
fix(lep/storage network for RWX volume): retain custom mounter

### DIFF
--- a/enhancements/20240522-storage-network-for-rwx-volumes.md
+++ b/enhancements/20240522-storage-network-for-rwx-volumes.md
@@ -48,9 +48,8 @@ As a Longhorn user, I want to use the storage network for only RWO volumes to av
 Users will be able to create RWX volumes that uses the storage network for data traffic. Key user-facing changes include:
 
 - **CSI Annotations:** Share manager pods and CSI plugin pods will be annotated with the storage network for NFS client mounting when the `storage-network-for-rwx-volume-enabled` setting is enabled. This annotation will only be applied once all RWX volumes have been detached.
-- **Headless Service:** RWX volume will use a headless service and a custom endpoint, removing dependency on ClusterIP, which is not suitable for Multus networking.
-- **Custom Mounter Replacement:** The custom mounter uses `hostPID` and host `proc` namespace will be replaced with running the CSI plugin with `hostNetwork: true`.
-- **Workload Pod Restart:** When a CSI plugin pod restarts, the NFS share mountpoint becomes unavailable, rendering any attempt to access it unresponsive. User can manually restart the workload pod, or they can enable the `auto-delete-pod-when-volume-detached-unexpectedly` setting. This allows Longhorn to delete the associated workload pod when it is using the storage-network. If the pod is managed by a controller, the kubelet will create a new pod. This allows the CSI controller to handle volume remounting through the CSI node server.
+- **Headless Service:** storage network enabled RWX volume will use a headless service and a custom endpoint, removing dependency on ClusterIP, which is not suitable for Multus networking.
+- **Workload Pod Restart:** When a CSI plugin pod restarts, the NFS share mountpoint becomes unavailable, rendering any attempt to access it unresponsive. User can manually restart the workload pod, or they can enable the `auto-delete-pod-when-volume-detached-unexpectedly` setting. This allows Longhorn to delete the associated workload pod when it is using the storage-network enabled RWX volume. If the pod is managed by a controller, the kubelet will create a new pod. This allows the CSI controller to handle volume remounting through the CSI node server.
 - **Upgrade to Longhorn v1.7.0:** Existing RWX volumes remain unchanged if the storage network is configured before the upgrade. To apply the storage network for RWX volumes, detach all RWX volumes, enable the `storage-network-for-rwx-volume-enabled` setting, and reattach the volumes.
 
 ### API changes
@@ -63,7 +62,7 @@ No API changes are required for this proposal.
 
 A new setting, `storage-network-for-rwx-volume-enabled`, allows controlling the application of the storage network for RWX volumes.
 
-When the CSI plugin pod of a workload using the storage network and RWX volume restarts, the workload pod also needs a restart to re-establish the NFS client mount connection. This setting enabled user to manage whether the storage network should be applied to the RWX volumes. For RWX volumes using the cluster network, no restart is required during the CSI plugin pod restarts.
+When the CSI plugin pod of a workload using the storage network enabled RWX volume restarts, the workload pod also needs a restart to re-establish the NFS client mount connection. This setting enabled user to manage whether the storage network should be applied to the RWX volumes. For RWX volumes using the cluster network, no restart is required during the CSI plugin pod restarts.
 
 ```golang
 	SettingDefinitionStorageNetworkForRWXVolumeEnabled = SettingDefinition{
@@ -114,7 +113,7 @@ service.Spec.ClusterIP = "None"
 	}
 ```
 
-The share manager will use the service FQDN for its endpoint instead of the value from service `ClusterIP` field.
+The share manager of the storage network enabled RWX volume will use the service FQDN for its endpoint instead of the value from service `ClusterIP` field.
 
 ```yaml
 endpoint: nfs://pvc-117d3553-1a2c-4b42-aa49-2b221dfb5cd9.longhorn-system.svc.cluster.local/pvc-117d3553-1a2c-4b42-aa49-2b221dfb5cd9
@@ -150,15 +149,13 @@ Introduce a new Kubernetes Endpoint controller to watch over share manager pod r
 
 ### Share Manager Process Namespaces
 
-Currently, the CSI plugin pod uses `HostPID` and mounts the host `proc` directory to be used by the custom mounter. This custom mounter wraps the commands (e.g., mount and umount) with `nsenter` to access the host namespaces, ensuring that the Kernel NFS client is tied to the host network namespace.
-
-This design ensures the NFS share mount persists after the CSI plugin pod restarts. However, this can be achieved without `HostPID` and the `nsenter` in the custom mounter, as long as the NFS client connection is established within the host network namespace. Therefore, the custom mounter will be removed and replaced with `hostNetwork:true` in the CSI plugin pod for RWX volumes without the storage network configured.
+Currently, the CSI plugin pod uses `HostPID` and mounts the host `proc` directory to be used by the custom mounter. This custom mounter wraps the commands (e.g., mount and umount) with `nsenter` to access the host namespaces, ensuring that the Kernel NFS client is tied to the host network namespace. This design ensures the NFS share mount persists after the CSI plugin pod restarts.
 
 A difference approach is required when the storage network is configured. Multus networks exist only in the Kubernetes network space. Therefore, for RWX volumes with a storage-network, the CSI plugin pod cannot run in the host network. When a RWX volume uses the storage network, the CSI plugin operate in its own network namespace. Since the NFS mount is managed by the Kernel module, the client is unaware of the client namespace is tied to the CSI plugin pod, resulting in a dangling mount after the CSI plugin pod restart. To workaround this, Longhorn will delete the workload pod (triggering its controller to restart the pod) to allow the CSI controller to handle the remount through the CSI node server's *NodeUnpublishVolume* and *NodePublishVolume*.
 
 ### Kubernetes Pod Controller
 
-Introduce a new responsibility to the Kubernetes pod controller: deleting workload pods that use the RWX volume and storage network when the CSI plugin pod restarts (during *Delete* operations). When a workload pod is deleted, its owning controller should create a new pod, initiating the normal volume attachment process. This process involves the CSI controller requesting the node server to unmount and mount the mount points, re-establishing the connection of the dangling mount. However, this approach results in a temporary disruption to the workload pod. Therefore, users can control this behavior using the `auto-delete-pod-when-volume-detached-unexpectedly` setting.
+Introduce a new responsibility to the Kubernetes pod controller: deleting workload pods that use the storage network enabled RWX volume when the CSI plugin pod restarts (during *Delete* operations). When a workload pod is deleted, its owning controller should create a new pod, initiating the normal volume attachment process. This process involves the CSI controller requesting the node server to unmount and mount the mount points, re-establishing the connection of the dangling mount. However, this approach results in a temporary disruption to the workload pod. Therefore, users can control this behavior using the `auto-delete-pod-when-volume-detached-unexpectedly` setting.
 
 The controller will not trigger RWX volume workload pod deletion in the following scenarios:
 - Storage network setting is not configured.
@@ -189,4 +186,5 @@ To resolve this issue, user have two options:
 
 ## Note [optional]
 
-The [original issue](https://github.com/longhorn/longhorn/issues/8184) includes discussions about the workload data directory becoming unresponsive after the CSI plugin pod restarts. To address this, there is an initial consensus on a solution that involves deleting the workload pod. This approach effectively re-establish the mount point, ensuring continued data accessibility.
+- The [original issue](https://github.com/longhorn/longhorn/issues/8184) includes discussions about the workload data directory becoming unresponsive after the CSI plugin pod restarts. To address this, there is an initial consensus on a solution that involves deleting the workload pod. This approach effectively re-establish the mount point, ensuring continued data accessibility.
+- The [[BUG] Networking between longhorn-csi-plugin and longhorn-manager is broken after upgrading Longhorn to 1.7.0-rc3](https://github.com/longhorn/longhorn/issues/9223) includes reason for retaining the custom mounter and the use of *ClusterIP* for the regular RWX volume share manager endpoint.


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#9223

#### What this PR does / why we need it:

Update LEP to reflect the fix from https://github.com/longhorn/longhorn/issues/9223.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

`None`
