### PR TITLE
fix(metrics): add rwx-volume-fast-failover to upgrade responder chart

### DIFF
--- a/deploy/upgrade_responder_server/chart-values.yaml
+++ b/deploy/upgrade_responder_server/chart-values.yaml
@@ -134,6 +134,10 @@ configMap:
           "dataType": "string",
           "maxLen": 200
         },
+        "longhornSettingFreezeFilesystemForSnapshot": {
+          "dataType": "string",
+          "maxLen": 200
+        },
         "longhornSettingKubernetesClusterAutoscalerEnabled": {
           "dataType": "string",
           "maxLen": 200
@@ -182,6 +186,10 @@ configMap:
           "dataType": "string",
           "maxLen": 200
         },
+        "longhornSettingRwxVolumeFastFailover": {
+          "dataType": "string",
+          "maxLen": 200
+        },
         "longhornSettingSnapshotDataIntegrity": {
           "dataType": "string",
           "maxLen": 200
@@ -215,10 +223,6 @@ configMap:
           "maxLen": 200
         },
         "longhornSettingV2DataEngine": {
-          "dataType": "string",
-          "maxLen": 200
-        },
-        "longhornSettingFreezeFilesystemForSnapshot"
           "dataType": "string",
           "maxLen": 200
         }
@@ -357,6 +361,9 @@ configMap:
         "longhornVolumeDataLocalityStrictLocalCount": {
           "dataType": "float"
         },
+        "longhornVolumeFreezeFilesystemForSnapshotTrueCount": {
+          "dataType": "float"
+        },
         "longhornVolumeFrontendBlockdevCount": {
           "dataType": "float"
         },
@@ -385,9 +392,6 @@ configMap:
           "dataType": "float"
         },
         "longhornVolumeUnmapMarkSnapChainRemovedFalseCount": {
-          "dataType": "float"
-        },
-        "longhornVolumeFreezeFilesystemForSnapshotTrueCount": {
           "dataType": "float"
         }
       }


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/longhorn/longhorn/issues/9347

#### What this PR does / why we need it:

Called out as necessary by @PhanLe1010 in https://github.com/longhorn/longhorn-manager/pull/3121#issuecomment-2327136164

#### Special notes for your reviewer:

#### Additional documentation or context

Also moved entries for `FreezeFilesystemForSnapshot` to keep the list alphabetized, and added some missing `{}`.
Made my best guess as to the capitalization of the setting tag.
