### PR TITLE
chore(ci): update status and sprint of community issues if non-longhorn user comments

### DIFF
--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -1,7 +1,10 @@
 name: Add-To-Projects
 on:
   issues:
-    types: [ opened, labeled ]
+    types: [opened, labeled, milestoned]
+  issue_comment:
+    types: [created, edited]
+
 jobs:
   community:
     runs-on: ubuntu-latest
@@ -14,23 +17,78 @@ jobs:
         organization: longhorn
         GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
 
+    - name: Get Issue
+      uses: octokit/request-action@v2.x
+      id: issue
+      with:
+        route: GET /repos/${{ github.repository }}/issues/${{ github.event.issue.number }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+
     - name: Add Issue to Community Sprint Project
       id: add-project
       if: fromJSON(steps.is-longhorn-member.outputs.teams)[0] == null
-      uses: actions/add-to-project@v1
+      uses: actions/add-to-project@v1.0.2
       with:
         project-url: https://github.com/orgs/longhorn/projects/5
         github-token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
 
-    - name: Update Issue Status in Community Sprint Project
-      if: ${{ steps.add-project.outputs.itemId != '' }}
+    - name: Update Item To New
+      if: |
+        steps.is-longhorn-member.outcome == 'success' &&
+        fromJSON(steps.is-longhorn-member.outputs.teams)[0] == null &&
+        steps.add-project.outputs.itemId != '' &&
+        github.event_name == 'issues' && github.event.action == 'opened'
       uses: titoportas/update-project-fields@v0.1.0
       with:
         project-url: https://github.com/orgs/longhorn/projects/5
         github-token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
         item-id: ${{ steps.add-project.outputs.itemId }}
         field-keys: Status,Sprint
-        field-values: New,[0]
+        field-values: "New,[0]"
+
+    - name: Move Item To Resolved
+      if: |
+        steps.is-longhorn-member.outcome == 'success' &&
+        fromJSON(steps.is-longhorn-member.outputs.teams)[0] == null &&
+        steps.add-project.outputs.itemId != '' &&
+        github.event_name == 'issues' && github.event.action == 'milestoned'
+      uses: titoportas/update-project-fields@v0.1.0
+      with:
+        project-url: https://github.com/orgs/longhorn/projects/5
+        github-token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+        item-id: ${{ steps.add-project.outputs.itemId }}
+        field-keys: Status,Sprint
+        field-values: "Resolved,[0]"
+
+    - name: Update Item To In Progress
+      if: |
+        steps.is-longhorn-member.outcome == 'success' &&
+        fromJSON(steps.is-longhorn-member.outputs.teams)[0] == null &&
+        steps.add-project.outputs.itemId != '' &&
+        github.event_name == 'issue_comment' && (github.event.action == 'created' || github.event.action == 'edited')
+      uses: titoportas/update-project-fields@v0.1.0
+      with:
+        project-url: https://github.com/orgs/longhorn/projects/5
+        github-token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+        item-id: ${{ steps.add-project.outputs.itemId }}
+        field-keys: Status,Sprint
+        field-values: ${{ fromJSON(steps.issue.outputs.data).milestone == null && 'In Progress,[0]' || 'Resolved,[0]' }}
+
+    - name: Update Item To In Closed
+      if: |
+        steps.is-longhorn-member.outcome == 'success' &&
+        fromJSON(steps.is-longhorn-member.outputs.teams)[0] == null &&
+        steps.add-project.outputs.itemId != '' &&
+        github.event_name == 'issues' && github.event.action == 'labeled' && (github.event.label.name == 'invalid' || github.event.label.name == 'wontfix')
+      uses: titoportas/update-project-fields@v0.1.0
+      with:
+        project-url: https://github.com/orgs/longhorn/projects/5
+        github-token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+        item-id: ${{ steps.add-project.outputs.itemId }}
+        field-keys: Status
+        field-values: Closed
+
   qa:
     runs-on: ubuntu-latest
     steps:
@@ -44,7 +102,7 @@ jobs:
 
     - name: Add Issue to QA Sprint Project
       if: fromJSON(steps.is-longhorn-member.outputs.teams)[0] != null
-      uses: actions/add-to-project@v1
+      uses: actions/add-to-project@v1.0.2
       with:
         project-url: https://github.com/orgs/longhorn/projects/4
         github-token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn#9411

#### What this PR does / why we need it:

- Add a check for teps.is_longhorn_member.outcome == 'success' to prevent errors caused by unrecognized users, such as github-action[bot].
- Move an issue to `New` if it is newly created
- Move an issue to `In Progress` status if a non-longhorn user replies. 
- Move an issue to `Resolved` if a milestone is set
- Move an issue to `Closed` if `wontfix` or `invalid` label is set


![image](https://github.com/user-attachments/assets/6c7f901f-55d7-4929-b814-ce54099b6275)


#### Special notes for your reviewer:

#### Additional documentation or context
