### PR TITLE
fix(cve): csi components

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -100,7 +100,7 @@ The `values.yaml` contains items used to tweak a deployment of this chart.
 | image.csi.nodeDriverRegistrar.repository | string | `"longhornio/csi-node-driver-registrar"` | Repository for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value. |
 | image.csi.nodeDriverRegistrar.tag | string | `"v2.12.0"` | Tag for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value. |
 | image.csi.provisioner.repository | string | `"longhornio/csi-provisioner"` | Repository for the CSI Provisioner image. When unspecified, Longhorn uses the default value. |
-| image.csi.provisioner.tag | string | `"v3.6.4"` | Tag for the CSI Provisioner image. When unspecified, Longhorn uses the default value. |
+| image.csi.provisioner.tag | string | `"v5.1.0"` | Tag for the CSI Provisioner image. When unspecified, Longhorn uses the default value. |
 | image.csi.resizer.repository | string | `"longhornio/csi-resizer"` | Repository for the CSI Resizer image. When unspecified, Longhorn uses the default value. |
 | image.csi.resizer.tag | string | `"v1.12.0"` | Tag for the CSI Resizer image. When unspecified, Longhorn uses the default value. |
 | image.csi.snapshotter.repository | string | `"longhornio/csi-snapshotter"` | Repository for the CSI Snapshotter image. When unspecified, Longhorn uses the default value. |

--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -113,7 +113,7 @@ questions:
     label: Longhorn CSI Provisioner Image Repository
     group: "Longhorn CSI Driver Images"
   - variable: image.csi.provisioner.tag
-    default: v3.6.4
+    default: v5.1.0
     description: "Tag for the CSI Provisioner image. When unspecified, Longhorn uses the default value."
     type: string
     label: Longhorn CSI Provisioner Image Tag

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -80,7 +80,7 @@ image:
       # -- Repository for the CSI Provisioner image. When unspecified, Longhorn uses the default value.
       repository: longhornio/csi-provisioner
       # -- Tag for the CSI Provisioner image. When unspecified, Longhorn uses the default value.
-      tag: v3.6.4
+      tag: v5.1.0
     nodeDriverRegistrar:
       # -- Repository for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value.
       repository: longhornio/csi-node-driver-registrar

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -1,5 +1,5 @@
 longhornio/csi-attacher:v4.7.0
-longhornio/csi-provisioner:v3.6.4
+longhornio/csi-provisioner:v5.1.0
 longhornio/csi-resizer:v1.12.0
 longhornio/csi-snapshotter:v6.3.4
 longhornio/csi-node-driver-registrar:v2.12.0

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -4749,7 +4749,7 @@ spec:
           - name: CSI_ATTACHER_IMAGE
             value: "longhornio/csi-attacher:v4.7.0"
           - name: CSI_PROVISIONER_IMAGE
-            value: "longhornio/csi-provisioner:v3.6.4"
+            value: "longhornio/csi-provisioner:v5.1.0"
           - name: CSI_NODE_DRIVER_REGISTRAR_IMAGE
             value: "longhornio/csi-node-driver-registrar:v2.12.0"
           - name: CSI_RESIZER_IMAGE


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#9562

#### What this PR does / why we need it:

Fix CVE issues.

**After:**
```
longhornio/csi-provisioner:v5.1.0 (debian 12.6)
===============================================
Total: 0 (HIGH: 0, CRITICAL: 0)


csi-provisioner (gobinary)
==========================
Total: 1 (HIGH: 1, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────┬───────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version  │                           Title                           │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────┼───────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-34156 │ HIGH     │ fixed  │ 1.22.5            │ 1.22.7, 1.23.1 │ encoding/gob: golang: Calling Decoder.Decode on a message │
│         │                │          │        │                   │                │ which contains deeply nested structures...                │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2024-34156                │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴────────────────┴───────────────────────────────────────────────────────────┘
```

**Before:**
```
longhornio/csi-provisioner:v3.6.4 (debian 11.9)
===============================================
Total: 0 (HIGH: 0, CRITICAL: 0)


csi-provisioner (gobinary)
==========================
Total: 3 (HIGH: 2, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                           Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-24790 │ CRITICAL │ fixed  │ 1.21.5            │ 1.21.11, 1.22.4 │ golang: net/netip: Unexpected behavior from Is methods for │
│         │                │          │        │                   │                 │ IPv4-mapped IPv6 addresses                                 │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24790                 │
│         ├────────────────┼──────────┤        │                   ├─────────────────┼────────────────────────────────────────────────────────────┤
│         │ CVE-2023-45288 │ HIGH     │        │                   │ 1.21.9, 1.22.2  │ golang: net/http, x/net/http2: unlimited number of         │
│         │                │          │        │                   │                 │ CONTINUATION frames causes DoS                             │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2023-45288                 │
│         ├────────────────┤          │        │                   ├─────────────────┼────────────────────────────────────────────────────────────┤
│         │ CVE-2024-34156 │          │        │                   │ 1.22.7, 1.23.1  │ encoding/gob: golang: Calling Decoder.Decode on a message  │
│         │                │          │        │                   │                 │ which contains deeply nested structures...                 │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-34156                 │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴────────────────────────────────────────────────────────────┘
```

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

`None`
