### PR TITLE
fix(cve): update external dependencies

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -120,7 +120,7 @@ The `values.yaml` contains items used to tweak a deployment of this chart.
 | image.longhorn.ui.repository | string | `"longhornio/longhorn-ui"` | Repository for the Longhorn UI image. |
 | image.longhorn.ui.tag | string | `"v1.6.1"` | Specify Longhorn ui image tag |
 | image.openshift.oauthProxy.repository | string | `"longhornio/openshift-origin-oauth-proxy"` | Repository for the OAuth Proxy image. This setting applies only to OpenShift users. |
-| image.openshift.oauthProxy.tag | float | `4.14` | Tag for the OAuth Proxy image. This setting applies only to OpenShift users. Specify OCP/OKD version 4.1 or later. The latest stable version is 4.14. |
+| image.openshift.oauthProxy.tag | float | `4.15` | Tag for the OAuth Proxy image. This setting applies only to OpenShift users. Specify OCP/OKD version 4.1 or later. The latest stable version is 4.15. |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy that applies to all user-deployed Longhorn components, such as Longhorn Manager, Longhorn driver, and Longhorn UI. |
 
 ### Service Settings

--- a/chart/README.md
+++ b/chart/README.md
@@ -102,7 +102,7 @@ The `values.yaml` contains items used to tweak a deployment of this chart.
 | image.csi.provisioner.repository | string | `"longhornio/csi-provisioner"` | Repository for the CSI Provisioner image. When unspecified, Longhorn uses the default value. |
 | image.csi.provisioner.tag | string | `"v3.6.4"` | Tag for the CSI Provisioner image. When unspecified, Longhorn uses the default value. |
 | image.csi.resizer.repository | string | `"longhornio/csi-resizer"` | Repository for the CSI Resizer image. When unspecified, Longhorn uses the default value. |
-| image.csi.resizer.tag | string | `"v1.10.1"` | Tag for the CSI Resizer image. When unspecified, Longhorn uses the default value. |
+| image.csi.resizer.tag | string | `"v1.12.0"` | Tag for the CSI Resizer image. When unspecified, Longhorn uses the default value. |
 | image.csi.snapshotter.repository | string | `"longhornio/csi-snapshotter"` | Repository for the CSI Snapshotter image. When unspecified, Longhorn uses the default value. |
 | image.csi.snapshotter.tag | string | `"v6.3.4"` | Tag for the CSI Snapshotter image. When unspecified, Longhorn uses the default value. |
 | image.longhorn.backingImageManager.repository | string | `"longhornio/backing-image-manager"` | Repository for the Backing Image Manager image. When unspecified, Longhorn uses the default value. |

--- a/chart/README.md
+++ b/chart/README.md
@@ -94,7 +94,7 @@ The `values.yaml` contains items used to tweak a deployment of this chart.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | image.csi.attacher.repository | string | `"longhornio/csi-attacher"` | Repository for the CSI attacher image. When unspecified, Longhorn uses the default value. |
-| image.csi.attacher.tag | string | `"v4.5.1"` | Tag for the CSI attacher image. When unspecified, Longhorn uses the default value. |
+| image.csi.attacher.tag | string | `"v4.7.0"` | Tag for the CSI attacher image. When unspecified, Longhorn uses the default value. |
 | image.csi.livenessProbe.repository | string | `"longhornio/livenessprobe"` | Repository for the CSI liveness probe image. When unspecified, Longhorn uses the default value. |
 | image.csi.livenessProbe.tag | string | `"v2.12.0"` | Tag for the CSI liveness probe image. When unspecified, Longhorn uses the default value. |
 | image.csi.nodeDriverRegistrar.repository | string | `"longhornio/csi-node-driver-registrar"` | Repository for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value. |

--- a/chart/README.md
+++ b/chart/README.md
@@ -98,7 +98,7 @@ The `values.yaml` contains items used to tweak a deployment of this chart.
 | image.csi.livenessProbe.repository | string | `"longhornio/livenessprobe"` | Repository for the CSI liveness probe image. When unspecified, Longhorn uses the default value. |
 | image.csi.livenessProbe.tag | string | `"v2.12.0"` | Tag for the CSI liveness probe image. When unspecified, Longhorn uses the default value. |
 | image.csi.nodeDriverRegistrar.repository | string | `"longhornio/csi-node-driver-registrar"` | Repository for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value. |
-| image.csi.nodeDriverRegistrar.tag | string | `"v2.9.2"` | Tag for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value. |
+| image.csi.nodeDriverRegistrar.tag | string | `"v2.12.0"` | Tag for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value. |
 | image.csi.provisioner.repository | string | `"longhornio/csi-provisioner"` | Repository for the CSI Provisioner image. When unspecified, Longhorn uses the default value. |
 | image.csi.provisioner.tag | string | `"v3.6.4"` | Tag for the CSI Provisioner image. When unspecified, Longhorn uses the default value. |
 | image.csi.resizer.repository | string | `"longhornio/csi-resizer"` | Repository for the CSI Resizer image. When unspecified, Longhorn uses the default value. |

