### PR TITLE
Helm Chart: Adds option for volume encryption and setup for volume encryption

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -157,6 +157,9 @@ The `values.yaml` contains items used to tweak a deployment of this chart.
 | persistence.recurringJobSelector.enable | bool | `false` | Setting that allows you to enable the recurring job selector for a Longhorn StorageClass. |
 | persistence.recurringJobSelector.jobList | list | `[]` | Recurring job selector for a Longhorn StorageClass. Ensure that quotes are used correctly when specifying job parameters. (Example: `[{"name":"backup", "isGroup":true}]`) |
 | persistence.removeSnapshotsDuringFilesystemTrim | string | `"ignored"` | Setting that allows you to enable automatic snapshot removal during filesystem trim for a Longhorn StorageClass. (Options: "ignored", "enabled", "disabled") |
+| persistence.encryption.enabled | bool | `false` | Enables volume encryption for persistent volumes. Requires `dm_crypt` kernel module and `cryptsetup` to be installed on nodes. |
+| persistence.encryption.secretName | string | `""` | (Optional) Name of the encryption secret. If not provided, a secret is automatically generated. |
+| persistence.encryption.secretNamespace | string | `""` | (Optional) Namespace where the encryption secret resides. Defaults to the release namespace. |
 
 ### CSI Settings
 

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,3 +1,18 @@
+{{- if .Values.persistence.encryption.enabled }}
+###############################################################################
+IMPORTANT: Backup the Encryption Secret
+###############################################################################
+Encryption has been enabled for your Longhorn volumes. To avoid losing access to your encrypted volumes, it’s crucial to back up the encryption secret.
+
+To backup the encryption secret, use the following command:
+
+kubectl get secret {{ .Values.persistence.encryption.secretName | default "longhorn-crypto" }} -n {{ include "release_namespace" . }} -o yaml > encryption-secret-backup.yaml
+
+Store this file securely, as losing this secret will result in permanent data loss for encrypted volumes.
+
+###############################################################################
+{{- end }}
+
 Longhorn is now installed on the cluster!
 
 Please wait a few minutes for other Longhorn components such as CSI deployments, Engine Images, and Instance Managers to be initialized.

--- a/chart/templates/storageclass.yaml
+++ b/chart/templates/storageclass.yaml
@@ -54,3 +54,12 @@ data:
       {{- if .Values.persistence.disableRevisionCounter }}
       disableRevisionCounter: "{{ .Values.persistence.disableRevisionCounter }}"
       {{- end }}
+      {{- if .Values.persistence.encryption.enabled }}
+      encrypted: "true"
+      csi.storage.k8s.io/provisioner-secret-name: {{ .Values.persistence.encryption.secretName | default "longhorn-crypto" | quote }}
+      csi.storage.k8s.io/provisioner-secret-namespace: {{ .Values.persistence.encryption.secretNamespace | default (include "release_namespace" .) | quote }}
+      csi.storage.k8s.io/node-publish-secret-name: {{ .Values.persistence.encryption.secretName | default "longhorn-crypto" | quote }}
+      csi.storage.k8s.io/node-publish-secret-namespace: {{ .Values.persistence.encryption.secretNamespace | default (include "release_namespace" .) | quote }}
+      csi.storage.k8s.io/node-stage-secret-name: {{ .Values.persistence.encryption.secretName | default "longhorn-crypto" | quote }}
+      csi.storage.k8s.io/node-stage-secret-namespace: {{ .Values.persistence.encryption.secretNamespace | default (include "release_namespace" .) | quote }}
+      {{- end }}

--- a/chart/templates/volume-encryption-secret.yaml
+++ b/chart/templates/volume-encryption-secret.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.persistence.encryption.enabled (not .Values.persistence.encryption.secretName) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: longhorn-crypto
+  namespace: {{ include "release_namespace" . }}
+data:
+    {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "longhorn-crypto") | default dict }}
+    {{- $secretData := (get $secretObj "data") | default dict }}
+    {{- $passphrase := (get $secretData "CRYPTO_KEY_VALUE") | default (randAlphaNum 32 | b64enc) }}
+    CRYPTO_KEY_VALUE: {{ $passphrase | quote }}
+    CRYPTO_KEY_PROVIDER: {{ ( "secret" | b64enc ) }}
+    CRYPTO_KEY_CIPHER: {{ ( "aes-xts-plain64" | b64enc ) }}
+    CRYPTO_KEY_HASH: {{ ( "sha256" | b64enc ) }}
+    CRYPTO_KEY_SIZE: {{ ( "256" | b64enc ) }}
+    CRYPTO_PBKDF: {{ ( "argon2i" | b64enc ) }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -172,6 +172,15 @@ persistence:
     selector: ""
   # -- Setting that allows you to enable automatic snapshot removal during filesystem trim for a Longhorn StorageClass. (Options: "ignored", "enabled", "disabled")
   removeSnapshotsDuringFilesystemTrim: ignored
+  encryption:
+    # -- Setting that allows you to enable volume encryption with a global secret (Details: https://longhorn.io/docs/1.7.1/advanced-resources/security/volume-encryption/).
+    # -- Requirements: To use encrypted volumes, ensure that the dm_crypt kernel module is loaded and that cryptsetup is installed on your worker nodes.
+    enabled: false
+    # -- Name of the encryption secret. When not provided, a secret is generated automatically.
+    # -- Note: As the secret generation uses helms lookup functions to check for existing secrets, there maybe some issues when using CD Tools like ArgoCD, relying on the templating engine and not supporting the lookup functions.
+    # secretName: ""
+    # -- Namespace of the encryption secret. Defaults to the release namespace.
+    # secretNamespace: ""
 
 preUpgradeChecker:
   # -- Setting that allows Longhorn to perform pre-upgrade checks. Disable this setting when installing Longhorn using Argo CD or other GitOps solutions.


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:

This PR introduces the option to enable volume encryption.

Adds:
- Volume Encryption: An option to enable encryption at the storage class level, ensuring that all new volumes are encrypted by default.
- Secret Management: Support for defining custom encryption secrets, with automatic generation of encryption secrets when not provided.
- Backup of Encryption Secret: Instructions are included for backing up/ extracting the encryption secret.

#### Special notes for your reviewer:

#### Additional documentation or context

[Longhorns docs](https://longhorn.io/docs/1.7.1/advanced-resources/security/volume-encryption/).