### PR TITLE
feat(chart): mount host's /boot & /proc on Longhorn manager for env check

### DIFF
--- a/chart/templates/daemonset-sa.yaml
+++ b/chart/templates/daemonset-sa.yaml
@@ -65,10 +65,12 @@ spec:
         volumeMounts:
         - name: boot
           mountPath: /host/boot/
+          readOnly: true
         - name: dev
           mountPath: /host/dev/
         - name: proc
           mountPath: /host/proc/
+          readOnly: true
         - name: etc
           mountPath: /host/etc/
           readOnly: true

--- a/deploy/longhorn-okd.yaml
+++ b/deploy/longhorn-okd.yaml
@@ -5032,10 +5032,12 @@ spec:
         volumeMounts:
         - name: boot
           mountPath: /host/boot/
+          readOnly: true
         - name: dev
           mountPath: /host/dev/
         - name: proc
           mountPath: /host/proc/
+          readOnly: true
         - name: etc
           mountPath: /host/etc/
           readOnly: true

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -4969,10 +4969,12 @@ spec:
         volumeMounts:
         - name: boot
           mountPath: /host/boot/
+          readOnly: true
         - name: dev
           mountPath: /host/dev/
         - name: proc
           mountPath: /host/proc/
+          readOnly: true
         - name: etc
           mountPath: /host/etc/
           readOnly: true


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#9830

#### What this PR does / why we need it:

For Longhorn manager, besides `/etc`, the `/boot` and `/proc` hostpath mounts are needed for environment check, thus we only need RO mount for safety.

#### Additional documentation or context

Previous change: #9910
Doc change: longhorn/website#1019