--- a/chart/README.md
+++ b/chart/README.md
@@ -96,7 +96,7 @@ The `values.yaml` contains items used to tweak a deployment of this chart.
 | image.csi.attacher.repository | string | `"longhornio/csi-attacher"` | Repository for the CSI attacher image. When unspecified, Longhorn uses the default value. |
 | image.csi.attacher.tag | string | `"v4.7.0"` | Tag for the CSI attacher image. When unspecified, Longhorn uses the default value. |
 | image.csi.livenessProbe.repository | string | `"longhornio/livenessprobe"` | Repository for the CSI liveness probe image. When unspecified, Longhorn uses the default value. |
-| image.csi.livenessProbe.tag | string | `"v2.12.0"` | Tag for the CSI liveness probe image. When unspecified, Longhorn uses the default value. |
+| image.csi.livenessProbe.tag | string | `"v2.14.0"` | Tag for the CSI liveness probe image. When unspecified, Longhorn uses the default value. |
 | image.csi.nodeDriverRegistrar.repository | string | `"longhornio/csi-node-driver-registrar"` | Repository for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value. |
 | image.csi.nodeDriverRegistrar.tag | string | `"v2.12.0"` | Tag for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value. |
 | image.csi.provisioner.repository | string | `"longhornio/csi-provisioner"` | Repository for the CSI Provisioner image. When unspecified, Longhorn uses the default value. |

--- a/chart/ocp-readme.md
+++ b/chart/ocp-readme.md
@@ -145,7 +145,7 @@ Minimum Adjustments Required
 openshift:
   oauthProxy:
     repository: quay.io/openshift/origin-oauth-proxy
-    tag: 4.14  # Use Your OCP/OKD 4.X Version, Current Stable is 4.14
+    tag: 4.15  # Use Your OCP/OKD 4.X Version, Current Stable is 4.15
 
 # defaultSettings: # Preparing nodes (Optional)
   # createDefaultDiskLabeledNodes: true

--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -137,7 +137,7 @@ questions:
     label: Longhorn CSI Driver Resizer Image Repository
     group: "Longhorn CSI Driver Images"
   - variable: image.csi.resizer.tag
-    default: v1.10.1
+    default: v1.12.0
     description: "Tag for the CSI Resizer image. When unspecified, Longhorn uses the default value."
     type: string
     label: Longhorn CSI Driver Resizer Image Tag

--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -101,7 +101,7 @@ questions:
     label: Longhorn CSI Attacher Image Repository
     group: "Longhorn CSI Driver Images"
   - variable: image.csi.attacher.tag
-    default: v4.5.1
+    default: v4.7.0
     description: "Tag for the CSI attacher image. When unspecified, Longhorn uses the default value."
     type: string
     label: Longhorn CSI Attacher Image Tag

--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -173,7 +173,7 @@ questions:
     label: OpenShift OAuth Proxy Image Repository
     group: "OpenShift Images"
   - variable: image.openshift.oauthProxy.tag
-    default: 4.14
+    default: 4.15
     description: "Tag for the OAuth Proxy image. This setting applies only to OpenShift users. Specify OCP/OKD version 4.1 or later."
     type: string
     label: OpenShift OAuth Proxy Image Tag

--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -161,7 +161,7 @@ questions:
     label: Longhorn CSI Liveness Probe Image Repository
     group: "Longhorn CSI Driver Images"
   - variable: image.csi.livenessProbe.tag
-    default: v2.12.0
+    default: v2.14.0
     description: "Tag for the CSI liveness probe image. When unspecified, Longhorn uses the default value."
     type: string
     label: Longhorn CSI Liveness Probe Image Tag

--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -125,7 +125,7 @@ questions:
     label: Longhorn CSI Node Driver Registrar Image Repository
     group: "Longhorn CSI Driver Images"
   - variable: image.csi.nodeDriverRegistrar.tag
-    default: v2.9.2
+    default: v2.12.0
     description: "Tag for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value."
     type: string
     label: Longhorn CSI Node Driver Registrar Image Tag

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -85,7 +85,7 @@ image:
       # -- Repository for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value.
       repository: longhornio/csi-node-driver-registrar
       # -- Tag for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value.
-      tag: v2.9.2
+      tag: v2.12.0
     resizer:
       # -- Repository for the CSI Resizer image. When unspecified, Longhorn uses the default value.
       repository: longhornio/csi-resizer

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -100,7 +100,7 @@ image:
       # -- Repository for the CSI liveness probe image. When unspecified, Longhorn uses the default value.
       repository: longhornio/livenessprobe
       # -- Tag for the CSI liveness probe image. When unspecified, Longhorn uses the default value.
-      tag: v2.12.0
+      tag: v2.14.0
   openshift:
     oauthProxy:
       # -- Repository for the OAuth Proxy image. This setting applies only to OpenShift users.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -75,7 +75,7 @@ image:
       # -- Repository for the CSI attacher image. When unspecified, Longhorn uses the default value.
       repository: longhornio/csi-attacher
       # -- Tag for the CSI attacher image. When unspecified, Longhorn uses the default value.
