### PR TITLE
chore(cve): update vendor

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -116,7 +116,7 @@ The `values.yaml` contains items used to tweak a deployment of this chart.
 | image.longhorn.shareManager.repository | string | `"longhornio/longhorn-share-manager"` | Repository for the Longhorn Share Manager image. |
 | image.longhorn.shareManager.tag | string | `"v1.6.1"` | Specify Longhorn share manager image tag |
 | image.longhorn.supportBundleKit.repository | string | `"longhornio/support-bundle-kit"` | Repository for the Longhorn Support Bundle Manager image. |
-| image.longhorn.supportBundleKit.tag | string | `"v0.0.47"` | Tag for the Longhorn Support Bundle Manager image. |
+| image.longhorn.supportBundleKit.tag | string | `"v0.0.48"` | Tag for the Longhorn Support Bundle Manager image. |
 | image.longhorn.ui.repository | string | `"longhornio/longhorn-ui"` | Repository for the Longhorn UI image. |
 | image.longhorn.ui.tag | string | `"v1.6.1"` | Specify Longhorn ui image tag |
 | image.openshift.oauthProxy.repository | string | `""` | Repository for the OAuth Proxy image. Specify the upstream image (for example, "quay.io/openshift/origin-oauth-proxy"). This setting applies only to OpenShift users. |

--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -89,7 +89,7 @@ questions:
     label: Longhorn Support Bundle Kit Image Repository
     group: "Longhorn Images Settings"
   - variable: image.longhorn.supportBundleKit.tag
-    default: v0.0.47
+    default: v0.0.48
     description: "Tag for the Longhorn Support Bundle Manager image."
     type: string
     label: Longhorn Support Bundle Kit Image Tag

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -69,7 +69,7 @@ image:
       # -- Repository for the Longhorn Support Bundle Manager image.
       repository: longhornio/support-bundle-kit
       # -- Tag for the Longhorn Support Bundle Manager image.
-      tag: v0.0.47
+      tag: v0.0.48
   csi:
     attacher:
       # -- Repository for the CSI attacher image. When unspecified, Longhorn uses the default value.

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -10,4 +10,4 @@ longhornio/longhorn-instance-manager:v1.6.3
 longhornio/longhorn-manager:v1.6.3
 longhornio/longhorn-share-manager:v1.6.3
 longhornio/longhorn-ui:v1.6.3
-longhornio/support-bundle-kit:v0.0.47
+longhornio/support-bundle-kit:v0.0.48

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -4631,7 +4631,7 @@ spec:
         - --backing-image-manager-image
         - "longhornio/backing-image-manager:v1.6.3"
         - --support-bundle-manager-image
-        - "longhornio/support-bundle-kit:v0.0.47"
+        - "longhornio/support-bundle-kit:v0.0.48"
         - --manager-image
         - "longhornio/longhorn-manager:v1.6.3"
         - --service-account


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#9898

#### What this PR does / why we need it:

**After**
```
longhornio/support-bundle-kit:v0.0.48 (suse linux enterprise server 15.6)
=========================================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


usr/bin/yq (gobinary)
=====================
Total: 1 (HIGH: 1, CRITICAL: 0)

┌──────────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬───────────────────────────────────────────────────┐
│     Library      │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                       Title                       │
├──────────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼───────────────────────────────────────────────────┤
│ golang.org/x/net │ CVE-2024-45338 │ HIGH     │ fixed  │ v0.32.0           │ 0.33.0        │ Non-linear parsing of case-insensitive content in │
│                  │                │          │        │                   │               │ golang.org/x/net/html                             │
│                  │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-45338        │
└──────────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴───────────────────────────────────────────────────┘
```

**Before**
```
rancher/support-bundle-kit:v0.0.47 (suse linux enterprise server 15.6)
======================================================================
Total: 1 (HIGH: 1, CRITICAL: 0)

┌───────────────┬─────────────────────┬──────────┬────────┬─────────────────────┬─────────────────────┬───────────────────────────┐
│    Library    │    Vulnerability    │ Severity │ Status │  Installed Version  │    Fixed Version    │           Title           │
├───────────────┼─────────────────────┼──────────┼────────┼─────────────────────┼─────────────────────┼───────────────────────────┤
│ libglib-2_0-0 │ SUSE-SU-2024:4254-1 │ HIGH     │ fixed  │ 2.78.6-150600.4.3.1 │ 2.78.6-150600.4.8.1 │ Security update for glib2 │
└───────────────┴─────────────────────┴──────────┴────────┴─────────────────────┴─────────────────────┴───────────────────────────┘

usr/bin/yq (gobinary)
=====================
Total: 1 (HIGH: 1, CRITICAL: 0)

┌──────────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬───────────────────────────────────────────────────┐
│     Library      │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                       Title                       │
├──────────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼───────────────────────────────────────────────────┤
│ golang.org/x/net │ CVE-2024-45338 │ HIGH     │ fixed  │ v0.31.0           │ 0.33.0        │ Non-linear parsing of case-insensitive content in │
│                  │                │          │        │                   │               │ golang.org/x/net/html                             │
│                  │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-45338        │
└──────────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴───────────────────────────────────────────────────┘
```

#### Special notes for your reviewer:

Won't fix:
- `yq`: not fixed in upstream yet.

#### Additional documentation or context

`None`
