### PR TITLE
Introducing Longhorn Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You can read more technical details of Longhorn [here](https://longhorn.io/).
 
 # Releases
 
-> - __<version>*__ means the release branch is under active support and will have periodic follow-up patch releases.
+> **NOTE**:
 > - __\<version\>*__ means the release branch is under active support and will have periodic follow-up patch releases.
 > - __Latest__ release means the version is the latest release of the newest release branch.
 > - __Stable__ release means the version is stable and has been widely adopted by users.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Releases](https://img.shields.io/github/release/longhorn/longhorn/all.svg)](https://github.com/longhorn/longhorn/releases)
 [![GitHub](https://img.shields.io/github/license/longhorn/longhorn)](https://github.com/longhorn/longhorn/blob/master/LICENSE)
 [![Docs](https://img.shields.io/badge/docs-latest-green.svg)](https://longhorn.io/docs/latest/)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Longhorn%20Guru-006BFF)](https://gurubase.io/g/longhorn)
 
 </div>
 
@@ -30,7 +31,7 @@ You can read more technical details of Longhorn [here](https://longhorn.io/).
 
 # Releases
 
-> **NOTE**:
+> - __<version>*__ means the release branch is under active support and will have periodic follow-up patch releases.
 > - __\<version\>*__ means the release branch is under active support and will have periodic follow-up patch releases.
 > - __Latest__ release means the version is the latest release of the newest release branch.
 > - __Stable__ release means the version is stable and has been widely adopted by users.


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Longhorn Guru](https://gurubase.io/g/longhorn) to Gurubase. Longhorn Guru uses the data from this repo and data from the [docs](https://longhorn.io/docs/1.7.2/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Longhorn Guru", which highlights that Longhorn now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Longhorn Guru in Gurubase, just let me know that's totally fine.
