### PR TITLE
fix(cve): update support-bundle-kit to 0.0.43

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -116,7 +116,7 @@ The `values.yaml` contains items used to tweak a deployment of this chart.
 | image.longhorn.shareManager.repository | string | `"longhornio/longhorn-share-manager"` | Repository for the Longhorn Share Manager image. |
 | image.longhorn.shareManager.tag | string | `"master-head"` | Tag for the Longhorn Share Manager image. |
 | image.longhorn.supportBundleKit.repository | string | `"longhornio/support-bundle-kit"` | Repository for the Longhorn Support Bundle Manager image. |
-| image.longhorn.supportBundleKit.tag | string | `"v0.0.42"` | Tag for the Longhorn Support Bundle Manager image. |
+| image.longhorn.supportBundleKit.tag | string | `"v0.0.43"` | Tag for the Longhorn Support Bundle Manager image. |
 | image.longhorn.ui.repository | string | `"longhornio/longhorn-ui"` | Repository for the Longhorn UI image. |
 | image.longhorn.ui.tag | string | `"master-head"` | Tag for the Longhorn UI image. |
 | image.openshift.oauthProxy.repository | string | `"longhornio/openshift-origin-oauth-proxy"` | Repository for the OAuth Proxy image. This setting applies only to OpenShift users. |

--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -89,7 +89,7 @@ questions:
     label: Longhorn Support Bundle Kit Image Repository
     group: "Longhorn Images Settings"
   - variable: image.longhorn.supportBundleKit.tag
-    default: v0.0.42
+    default: v0.0.43
     description: "Tag for the Longhorn Support Bundle Manager image."
     type: string
     label: Longhorn Support Bundle Kit Image Tag

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -69,7 +69,7 @@ image:
       # -- Repository for the Longhorn Support Bundle Manager image.
       repository: longhornio/support-bundle-kit
       # -- Tag for the Longhorn Support Bundle Manager image.
-      tag: v0.0.42
+      tag: v0.0.43
   csi:
     attacher:
       # -- Repository for the CSI attacher image. When unspecified, Longhorn uses the default value.

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -12,4 +12,4 @@ longhornio/longhorn-manager:master-head
 longhornio/longhorn-share-manager:master-head
 longhornio/longhorn-ui:master-head
 longhornio/longhorn-cli:master-head
-longhornio/support-bundle-kit:v0.0.42
+longhornio/support-bundle-kit:v0.0.43

--- a/deploy/longhorn-okd.yaml
+++ b/deploy/longhorn-okd.yaml
@@ -4991,7 +4991,7 @@ spec:
         - --backing-image-manager-image
         - "longhornio/backing-image-manager:master-head"
         - --support-bundle-manager-image
-        - "longhornio/support-bundle-kit:v0.0.42"
+        - "longhornio/support-bundle-kit:v0.0.43"
         - --manager-image
         - "longhornio/longhorn-manager:master-head"
         - --service-account

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -4928,7 +4928,7 @@ spec:
         - --backing-image-manager-image
         - "longhornio/backing-image-manager:master-head"
         - --support-bundle-manager-image
-        - "longhornio/support-bundle-kit:v0.0.42"
+        - "longhornio/support-bundle-kit:v0.0.43"
         - --manager-image
         - "longhornio/longhorn-manager:master-head"
         - --service-account


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#9132

#### What this PR does / why we need it:

Fix CVE issues.

Before:
```
longhornio/support-bundle-kit:v0.0.42 (suse linux enterprise server 15.6)
=========================================================================
Total: 3 (HIGH: 3, CRITICAL: 0)

┌────────────────────────────┬─────────────────────┬──────────┬────────┬─────────────────────┬─────────────────────┬───────────────────────────────┐
│          Library           │    Vulnerability    │ Severity │ Status │  Installed Version  │    Fixed Version    │             Title             │
├────────────────────────────┼─────────────────────┼──────────┼────────┼─────────────────────┼─────────────────────┼───────────────────────────────┤
│ libopenssl-3-fips-provider │ SUSE-SU-2024:3106-1 │ HIGH     │ fixed  │ 3.1.4-150600.5.10.1 │ 3.1.4-150600.5.15.1 │ Security update for openssl-3 │
├────────────────────────────┤                     │          │        │                     │                     │                               │
│ libopenssl3                │                     │          │        │                     │                     │                               │
├────────────────────────────┤                     │          │        │                     │                     │                               │
│ openssl-3                  │                     │          │        │                     │                     │                               │
└────────────────────────────┴─────────────────────┴──────────┴────────┴─────────────────────┴─────────────────────┴───────────────────────────────┘
```

After:
```
longhornio/support-bundle-kit:v0.0.43 (suse linux enterprise server 15.6)
=========================================================================
Total: 0 (HIGH: 0, CRITICAL: 0)
```

#### Special notes for your reviewer:

- TODO: backport to v1.7.x and v1.6.x.

#### Additional documentation or context

`None`
