### PR TITLE
ci: add wont fix label if issues are marked as unplanned

### DIFF
--- a/.github/workflows/wont-fix.yml
+++ b/.github/workflows/wont-fix.yml
@@ -1,0 +1,27 @@
+name: Add-Wontfix-Label-To-Not-Planned-Issue
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  add-wontfix-label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check if the issue was closed with reason "not planned"
+        id: check-closed-reason
+        uses: actions/github-script@v6
+        with:
+          script: |
+            if (context.payload.issue.state_reason === "not_planned") {
+              return true;
+            }
+            return false;
+
+      - name: Add wontfix label
+        if: steps.check-closed-reason.outputs.result == 'true'
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: wontfix
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/8169

#### What this PR does / why we need it:

add wont fix label if issues are marked as unplanned

#### Special notes for your reviewer:

#### Additional documentation or context