-      tag: v4.5.1
+      tag: v4.7.0
     provisioner:
       # -- Repository for the CSI Provisioner image. When unspecified, Longhorn uses the default value.
       repository: longhornio/csi-provisioner

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -90,7 +90,7 @@ image:
       # -- Repository for the CSI Resizer image. When unspecified, Longhorn uses the default value.
       repository: longhornio/csi-resizer
       # -- Tag for the CSI Resizer image. When unspecified, Longhorn uses the default value.
-      tag: v1.10.1
+      tag: v1.12.0
     snapshotter:
       # -- Repository for the CSI Snapshotter image. When unspecified, Longhorn uses the default value.
       repository: longhornio/csi-snapshotter

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -105,8 +105,8 @@ image:
     oauthProxy:
       # -- Repository for the OAuth Proxy image. This setting applies only to OpenShift users.
       repository: longhornio/openshift-origin-oauth-proxy
-      # -- Tag for the OAuth Proxy image. This setting applies only to OpenShift users. Specify OCP/OKD version 4.1 or later. The latest stable version is 4.14.
-      tag: 4.14
+      # -- Tag for the OAuth Proxy image. This setting applies only to OpenShift users. Specify OCP/OKD version 4.1 or later. The latest stable version is 4.15.
+      tag: 4.15
   # -- Image pull policy that applies to all user-deployed Longhorn components, such as Longhorn Manager, Longhorn driver, and Longhorn UI.
   pullPolicy: IfNotPresent
 

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -1,4 +1,4 @@
-longhornio/csi-attacher:v4.5.1
+longhornio/csi-attacher:v4.7.0
 longhornio/csi-provisioner:v3.6.4
 longhornio/csi-resizer:v1.10.1
 longhornio/csi-snapshotter:v6.3.4

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -1,6 +1,6 @@
 longhornio/csi-attacher:v4.7.0
 longhornio/csi-provisioner:v3.6.4
-longhornio/csi-resizer:v1.10.1
+longhornio/csi-resizer:v1.12.0
 longhornio/csi-snapshotter:v6.3.4
 longhornio/csi-node-driver-registrar:v2.9.2
 longhornio/livenessprobe:v2.12.0

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -4,7 +4,7 @@ longhornio/csi-resizer:v1.12.0
 longhornio/csi-snapshotter:v6.3.4
 longhornio/csi-node-driver-registrar:v2.12.0
 longhornio/livenessprobe:v2.14.0
-longhornio/openshift-origin-oauth-proxy:4.14
+longhornio/openshift-origin-oauth-proxy:4.15
 longhornio/backing-image-manager:v1.6.2
 longhornio/longhorn-engine:v1.6.2
 longhornio/longhorn-instance-manager:v1.6.2

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -3,7 +3,7 @@ longhornio/csi-provisioner:v3.6.4
 longhornio/csi-resizer:v1.12.0
 longhornio/csi-snapshotter:v6.3.4
 longhornio/csi-node-driver-registrar:v2.12.0
-longhornio/livenessprobe:v2.12.0
+longhornio/livenessprobe:v2.14.0
 longhornio/openshift-origin-oauth-proxy:4.14
 longhornio/backing-image-manager:v1.6.2
 longhornio/longhorn-engine:v1.6.2

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -2,7 +2,7 @@ longhornio/csi-attacher:v4.7.0
 longhornio/csi-provisioner:v3.6.4
 longhornio/csi-resizer:v1.12.0
 longhornio/csi-snapshotter:v6.3.4
-longhornio/csi-node-driver-registrar:v2.9.2
+longhornio/csi-node-driver-registrar:v2.12.0
 longhornio/livenessprobe:v2.12.0
 longhornio/openshift-origin-oauth-proxy:4.14
 longhornio/backing-image-manager:v1.6.2

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -4482,7 +4482,7 @@ spec:
               fieldRef:
                 fieldPath: spec.serviceAccountName
           - name: CSI_ATTACHER_IMAGE
-            value: "longhornio/csi-attacher:v4.5.1"
+            value: "longhornio/csi-attacher:v4.7.0"
           - name: CSI_PROVISIONER_IMAGE
             value: "longhornio/csi-provisioner:v3.6.4"
           - name: CSI_NODE_DRIVER_REGISTRAR_IMAGE

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -4492,7 +4492,7 @@ spec:
           - name: CSI_SNAPSHOTTER_IMAGE
             value: "longhornio/csi-snapshotter:v6.3.4"
           - name: CSI_LIVENESS_PROBE_IMAGE
-            value: "longhornio/livenessprobe:v2.12.0"
+            value: "longhornio/livenessprobe:v2.14.0"
       priorityClassName: "longhorn-critical"
       serviceAccountName: longhorn-service-account
       securityContext:

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -4488,7 +4488,7 @@ spec:
           - name: CSI_NODE_DRIVER_REGISTRAR_IMAGE
             value: "longhornio/csi-node-driver-registrar:v2.9.2"
           - name: CSI_RESIZER_IMAGE
