### PR TITLE
ci: unset milestone if a backport ticket is closed as not planned

### DIFF
--- a/.github/workflows/wont-fix.yml
+++ b/.github/workflows/wont-fix.yml
@@ -25,3 +25,17 @@ jobs:
         with:
           labels: wontfix
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Clear milestone
+        if: steps.check-closed-reason.outputs.result == 'true'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const issue_number = context.payload.issue.number;
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              milestone: null
+            });
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/9611

#### What this PR does / why we need it:

unset milestone if a backport ticket is closed as not planned

#### Special notes for your reviewer:

#### Additional documentation or context
