### PR TITLE
feat(script/env_check): check overriden NFS version

### DIFF
--- a/scripts/environment_check.sh
+++ b/scripts/environment_check.sh
@@ -388,6 +388,7 @@ check_nfs_client() {
     return 1
   fi
 
+  local nfs_module_not_found=1
   for option in "${options[@]}"; do
     kubectl exec ${pod} -- nsenter --mount=/proc/1/ns/mnt -- bash -c "[ -f /boot/config-${kernel} ]" > /dev/null 2>&1
     if [ $? -ne 0 ]; then
@@ -396,13 +397,27 @@ check_nfs_client() {
     fi
 
     check_kernel_module ${pod} ${option} nfs
-    if [ $? = 0 ]; then
-      return 0
+    nfs_module_not_found=$?
+    if [ $nfs_module_not_found = 0 ]; then
+      break
     fi
   done
 
-  error "NFS clients ${options[*]} not found. At least one should be enabled"
-  return 1
+  if [ $nfs_module_not_found -ne 0 ]; then
+    error "NFS clients ${options[*]} not found. At least one should be enabled"
+    return 1
+  fi
+
+  local nfs_ver_overriden=$(kubectl exec ${pod} -- nsenter --mount=/proc/1/ns/mnt -- bash -c "grep '^\s*Defaultvers=' /etc/nfsmount.conf" 2> /dev/null)
+  if [ "$nfs_ver_overriden" ]; then
+    echo "$nfs_ver_overriden" | grep -x '.*Defaultvers=4\(\.[0-2]\?\)\?\s*'
+    if [ $? -ne 0 ]; then
+      error "NFS4 is supported, but default protocol version (${nfs_ver_overriden}) is not 4, 4.1, or 4.2. Please refer to the NFS mount configuration manual page for more information: man 5 nfsmount.conf"
+      return 1
+    fi
+  fi
+
+  return 0
 }
 
 check_kernel_module() {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#9830

#### What this PR does / why we need it:

Though the node supports NFSv4, the NFS client picks the protocol version by `Defaultvers` defined in `nfsmount.conf`. This may cause problem while using backup-related features.

This change is kind of a backport version of longhorn/cli#129. It is needed since Longhorn v1.6 is still maintained, while `longhornctl check preflight` is provided after v1.7.

#### Special notes for your reviewer:

#### Additional documentation or context