-            value: "longhornio/csi-resizer:v1.10.1"
+            value: "longhornio/csi-resizer:v1.12.0"
           - name: CSI_SNAPSHOTTER_IMAGE
             value: "longhornio/csi-snapshotter:v6.3.4"
           - name: CSI_LIVENESS_PROBE_IMAGE

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -4486,7 +4486,7 @@ spec:
           - name: CSI_PROVISIONER_IMAGE
             value: "longhornio/csi-provisioner:v3.6.4"
           - name: CSI_NODE_DRIVER_REGISTRAR_IMAGE
-            value: "longhornio/csi-node-driver-registrar:v2.9.2"
+            value: "longhornio/csi-node-driver-registrar:v2.12.0"
           - name: CSI_RESIZER_IMAGE
             value: "longhornio/csi-resizer:v1.12.0"
           - name: CSI_SNAPSHOTTER_IMAGE


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#9132

#### What this PR does / why we need it:

Fix CVE issues

**After**
```
longhornio/csi-attacher:v4.7.0 (debian 12.6)
============================================
Total: 0 (HIGH: 0, CRITICAL: 0)
```
```
longhornio/csi-resizer:v1.12.0 (debian 12.6)
============================================
Total: 0 (HIGH: 0, CRITICAL: 0)
```
```
longhornio/csi-node-driver-registrar:v2.12.0 (debian 12.6)
==========================================================
Total: 0 (HIGH: 0, CRITICAL: 0)
```
```
longhornio/livenessprobe:v2.14.0 (debian 12.6)
==============================================
Total: 0 (HIGH: 0, CRITICAL: 0)
```
```
longhornio/openshift-origin-oauth-proxy:4.15 (redhat 9.2)
=========================================================
Total: 12 (HIGH: 12, CRITICAL: 0)

┌──────────────────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────────┬────────────────────────────────────────────────────────┐
│         Library          │ Vulnerability  │ Severity │ Status │ Installed Version │   Fixed Version   │                         Title                          │
├──────────────────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────────┼────────────────────────────────────────────────────────┤
│ glibc                    │ CVE-2024-2961  │ HIGH     │ fixed  │ 2.34-60.el9_2.7   │ 2.34-60.el9_2.14  │ glibc: Out of bounds write in iconv may lead to remote │
│                          │                │          │        │                   │                   │ code...                                                │
│                          │                │          │        │                   │                   │ https://avd.aquasec.com/nvd/cve-2024-2961              │
│                          ├────────────────┤          │        │                   │                   ├────────────────────────────────────────────────────────┤
│                          │ CVE-2024-33599 │          │        │                   │                   │ glibc: stack-based buffer overflow in netgroup cache   │
│                          │                │          │        │                   │                   │ https://avd.aquasec.com/nvd/cve-2024-33599             │
├──────────────────────────┼────────────────┤          │        │                   │                   ├────────────────────────────────────────────────────────┤
│ glibc-common             │ CVE-2024-2961  │          │        │                   │                   │ glibc: Out of bounds write in iconv may lead to remote │
│                          │                │          │        │                   │                   │ code...                                                │
│                          │                │          │        │                   │                   │ https://avd.aquasec.com/nvd/cve-2024-2961              │
│                          ├────────────────┤          │        │                   │                   ├────────────────────────────────────────────────────────┤
│                          │ CVE-2024-33599 │          │        │                   │                   │ glibc: stack-based buffer overflow in netgroup cache   │
│                          │                │          │        │                   │                   │ https://avd.aquasec.com/nvd/cve-2024-33599             │
├──────────────────────────┼────────────────┤          │        │                   │                   ├────────────────────────────────────────────────────────┤
│ glibc-langpack-en        │ CVE-2024-2961  │          │        │                   │                   │ glibc: Out of bounds write in iconv may lead to remote │
│                          │                │          │        │                   │                   │ code...                                                │
│                          │                │          │        │                   │                   │ https://avd.aquasec.com/nvd/cve-2024-2961              │
│                          ├────────────────┤          │        │                   │                   ├────────────────────────────────────────────────────────┤
│                          │ CVE-2024-33599 │          │        │                   │                   │ glibc: stack-based buffer overflow in netgroup cache   │
│                          │                │          │        │                   │                   │ https://avd.aquasec.com/nvd/cve-2024-33599             │
├──────────────────────────┼────────────────┤          │        │                   │                   ├────────────────────────────────────────────────────────┤
│ glibc-minimal-langpack   │ CVE-2024-2961  │          │        │                   │                   │ glibc: Out of bounds write in iconv may lead to remote │
│                          │                │          │        │                   │                   │ code...                                                │
│                          │                │          │        │                   │                   │ https://avd.aquasec.com/nvd/cve-2024-2961              │
│                          ├────────────────┤          │        │                   │                   ├────────────────────────────────────────────────────────┤
│                          │ CVE-2024-33599 │          │        │                   │                   │ glibc: stack-based buffer overflow in netgroup cache   │
│                          │                │          │        │                   │                   │ https://avd.aquasec.com/nvd/cve-2024-33599             │
├──────────────────────────┼────────────────┤          │        ├───────────────────┼───────────────────┼────────────────────────────────────────────────────────┤
│ python3                  │ CVE-2023-6597  │          │        │ 3.9.16-1.el9_2.2  │ 3.9.16-1.el9_2.5  │ python: Path traversal on tempfile.TemporaryDirectory  │
│                          │                │          │        │                   │                   │ https://avd.aquasec.com/nvd/cve-2023-6597              │
├──────────────────────────┤                │          │        │                   │                   │                                                        │
│ python3-libs             │                │          │        │                   │                   │                                                        │
│                          │                │          │        │                   │                   │                                                        │
├──────────────────────────┼────────────────┤          │        ├───────────────────┼───────────────────┼────────────────────────────────────────────────────────┤
│ python3-setuptools       │ CVE-2024-6345  │          │        │ 53.0.0-12.el9     │ 53.0.0-12.el9_2.1 │ pypa/setuptools: Remote code execution via download    │
│                          │                │          │        │                   │                   │ functions in the package_index module in...            │
│                          │                │          │        │                   │                   │ https://avd.aquasec.com/nvd/cve-2024-6345              │
├──────────────────────────┤                │          │        │                   │                   │                                                        │
│ python3-setuptools-wheel │                │          │        │                   │                   │                                                        │
│                          │                │          │        │                   │                   │                                                        │
│                          │                │          │        │                   │                   │                                                        │
└──────────────────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────────┴────────────────────────────────────────────────────────┘

usr/bin/oauth-proxy (gobinary)
==============================
Total: 6 (HIGH: 5, CRITICAL: 1)

┌──────────────────────────────────────────────────────────────┬─────────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────────┬─────────────────────────────────────────────────────────────┐
│                           Library                            │    Vulnerability    │ Severity │ Status │ Installed Version │          Fixed Version           │                            Title                            │
├──────────────────────────────────────────────────────────────┼─────────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│ go.opentelemetry.io/contrib/instrumentation/google.golang.o- │ CVE-2023-47108      │ HIGH     │ fixed  │ v0.35.0           │ 0.46.0                           │ opentelemetry-go-contrib: DoS vulnerability in otelgrpc due │
│ rg/grpc/otelgrpc                                             │                     │          │        │                   │                                  │ to unbound cardinality metrics                              │
│                                                              │                     │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-47108                  │
├──────────────────────────────────────────────────────────────┼─────────────────────┤          │        ├───────────────────┼──────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│ go.opentelemetry.io/contrib/instrumentation/net/http/otelht- │ CVE-2023-45142      │          │        │ v0.35.1           │ 0.44.0                           │ opentelemetry: DoS vulnerability in otelhttp                │
│ tp                                                           │                     │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-45142                  │
├──────────────────────────────────────────────────────────────┼─────────────────────┤          │        ├───────────────────┼──────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│ google.golang.org/grpc                                       │ GHSA-m425-mq94-257g │          │        │ v1.51.0           │ 1.56.3, 1.57.1, 1.58.3           │ gRPC-Go HTTP/2 Rapid Reset vulnerability                    │
│                                                              │                     │          │        │                   │                                  │ https://github.com/advisories/GHSA-m425-mq94-257g           │
├──────────────────────────────────────────────────────────────┼─────────────────────┼──────────┤        ├───────────────────┼──────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│ stdlib                                                       │ CVE-2024-24790      │ CRITICAL │        │ 1.20.10           │ 1.21.11, 1.22.4                  │ golang: net/netip: Unexpected behavior from Is methods for  │
│                                                              │                     │          │        │                   │                                  │ IPv4-mapped IPv6 addresses                                  │
│                                                              │                     │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2024-24790                  │
│                                                              ├─────────────────────┼──────────┤        │                   ├──────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│                                                              │ CVE-2023-45283      │ HIGH     │        │                   │ 1.20.11, 1.21.4, 1.20.12, 1.21.5 │ The filepath package does not recognize paths with a \??\   │
│                                                              │                     │          │        │                   │                                  │ prefix as...                                                │
│                                                              │                     │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-45283                  │
│                                                              ├─────────────────────┤          │        │                   ├──────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│                                                              │ CVE-2023-45288      │          │        │                   │ 1.21.9, 1.22.2                   │ golang: net/http, x/net/http2: unlimited number of          │
│                                                              │                     │          │        │                   │                                  │ CONTINUATION frames causes DoS                              │
│                                                              │                     │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-45288                  │
└──────────────────────────────────────────────────────────────┴─────────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────────┴─────────────────────────────────────────────────────────────┘
```

