### PR TITLE
chore: update cifs backupstore image

### DIFF
--- a/deploy/backupstores/cifs-backupstore.yaml
+++ b/deploy/backupstores/cifs-backupstore.yaml
@@ -40,7 +40,7 @@ spec:
         emptyDir: {}
       containers:
       - name: longhorn-test-cifs-container
-        image: derekbit/samba:latest
+        image: chanow/samba:latest
         ports:
         - containerPort: 139
         - containerPort: 445


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue #9699

#### What this PR does / why we need it:

cifs in cluster pod crashs on sles15, update the deploy manifest to use new image which include fix https://github.com/derekbit/backupstore-samba/commit/980013dca97703d4543e9b68e5ff888b0e286020 

cc @derekbit 

#### Special notes for your reviewer:

N/A

#### Additional documentation or context

N/A
