### PR TITLE
fix(cve): update external components

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -96,7 +96,7 @@ The `values.yaml` contains items used to tweak a deployment of this chart.
 | image.csi.attacher.repository | string | `"longhornio/csi-attacher"` | Repository for the CSI attacher image. When unspecified, Longhorn uses the default value. |
 | image.csi.attacher.tag | string | `"v4.6.1"` | Tag for the CSI attacher image. When unspecified, Longhorn uses the default value. |
 | image.csi.livenessProbe.repository | string | `"longhornio/livenessprobe"` | Repository for the CSI liveness probe image. When unspecified, Longhorn uses the default value. |
-| image.csi.livenessProbe.tag | string | `"v2.13.1"` | Tag for the CSI liveness probe image. When unspecified, Longhorn uses the default value. |
+| image.csi.livenessProbe.tag | string | `"v2.14.0"` | Tag for the CSI liveness probe image. When unspecified, Longhorn uses the default value. |
 | image.csi.nodeDriverRegistrar.repository | string | `"longhornio/csi-node-driver-registrar"` | Repository for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value. |
 | image.csi.nodeDriverRegistrar.tag | string | `"v2.12.0"` | Tag for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value. |
 | image.csi.provisioner.repository | string | `"longhornio/csi-provisioner"` | Repository for the CSI Provisioner image. When unspecified, Longhorn uses the default value. |

--- a/chart/README.md
+++ b/chart/README.md
@@ -98,7 +98,7 @@ The `values.yaml` contains items used to tweak a deployment of this chart.
 | image.csi.livenessProbe.repository | string | `"longhornio/livenessprobe"` | Repository for the CSI liveness probe image. When unspecified, Longhorn uses the default value. |
 | image.csi.livenessProbe.tag | string | `"v2.13.1"` | Tag for the CSI liveness probe image. When unspecified, Longhorn uses the default value. |
 | image.csi.nodeDriverRegistrar.repository | string | `"longhornio/csi-node-driver-registrar"` | Repository for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value. |
-| image.csi.nodeDriverRegistrar.tag | string | `"v2.11.1"` | Tag for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value. |
+| image.csi.nodeDriverRegistrar.tag | string | `"v2.12.0"` | Tag for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value. |
 | image.csi.provisioner.repository | string | `"longhornio/csi-provisioner"` | Repository for the CSI Provisioner image. When unspecified, Longhorn uses the default value. |
 | image.csi.provisioner.tag | string | `"v4.0.1"` | Tag for the CSI Provisioner image. When unspecified, Longhorn uses the default value. |
 | image.csi.resizer.repository | string | `"longhornio/csi-resizer"` | Repository for the CSI Resizer image. When unspecified, Longhorn uses the default value. |

--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -125,7 +125,7 @@ questions:
     label: Longhorn CSI Node Driver Registrar Image Repository
     group: "Longhorn CSI Driver Images"
   - variable: image.csi.nodeDriverRegistrar.tag
-    default: v2.11.1
+    default: v2.12.0
     description: "Tag for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value."
     type: string
     label: Longhorn CSI Node Driver Registrar Image Tag

--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -161,7 +161,7 @@ questions:
     label: Longhorn CSI Liveness Probe Image Repository
     group: "Longhorn CSI Driver Images"
   - variable: image.csi.livenessProbe.tag
-    default: v2.13.1
+    default: v2.14.0
     description: "Tag for the CSI liveness probe image. When unspecified, Longhorn uses the default value."
     type: string
     label: Longhorn CSI Liveness Probe Image Tag

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -100,7 +100,7 @@ image:
       # -- Repository for the CSI liveness probe image. When unspecified, Longhorn uses the default value.
       repository: longhornio/livenessprobe
       # -- Tag for the CSI liveness probe image. When unspecified, Longhorn uses the default value.
-      tag: v2.13.1
+      tag: v2.14.0
   openshift:
     oauthProxy:
       # -- Repository for the OAuth Proxy image. This setting applies only to OpenShift users.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -85,7 +85,7 @@ image:
       # -- Repository for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value.
       repository: longhornio/csi-node-driver-registrar
       # -- Tag for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value.
-      tag: v2.11.1
+      tag: v2.12.0
     resizer:
       # -- Repository for the CSI Resizer image. When unspecified, Longhorn uses the default value.
       repository: longhornio/csi-resizer

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -2,7 +2,7 @@ longhornio/csi-attacher:v4.6.1
 longhornio/csi-provisioner:v4.0.1
 longhornio/csi-resizer:v1.11.1
 longhornio/csi-snapshotter:v7.0.2
