### PR TITLE
chore: increase cifs in cluster backupstore size from 4096 to 8192

### DIFF
--- a/deploy/backupstores/cifs-backupstore.yaml
+++ b/deploy/backupstores/cifs-backupstore.yaml
@@ -49,7 +49,7 @@ spec:
         - name: EXPORT_PATH
           value: /opt/backupstore
         - name: CIFS_DISK_IMAGE_SIZE_MB
-          value: "4096"
+          value: "8192"
         - name: CIFS_USERNAME
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

N/A

#### What this PR does / why we need it:

For support e2e test case [Test Incremental Restore](https://github.com/longhorn/longhorn-tests/blob/942e57e38ecf62266a449924b3725dfffcbbac36/e2e/tests/regression/test_backup.robot#L63), the default size `4 Gi` is not enough.

#### Special notes for your reviewer:

After the backup store size increased, test case `Test Incremental Restore` passed on local env using `cifs` backup store

#### Additional documentation or context

N/A