### PR TITLE
chore(workflow): add-to-projects doesn't need to handle labeled event

### DIFF
--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -1,7 +1,7 @@
 name: Add-To-Projects
 on:
   issues:
-    types: [opened, labeled]
+    types: [opened]
 
 jobs:
   community:
@@ -39,8 +39,7 @@ jobs:
       if: |
         steps.is-longhorn-member.outcome == 'success' &&
         fromJSON(steps.is-longhorn-member.outputs.teams)[0] == null &&
-        steps.add-project.outputs.itemId != '' &&
-        github.event_name == 'issues' && github.event.action == 'opened'
+        steps.add-project.outputs.itemId != ''
       uses: titoportas/update-project-fields@v0.1.0
       with:
         project-url: https://github.com/orgs/longhorn/projects/5


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
