### PR TITLE
feat(crd): add realSize field to backingimage and scheduledBackingImage field to node

### DIFF
--- a/chart/templates/crds.yaml
+++ b/chart/templates/crds.yaml
@@ -342,6 +342,9 @@ spec:
                       type: string
                     progress:
                       type: integer
+                    realSize:
+                      format: int64
+                      type: integer
                     senderManagerAddress:
                       type: string
                     sendingReference:
@@ -559,13 +562,18 @@ spec:
                 type: object
               ownerID:
                 type: string
+              realSize:
+                description: Real size of image in bytes, which may be smaller than the size 
+                  when the file is a sparse file. Will be zero until known (e.g. while a backing image is uploading)
+                format: int64
+                type: integer
               size:
                 format: int64
                 type: integer
               uuid:
                 type: string
               virtualSize:
-                description: Virtual size of image, which may be larger than physical
+                description: Virtual size of image in bytes, which may be larger than physical
                   size. Will be zero until known (e.g. while a backing image is uploading)
                 format: int64
                 type: integer
@@ -2506,6 +2514,12 @@ spec:
                       type: string
                     instanceManagerName:
                       type: string
+                    scheduledBackingImage:
+                      additionalProperties:
+                        format: int64
+                        type: integer
+                      nullable: true
+                      type: object
                     scheduledReplica:
                       additionalProperties:
                         format: int64

--- a/deploy/longhorn-okd.yaml
+++ b/deploy/longhorn-okd.yaml
@@ -452,6 +452,9 @@ spec:
                       type: string
                     progress:
                       type: integer
+                    realSize:
+                      format: int64
+                      type: integer
                     senderManagerAddress:
                       type: string
                     sendingReference:
@@ -673,13 +676,18 @@ spec:
                 type: object
               ownerID:
                 type: string
+              realSize:
+                description: Real size of image in bytes, which may be smaller than the size 
+                  when the file is a sparse file. Will be zero until known (e.g. while a backing image is uploading)
+                format: int64
+                type: integer
               size:
                 format: int64
                 type: integer
               uuid:
                 type: string
               virtualSize:
-                description: Virtual size of image, which may be larger than physical
+                description: Virtual size of image in bytes, which may be larger than physical
                   size. Will be zero until known (e.g. while a backing image is uploading)
                 format: int64
                 type: integer
@@ -2652,6 +2660,12 @@ spec:
                       type: string
                     instanceManagerName:
                       type: string
+                    scheduledBackingImage:
+                      additionalProperties:
+                        format: int64
+                        type: integer
+                      nullable: true
+                      type: object
                     scheduledReplica:
                       additionalProperties:
                         format: int64

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -450,6 +450,9 @@ spec:
                       type: string
                     progress:
                       type: integer
+                    realSize:
+                      format: int64
+                      type: integer
                     senderManagerAddress:
                       type: string
                     sendingReference:
@@ -671,13 +674,18 @@ spec:
                 type: object
               ownerID:
                 type: string
+              realSize:
+                description: Real size of image in bytes, which may be smaller than the size 
+                  when the file is a sparse file. Will be zero until known (e.g. while a backing image is uploading)
+                format: int64
+                type: integer
               size:
                 format: int64
                 type: integer
               uuid:
                 type: string
               virtualSize:
-                description: Virtual size of image, which may be larger than physical
+                description: Virtual size of image in bytes, which may be larger than physical
                   size. Will be zero until known (e.g. while a backing image is uploading)
                 format: int64
                 type: integer
@@ -2650,6 +2658,12 @@ spec:
                       type: string
                     instanceManagerName:
                       type: string
+                    scheduledBackingImage:
+                      additionalProperties:
+                        format: int64
+                        type: integer
+                      nullable: true
+                      type: object
                     scheduledReplica:
                       additionalProperties:
                         format: int64


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/8757

- store realsize of backingimage in status
- add the realsize to storageScheduled in diskStatus
- add new field scheduledBackingImage in diskStatus