### PR TITLE
feat(chart): mount host's /etc on Longhorn manager for NFS configuration check

### DIFF
--- a/chart/templates/daemonset-sa.yaml
+++ b/chart/templates/daemonset-sa.yaml
@@ -69,6 +69,8 @@ spec:
           mountPath: /host/dev/
         - name: proc
           mountPath: /host/proc/
+        - name: etc
+          mountPath: /host/etc/
         - name: longhorn
           mountPath: /var/lib/longhorn/
           mountPropagation: Bidirectional
@@ -113,6 +115,9 @@ spec:
       - name: proc
         hostPath:
           path: /proc/
+      - name: etc
+        hostPath:
+          path: /etc/
       - name: longhorn
         hostPath:
           path: /var/lib/longhorn/

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -4896,6 +4896,8 @@ spec:
           mountPath: /host/dev/
         - name: proc
           mountPath: /host/proc/
+        - name: etc
+          mountPath: /host/etc/
         - name: longhorn
           mountPath: /var/lib/longhorn/
           mountPropagation: Bidirectional
@@ -4932,6 +4934,9 @@ spec:
       - name: proc
         hostPath:
           path: /proc/
+      - name: etc
+        hostPath:
+          path: /etc/
       - name: longhorn
         hostPath:
           path: /var/lib/longhorn/


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#9830

#### What this PR does / why we need it:

LH manager's node controller checks the NFS configuration for LH node runtime status. It needs host's `/etc/` to read `/etc/nfsmount.conf`

#### Special notes for your reviewer:

#### Additional documentation or context