**Before**
```
longhornio/csi-attacher:v4.5.1 (debian 11.9)
============================================
Total: 0 (HIGH: 0, CRITICAL: 0)


csi-attacher (gobinary)
=======================
Total: 3 (HIGH: 2, CRITICAL: 1)

┌──────────────────────────────────────────────────────────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬─────────────────────────────────────────────────────────────┐
│                           Library                            │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                            Title                            │
├──────────────────────────────────────────────────────────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼─────────────────────────────────────────────────────────────┤
│ go.opentelemetry.io/contrib/instrumentation/google.golang.o- │ CVE-2023-47108 │ HIGH     │ fixed  │ v0.44.0           │ 0.46.0          │ opentelemetry-go-contrib: DoS vulnerability in otelgrpc due │
│ rg/grpc/otelgrpc                                             │                │          │        │                   │                 │ to unbound cardinality metrics                              │
│                                                              │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2023-47108                  │
├──────────────────────────────────────────────────────────────┼────────────────┼──────────┤        ├───────────────────┼─────────────────┼─────────────────────────────────────────────────────────────┤
│ stdlib                                                       │ CVE-2024-24790 │ CRITICAL │        │ 1.21.5            │ 1.21.11, 1.22.4 │ golang: net/netip: Unexpected behavior from Is methods for  │
│                                                              │                │          │        │                   │                 │ IPv4-mapped IPv6 addresses                                  │
│                                                              │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24790                  │
│                                                              ├────────────────┼──────────┤        │                   ├─────────────────┼─────────────────────────────────────────────────────────────┤
│                                                              │ CVE-2023-45288 │ HIGH     │        │                   │ 1.21.9, 1.22.2  │ golang: net/http, x/net/http2: unlimited number of          │
│                                                              │                │          │        │                   │                 │ CONTINUATION frames causes DoS                              │
│                                                              │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2023-45288                  │
└──────────────────────────────────────────────────────────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴─────────────────────────────────────────────────────────────┘
```
```
longhornio/csi-resizer:v1.10.1 (debian 11.9)
============================================
Total: 0 (HIGH: 0, CRITICAL: 0)


csi-resizer (gobinary)
======================
Total: 3 (HIGH: 2, CRITICAL: 1)

┌──────────────────────────────────────────────────────────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬─────────────────────────────────────────────────────────────┐
│                           Library                            │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                            Title                            │
├──────────────────────────────────────────────────────────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼─────────────────────────────────────────────────────────────┤
│ go.opentelemetry.io/contrib/instrumentation/google.golang.o- │ CVE-2023-47108 │ HIGH     │ fixed  │ v0.44.0           │ 0.46.0          │ opentelemetry-go-contrib: DoS vulnerability in otelgrpc due │
│ rg/grpc/otelgrpc                                             │                │          │        │                   │                 │ to unbound cardinality metrics                              │
│                                                              │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2023-47108                  │
├──────────────────────────────────────────────────────────────┼────────────────┼──────────┤        ├───────────────────┼─────────────────┼─────────────────────────────────────────────────────────────┤
│ stdlib                                                       │ CVE-2024-24790 │ CRITICAL │        │ 1.21.5            │ 1.21.11, 1.22.4 │ golang: net/netip: Unexpected behavior from Is methods for  │
│                                                              │                │          │        │                   │                 │ IPv4-mapped IPv6 addresses                                  │
│                                                              │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24790                  │
│                                                              ├────────────────┼──────────┤        │                   ├─────────────────┼─────────────────────────────────────────────────────────────┤
│                                                              │ CVE-2023-45288 │ HIGH     │        │                   │ 1.21.9, 1.22.2  │ golang: net/http, x/net/http2: unlimited number of          │
│                                                              │                │          │        │                   │                 │ CONTINUATION frames causes DoS                              │
│                                                              │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2023-45288                  │
└──────────────────────────────────────────────────────────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴─────────────────────────────────────────────────────────────┘
```
```
longhornio/csi-node-driver-registrar:v2.9.2 (debian 11.8)
=========================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


csi-node-driver-registrar (gobinary)
====================================
Total: 4 (HIGH: 3, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────────┬──────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │          Fixed Version           │                            Title                             │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-24790 │ CRITICAL │ fixed  │ 1.20.5            │ 1.21.11, 1.22.4                  │ golang: net/netip: Unexpected behavior from Is methods for   │
│         │                │          │        │                   │                                  │ IPv4-mapped IPv6 addresses                                   │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2024-24790                   │
│         ├────────────────┼──────────┤        │                   ├──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2023-39325 │ HIGH     │        │                   │ 1.20.10, 1.21.3                  │ golang: net/http, x/net/http2: rapid stream resets can cause │
│         │                │          │        │                   │                                  │ excessive work (CVE-2023-44487)                              │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-39325                   │
│         ├────────────────┤          │        │                   ├──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2023-45283 │          │        │                   │ 1.20.11, 1.21.4, 1.20.12, 1.21.5 │ The filepath package does not recognize paths with a \??\    │
│         │                │          │        │                   │                                  │ prefix as...                                                 │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-45283                   │
│         ├────────────────┤          │        │                   ├──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2023-45288 │          │        │                   │ 1.21.9, 1.22.2                   │ golang: net/http, x/net/http2: unlimited number of           │
│         │                │          │        │                   │                                  │ CONTINUATION frames causes DoS                               │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-45288                   │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────────┴──────────────────────────────────────────────────────────────┘
```
```
livenessprobe (gobinary)
========================
Total: 2 (HIGH: 1, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                           Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-24790 │ CRITICAL │ fixed  │ 1.21.5            │ 1.21.11, 1.22.4 │ golang: net/netip: Unexpected behavior from Is methods for │
│         │                │          │        │                   │                 │ IPv4-mapped IPv6 addresses                                 │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24790                 │
│         ├────────────────┼──────────┤        │                   ├─────────────────┼────────────────────────────────────────────────────────────┤
│         │ CVE-2023-45288 │ HIGH     │        │                   │ 1.21.9, 1.22.2  │ golang: net/http, x/net/http2: unlimited number of         │
│         │                │          │        │                   │                 │ CONTINUATION frames causes DoS                             │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2023-45288                 │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴────────────────────────────────────────────────────────────┘
```
```
longhornio/openshift-origin-oauth-proxy:4.14 (redhat 8.6)
=========================================================
Total: 25 (HIGH: 25, CRITICAL: 0)

┌────────────────────────┬────────────────┬──────────┬────────┬──────────────────────┬──────────────────────┬──────────────────────────────────────────────────────────────┐
│        Library         │ Vulnerability  │ Severity │ Status │  Installed Version   │    Fixed Version     │                            Title                             │
├────────────────────────┼────────────────┼──────────┼────────┼──────────────────────┼──────────────────────┼──────────────────────────────────────────────────────────────┤
│ bind-libs              │ CVE-2023-4408  │ HIGH     │ fixed  │ 32:9.11.36-3.el8_6.5 │ 32:9.11.36-3.el8_6.7 │ bind9: Parsing large DNS messages may cause excessive CPU    │
│                        │                │          │        │                      │                      │ load                                                         │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-4408                    │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-50387 │          │        │                      │                      │ bind9: KeyTrap - Extreme CPU consumption in DNSSEC validator │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-50387                   │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-50868 │          │        │                      │                      │ bind9: Preparing an NSEC3 closest encloser proof can exhaust │
│                        │                │          │        │                      │                      │ CPU resources                                                │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-50868                   │
├────────────────────────┼────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│ bind-libs-lite         │ CVE-2023-4408  │          │        │                      │                      │ bind9: Parsing large DNS messages may cause excessive CPU    │
│                        │                │          │        │                      │                      │ load                                                         │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-4408                    │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-50387 │          │        │                      │                      │ bind9: KeyTrap - Extreme CPU consumption in DNSSEC validator │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-50387                   │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-50868 │          │        │                      │                      │ bind9: Preparing an NSEC3 closest encloser proof can exhaust │
│                        │                │          │        │                      │                      │ CPU resources                                                │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-50868                   │
├────────────────────────┼────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│ bind-license           │ CVE-2023-4408  │          │        │                      │                      │ bind9: Parsing large DNS messages may cause excessive CPU    │
│                        │                │          │        │                      │                      │ load                                                         │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-4408                    │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-50387 │          │        │                      │                      │ bind9: KeyTrap - Extreme CPU consumption in DNSSEC validator │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-50387                   │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-50868 │          │        │                      │                      │ bind9: Preparing an NSEC3 closest encloser proof can exhaust │
│                        │                │          │        │                      │                      │ CPU resources                                                │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-50868                   │
├────────────────────────┼────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│ bind-utils             │ CVE-2023-4408  │          │        │                      │                      │ bind9: Parsing large DNS messages may cause excessive CPU    │
│                        │                │          │        │                      │                      │ load                                                         │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-4408                    │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-50387 │          │        │                      │                      │ bind9: KeyTrap - Extreme CPU consumption in DNSSEC validator │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-50387                   │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-50868 │          │        │                      │                      │ bind9: Preparing an NSEC3 closest encloser proof can exhaust │
│                        │                │          │        │                      │                      │ CPU resources                                                │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-50868                   │
├────────────────────────┼────────────────┤          │        ├──────────────────────┼──────────────────────┼──────────────────────────────────────────────────────────────┤
│ glibc                  │ CVE-2024-2961  │          │        │ 2.28-189.6.el8_6     │ 2.28-189.10.el8_6    │ glibc: Out of bounds write in iconv may lead to remote       │
│                        │                │          │        │                      │                      │ code...                                                      │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2024-2961                    │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2024-33599 │          │        │                      │                      │ glibc: stack-based buffer overflow in netgroup cache         │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2024-33599                   │
├────────────────────────┼────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│ glibc-common           │ CVE-2024-2961  │          │        │                      │                      │ glibc: Out of bounds write in iconv may lead to remote       │
│                        │                │          │        │                      │                      │ code...                                                      │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2024-2961                    │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2024-33599 │          │        │                      │                      │ glibc: stack-based buffer overflow in netgroup cache         │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2024-33599                   │
├────────────────────────┼────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│ glibc-gconv-extra      │ CVE-2024-2961  │          │        │                      │                      │ glibc: Out of bounds write in iconv may lead to remote       │
│                        │                │          │        │                      │                      │ code...                                                      │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2024-2961                    │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2024-33599 │          │        │                      │                      │ glibc: stack-based buffer overflow in netgroup cache         │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2024-33599                   │
├────────────────────────┼────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│ glibc-langpack-en      │ CVE-2024-2961  │          │        │                      │                      │ glibc: Out of bounds write in iconv may lead to remote       │
│                        │                │          │        │                      │                      │ code...                                                      │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2024-2961                    │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2024-33599 │          │        │                      │                      │ glibc: stack-based buffer overflow in netgroup cache         │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2024-33599                   │
├────────────────────────┼────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│ glibc-minimal-langpack │ CVE-2024-2961  │          │        │                      │                      │ glibc: Out of bounds write in iconv may lead to remote       │
│                        │                │          │        │                      │                      │ code...                                                      │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2024-2961                    │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2024-33599 │          │        │                      │                      │ glibc: stack-based buffer overflow in netgroup cache         │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2024-33599                   │
├────────────────────────┼────────────────┤          │        ├──────────────────────┼──────────────────────┼──────────────────────────────────────────────────────────────┤
│ python3-bind           │ CVE-2023-4408  │          │        │ 32:9.11.36-3.el8_6.5 │ 32:9.11.36-3.el8_6.7 │ bind9: Parsing large DNS messages may cause excessive CPU    │
│                        │                │          │        │                      │                      │ load                                                         │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-4408                    │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-50387 │          │        │                      │                      │ bind9: KeyTrap - Extreme CPU consumption in DNSSEC validator │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-50387                   │
│                        ├────────────────┤          │        │                      │                      ├──────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-50868 │          │        │                      │                      │ bind9: Preparing an NSEC3 closest encloser proof can exhaust │
│                        │                │          │        │                      │                      │ CPU resources                                                │
│                        │                │          │        │                      │                      │ https://avd.aquasec.com/nvd/cve-2023-50868                   │
└────────────────────────┴────────────────┴──────────┴────────┴──────────────────────┴──────────────────────┴──────────────────────────────────────────────────────────────┘

usr/bin/oauth-proxy (gobinary)
==============================
Total: 6 (HIGH: 5, CRITICAL: 1)

┌──────────────────────────────────────────────────────────────┬─────────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────────┬─────────────────────────────────────────────────────────────┐
│                           Library                            │    Vulnerability    │ Severity │ Status │ Installed Version │          Fixed Version           │                            Title                            │
├──────────────────────────────────────────────────────────────┼─────────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│ go.opentelemetry.io/contrib/instrumentation/google.golang.o- │ CVE-2023-47108      │ HIGH     │ fixed  │ v0.35.0           │ 0.46.0                           │ opentelemetry-go-contrib: DoS vulnerability in otelgrpc due │
│ rg/grpc/otelgrpc                                             │                     │          │        │                   │                                  │ to unbound cardinality metrics                              │
│                                                              │                     │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-47108                  │
├──────────────────────────────────────────────────────────────┼─────────────────────┤          │        ├───────────────────┼──────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│ go.opentelemetry.io/contrib/instrumentation/net/http/otelht- │ CVE-2023-45142      │          │        │ v0.35.1           │ 0.44.0                           │ opentelemetry: DoS vulnerability in otelhttp                │
│ tp                                                           │                     │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-45142                  │
├──────────────────────────────────────────────────────────────┼─────────────────────┤          │        ├───────────────────┼──────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│ google.golang.org/grpc                                       │ GHSA-m425-mq94-257g │          │        │ v1.51.0           │ 1.56.3, 1.57.1, 1.58.3           │ gRPC-Go HTTP/2 Rapid Reset vulnerability                    │
│                                                              │                     │          │        │                   │                                  │ https://github.com/advisories/GHSA-m425-mq94-257g           │
├──────────────────────────────────────────────────────────────┼─────────────────────┼──────────┤        ├───────────────────┼──────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│ stdlib                                                       │ CVE-2024-24790      │ CRITICAL │        │ 1.20.10           │ 1.21.11, 1.22.4                  │ golang: net/netip: Unexpected behavior from Is methods for  │
│                                                              │                     │          │        │                   │                                  │ IPv4-mapped IPv6 addresses                                  │
│                                                              │                     │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2024-24790                  │
│                                                              ├─────────────────────┼──────────┤        │                   ├──────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│                                                              │ CVE-2023-45283      │ HIGH     │        │                   │ 1.20.11, 1.21.4, 1.20.12, 1.21.5 │ The filepath package does not recognize paths with a \??\   │
│                                                              │                     │          │        │                   │                                  │ prefix as...                                                │
│                                                              │                     │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-45283                  │
│                                                              ├─────────────────────┤          │        │                   ├──────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│                                                              │ CVE-2023-45288      │          │        │                   │ 1.21.9, 1.22.2                   │ golang: net/http, x/net/http2: unlimited number of          │
│                                                              │                     │          │        │                   │                                  │ CONTINUATION frames causes DoS                              │
│                                                              │                     │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-45288                  │
└──────────────────────────────────────────────────────────────┴─────────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────────┴─────────────────────────────────────────────────────────────┘
```

#### Special notes for your reviewer:

We don't need to backport this to the master and v1.7.x branches, as CVE issues are handled independently for each version and will be addressed before each release. cc @derekbit @innobead 

#### Additional documentation or context
