### PR TITLE
fix(metrics): add rwx-volume-fast-failover to upgrade responder insta…

### DIFF
--- a/dev/upgrade-responder/install.sh
+++ b/dev/upgrade-responder/install.sh
@@ -144,6 +144,10 @@ configMap:
           "dataType": "string",
           "maxLen": 200
         },
+        "longhornSettingFreezeFilesystemForSnapshot": {
+          "dataType": "string",
+          "maxLen": 200
+        },
         "longhornSettingKubernetesClusterAutoscalerEnabled": {
           "dataType": "string",
           "maxLen": 200
@@ -189,6 +193,10 @@ configMap:
           "maxLen": 200
         },
         "longhornSettingRestoreVolumeRecurringJobs": {
+          "dataType": "string",
+          "maxLen": 200
+        },
+        "longhornSettingRwxVolumeFastFailover": {
           "dataType": "string",
           "maxLen": 200
         },
@@ -361,6 +369,9 @@ configMap:
           "dataType": "float"
         },
         "longhornVolumeDataLocalityStrictLocalCount": {
+          "dataType": "float"
+        },
+        "longhornFreezeFilesystemForSnapshotTrueCount": {
           "dataType": "float"
         },
         "longhornVolumeFrontendBlockdevCount": {


### PR DESCRIPTION
…ll script.

#### Which issue(s) this PR fixes:

https://github.com/longhorn/longhorn/issues/9347

#### What this PR does / why we need it:

It appears that dev/upgrade-responder/install.sh is meant to track the upgrade-responder chart with respect to the `requestSchema`, so catch it up.

#### Special notes for your reviewer:

#### Additional documentation or context
