### PR TITLE
chore: deploy MinIO/NFS on ctrl node for stability

### DIFF
--- a/deploy/backupstores/minio-backupstore.yaml
+++ b/deploy/backupstores/minio-backupstore.yaml
@@ -41,6 +41,27 @@ spec:
       labels:
         app: longhorn-test-minio
     spec:
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: "true"
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoExecute"
+      - key: "node-role.kubernetes.io/control-plane"
+        operator: "Exists"
+        effect: "NoSchedule"
+      - key: "node-role.kubernetes.io/control-plane"
+        operator: "Exists"
+        effect: "NoExecute"
+      - key: "node-role.kubernetes.io/etcd"
+        operator: "Exists"
+        effect: "NoSchedule"
+      - key: "node-role.kubernetes.io/etcd"
+        operator: "Exists"
+        effect: "NoExecute"
       volumes:
       - name: minio-volume
         emptyDir: {}

--- a/deploy/backupstores/nfs-backupstore.yaml
+++ b/deploy/backupstores/nfs-backupstore.yaml
@@ -14,6 +14,27 @@ spec:
       labels:
         app: longhorn-test-nfs
     spec:
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: "true"
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoExecute"
+      - key: "node-role.kubernetes.io/control-plane"
+        operator: "Exists"
+        effect: "NoSchedule"
+      - key: "node-role.kubernetes.io/control-plane"
+        operator: "Exists"
+        effect: "NoExecute"
+      - key: "node-role.kubernetes.io/etcd"
+        operator: "Exists"
+        effect: "NoSchedule"
+      - key: "node-role.kubernetes.io/etcd"
+        operator: "Exists"
+        effect: "NoExecute"
       volumes:
       - name: nfs-volume
         emptyDir: {}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
https://github.com/longhorn/longhorn/issues/8425

#### What this PR does / why we need it:
- Deploys the backup store on the control node to improve reliability. This is based on discussions with @yangchiu and @chriscchien.
- Previous tests showed that when the `DR volume` is attached to the same node as the `longhorn-test-minio` pod or an `NFS` pod, rebooting the node causes the `DR` volume to enter a Faulted state.

Note : **This change might affect existing backup and restore processes in environments without a dedicated control node.**

#### Special notes for your reviewer:

#### Additional documentation or context
https://github.com/longhorn/longhorn/issues/8425
https://github.com/longhorn/longhorn/issues/9752#issuecomment-2453923408

`MinIO`/`NFS` on the control node regression test result: https://ci.longhorn.io/job/private/job/longhorn-tests-regression/7724
![Screenshot_20241202_121227](https://github.com/user-attachments/assets/7c915b82-a22d-4534-9842-16f4ec34a267)
![Screenshot_20241202_121207](https://github.com/user-attachments/assets/595e2d2f-2bb2-4bba-b612-1c39b4e32392)
