### PR TITLE
chore: update azurite image from 3.30.0 to 3.33.0

### DIFF
--- a/deploy/backupstores/azurite-backupstore.yaml
+++ b/deploy/backupstores/azurite-backupstore.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: azurite
-        image: mcr.microsoft.com/azure-storage/azurite:3.30.0
+        image: mcr.microsoft.com/azure-storage/azurite:3.33.0
         ports:
         - containerPort: 10000
 ---


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

N/A

#### What this PR does / why we need it:

The default [Azure CLI ](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt)version on SLES 15 is `2.58.0`, and the Azurite container image need updating.

Or below error will appear when using in cluster azurite backup store
```
RESPONSE 400: 400 The API version 2024-08-04 is not supported by Azurite. Please upgrade Azurite to latest version and retry
```

#### Special notes for your reviewer:

Tested on Sles15 (default azure cli version =`2.58.0`) and on ubuntu 24.04 (default azure cli version =`2.65.0`)

#### Additional documentation or context