-longhornio/csi-node-driver-registrar:v2.11.1
+longhornio/csi-node-driver-registrar:v2.12.0
 longhornio/livenessprobe:v2.13.1
 longhornio/openshift-origin-oauth-proxy:4.15
 longhornio/backing-image-manager:master-head

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -3,7 +3,7 @@ longhornio/csi-provisioner:v4.0.1
 longhornio/csi-resizer:v1.11.1
 longhornio/csi-snapshotter:v7.0.2
 longhornio/csi-node-driver-registrar:v2.12.0
-longhornio/livenessprobe:v2.13.1
+longhornio/livenessprobe:v2.14.0
 longhornio/openshift-origin-oauth-proxy:4.15
 longhornio/backing-image-manager:master-head
 longhornio/longhorn-engine:master-head

--- a/deploy/longhorn-okd.yaml
+++ b/deploy/longhorn-okd.yaml
@@ -5109,7 +5109,7 @@ spec:
           - name: CSI_SNAPSHOTTER_IMAGE
             value: "longhornio/csi-snapshotter:v7.0.2"
           - name: CSI_LIVENESS_PROBE_IMAGE
-            value: "longhornio/livenessprobe:v2.13.1"
+            value: "longhornio/livenessprobe:v2.14.0"
       priorityClassName: "longhorn-critical"
       serviceAccountName: longhorn-service-account
       securityContext:

--- a/deploy/longhorn-okd.yaml
+++ b/deploy/longhorn-okd.yaml
@@ -5103,7 +5103,7 @@ spec:
           - name: CSI_PROVISIONER_IMAGE
             value: "longhornio/csi-provisioner:v4.0.1"
           - name: CSI_NODE_DRIVER_REGISTRAR_IMAGE
-            value: "longhornio/csi-node-driver-registrar:v2.11.1"
+            value: "longhornio/csi-node-driver-registrar:v2.12.0"
           - name: CSI_RESIZER_IMAGE
             value: "longhornio/csi-resizer:v1.11.1"
           - name: CSI_SNAPSHOTTER_IMAGE

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -5040,7 +5040,7 @@ spec:
           - name: CSI_PROVISIONER_IMAGE
             value: "longhornio/csi-provisioner:v4.0.1"
           - name: CSI_NODE_DRIVER_REGISTRAR_IMAGE
-            value: "longhornio/csi-node-driver-registrar:v2.11.1"
+            value: "longhornio/csi-node-driver-registrar:v2.12.0"
           - name: CSI_RESIZER_IMAGE
             value: "longhornio/csi-resizer:v1.11.1"
           - name: CSI_SNAPSHOTTER_IMAGE

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -5046,7 +5046,7 @@ spec:
           - name: CSI_SNAPSHOTTER_IMAGE
             value: "longhornio/csi-snapshotter:v7.0.2"
           - name: CSI_LIVENESS_PROBE_IMAGE
-            value: "longhornio/livenessprobe:v2.13.1"
+            value: "longhornio/livenessprobe:v2.14.0"
       priorityClassName: "longhorn-critical"
       serviceAccountName: longhorn-service-account
       securityContext:


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#9354

#### What this PR does / why we need it:

Fix CVE issues.

Before:
```
longhornio/csi-node-driver-registrar:v2.11.1 (debian 12.6)
==========================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


csi-node-driver-registrar (gobinary)
====================================
Total: 1 (HIGH: 0, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                           Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-24790 │ CRITICAL │ fixed  │ 1.22.3            │ 1.21.11, 1.22.4 │ golang: net/netip: Unexpected behavior from Is methods for │
│         │                │          │        │                   │                 │ IPv4-mapped IPv6 addresses                                 │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24790                 │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴────────────────────────────────────────────────────────────┘
```
```
longhornio/livenessprobe:v2.13.1 (debian 12.6)
==============================================
Total: 0 (HIGH: 0, CRITICAL: 0)


livenessprobe (gobinary)
========================
Total: 1 (HIGH: 0, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                           Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-24790 │ CRITICAL │ fixed  │ 1.22.3            │ 1.21.11, 1.22.4 │ golang: net/netip: Unexpected behavior from Is methods for │
│         │                │          │        │                   │                 │ IPv4-mapped IPv6 addresses                                 │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24790                 │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴────────────────────────────────────────────────────────────┘
```

After:
```
longhornio/csi-node-driver-registrar:v2.12.0 (debian 12.6)
==========================================================
Total: 0 (HIGH: 0, CRITICAL: 0)
```
```
longhornio/livenessprobe:v2.14.0 (debian 12.6)
==============================================
Total: 0 (HIGH: 0, CRITICAL: 0)
```

#### Special notes for your reviewer:

- TODO: backport to v1.7.x

#### Additional documentation or context

`None`
