### PR TITLE
feat(backup): separate backup settings from default settings

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -120,7 +120,7 @@ The `values.yaml` contains items used to tweak a deployment of this chart.
 | image.longhorn.ui.repository | string | `"longhornio/longhorn-ui"` | Repository for the Longhorn UI image. |
 | image.longhorn.ui.tag | string | `"master-head"` | Tag for the Longhorn UI image. |
 | image.openshift.oauthProxy.repository | string | `""` | Repository for the OAuth Proxy image. Specify the upstream image (for example, "quay.io/openshift/origin-oauth-proxy"). This setting applies only to OpenShift users. |
-| image.openshift.oauthProxy.tag | float | `""` | Tag for the OAuth Proxy image. Specify OCP/OKD version 4.1 or later (including version 4.15, which is available at quay.io/openshift/origin-oauth-proxy:4.15). This setting applies only to OpenShift users. |
+| image.openshift.oauthProxy.tag | string | `""` | Tag for the OAuth Proxy image. Specify OCP/OKD version 4.1 or later (including version 4.15, which is available at quay.io/openshift/origin-oauth-proxy:4.15). This setting applies only to OpenShift users. |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy that applies to all user-deployed Longhorn components, such as Longhorn Manager, Longhorn driver, and Longhorn UI. |
 
 ### Service Settings
@@ -141,6 +141,7 @@ The `values.yaml` contains items used to tweak a deployment of this chart.
 | persistence.backingImage.enable | bool | `false` | Setting that allows you to use a backing image in a Longhorn StorageClass. |
 | persistence.backingImage.expectedChecksum | string | `nil` | Expected SHA-512 checksum of a backing image used in a Longhorn StorageClass. |
 | persistence.backingImage.name | string | `nil` | Backing image to be used for creating and restoring volumes in a Longhorn StorageClass. When no backing images are available, specify the data source type and parameters that Longhorn can use to create a backing image. |
+| persistence.dataEngine | string | `"v1"` | Setting that allows you to specify the data engine version for the default Longhorn StorageClass. (Options: "v1", "v2") |
 | persistence.defaultClass | bool | `true` | Setting that allows you to specify the default Longhorn StorageClass. |
 | persistence.defaultClassReplicaCount | int | `3` | Replica count of the default Longhorn StorageClass. |
 | persistence.defaultDataLocality | string | `"disabled"` | Data locality of the default Longhorn StorageClass. (Options: "disabled", "best-effort") |
@@ -259,6 +260,10 @@ For more details, see the [ocp-readme](https://github.com/longhorn/longhorn/blob
 | Key | Default | Description |
 |-----|---------|-------------|
 | annotations | `{}` | Annotation for the Longhorn Manager DaemonSet pods. This setting is optional. |
+| defaultBackupStore | `{"backupTarget":null,"backupTargetCredentialSecret":null,"pollInterval":null}` | Setting that allows you to update the default backupstore. |
+| defaultBackupStore.backupTarget | `nil` | Endpoint used to access the default backupstore. (Options: "NFS", "CIFS", "AWS", "GCP", "AZURE") |
+| defaultBackupStore.backupTargetCredentialSecret | `nil` | Name of the Kubernetes secret associated with the default backup target. |
+| defaultBackupStore.pollInterval | `nil` | Number of seconds that Longhorn waits before checking the default backupstore for new backups. The default value is "300". When the value is "0", polling is disabled. |
 | enableGoCoverDir | `false` | Setting that allows Longhorn to generate code coverage profiles. |
 | enablePSP | `false` | Setting that allows you to enable pod security policies (PSPs) that allow privileged Longhorn pods to start. This setting applies only to clusters running Kubernetes 1.25 and earlier, and with the built-in Pod Security admission controller enabled. |
 | namespaceOverride | `""` | Specify override namespace, specifically this is useful for using longhorn as sub-chart and its release namespace is not the `longhorn-system`. |
@@ -286,9 +291,6 @@ During installation, you can either allow Longhorn to use the default system set
 | defaultSettings.backupCompressionMethod | Setting that allows you to specify a backup compression method. |
 | defaultSettings.backupConcurrentLimit | Maximum number of worker threads that can concurrently run for each backup. |
 | defaultSettings.backupExecutionTimeout | Number of minutes that Longhorn allows for the backup execution. The default value is "1". |
-| defaultSettings.backupTarget | Endpoint used to access the backupstore. (Options: "NFS", "CIFS", "AWS", "GCP", "AZURE") |
-| defaultSettings.backupTargetCredentialSecret | Name of the Kubernetes secret associated with the backup target. |
-| defaultSettings.backupstorePollInterval | Number of seconds that Longhorn waits before checking the backupstore for new backups. The default value is "300". When the value is "0", polling is disabled. |
 | defaultSettings.concurrentAutomaticEngineUpgradePerNodeLimit | Maximum number of engines that are allowed to concurrently upgrade on each node after Longhorn Manager is upgraded. When the value is "0", Longhorn does not automatically upgrade volume engines to the new default engine image version. |
 | defaultSettings.concurrentReplicaRebuildPerNodeLimit | Maximum number of replicas that can be concurrently rebuilt on each node. |
 | defaultSettings.concurrentVolumeBackupRestorePerNodeLimit | Maximum number of volumes that can be concurrently restored on each node using a backup. When the value is "0", restoration of volumes using a backup is disabled. |

--- a/chart/templates/default-resource.yaml
+++ b/chart/templates/default-resource.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: longhorn-default-resource
+  namespace: {{ include "release_namespace" . }}
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+data:
+  default-resource.yaml: |-
+    {{- if not (kindIs "invalid" .Values.defaultBackupStore.backupTarget) }}
+    backup-target: {{ .Values.defaultBackupStore.backupTarget }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultBackupStore.backupTargetCredentialSecret) }}
+    backup-target-credential-secret: {{ .Values.defaultBackupStore.backupTargetCredentialSecret }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultBackupStore.pollInterval) }}
+    backupstore-poll-interval: {{ .Values.defaultBackupStore.pollInterval }}
+    {{- end }}

--- a/chart/templates/default-setting.yaml
+++ b/chart/templates/default-setting.yaml
@@ -6,12 +6,6 @@ metadata:
   labels: {{- include "longhorn.labels" . | nindent 4 }}
 data:
   default-setting.yaml: |-
-    {{- if not (kindIs "invalid" .Values.defaultSettings.backupTarget) }}
-    backup-target: {{ .Values.defaultSettings.backupTarget }}
-    {{- end }}
-    {{- if not (kindIs "invalid" .Values.defaultSettings.backupTargetCredentialSecret) }}
-    backup-target-credential-secret: {{ .Values.defaultSettings.backupTargetCredentialSecret }}
-    {{- end }}
     {{- if not (kindIs "invalid" .Values.defaultSettings.allowRecurringJobWhileVolumeDetached) }}
     allow-recurring-job-while-volume-detached: {{ .Values.defaultSettings.allowRecurringJobWhileVolumeDetached }}
     {{- end }}
@@ -47,9 +41,6 @@ data:
     {{- end }}
     {{- if not (kindIs "invalid" .Values.defaultSettings.defaultLonghornStaticStorageClass) }}
     default-longhorn-static-storage-class: {{ .Values.defaultSettings.defaultLonghornStaticStorageClass }}
-    {{- end }}
-    {{- if not (kindIs "invalid" .Values.defaultSettings.backupstorePollInterval) }}
-    backupstore-poll-interval: {{ .Values.defaultSettings.backupstorePollInterval }}
     {{- end }}
     {{- if not (kindIs "invalid" .Values.defaultSettings.failedBackupTTL) }}
     failed-backup-ttl: {{ .Values.defaultSettings.failedBackupTTL }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -194,10 +194,6 @@ csi:
   snapshotterReplicaCount: ~
 
 defaultSettings:
-  # -- Endpoint used to access the backupstore. (Options: "NFS", "CIFS", "AWS", "GCP", "AZURE")
-  backupTarget: ~
-  # -- Name of the Kubernetes secret associated with the backup target.
-  backupTargetCredentialSecret: ~
   # -- Setting that allows Longhorn to automatically attach a volume and create snapshots or backups when recurring jobs are run.
   allowRecurringJobWhileVolumeDetached: ~
   # -- Setting that allows Longhorn to automatically create a default disk only on nodes with the label "node.longhorn.io/create-default-disk=true" (if no other disks exist). When this setting is disabled, Longhorn creates a default disk on each node that is added to the cluster.
@@ -222,8 +218,6 @@ defaultSettings:
   defaultReplicaCount: ~
   # -- Default name of Longhorn static StorageClass. "storageClassName" is assigned to PVs and PVCs that are created for an existing Longhorn volume. "storageClassName" can also be used as a label, so it is possible to use a Longhorn StorageClass to bind a workload to an existing PV without creating a Kubernetes StorageClass object. "storageClassName" needs to be an existing StorageClass. The default value is "longhorn-static".
   defaultLonghornStaticStorageClass: ~
-  # -- Number of seconds that Longhorn waits before checking the backupstore for new backups. The default value is "300". When the value is "0", polling is disabled.
-  backupstorePollInterval: ~
   # -- Number of minutes that Longhorn keeps a failed backup resource. When the value is "0", automatic deletion is disabled.
   failedBackupTTL: ~
   # -- Number of minutes that Longhorn allows for the backup execution. The default value is "1".
@@ -349,6 +343,15 @@ defaultSettings:
   autoCleanupSnapshotWhenDeleteBackup: ~
   # -- Setting that allows Longhorn to detect node failure and immediately migrate affected RWX volumes.
   rwxVolumeFastFailover: ~
+
+# -- Setting that allows you to update the default backupstore.
+defaultBackupStore:
+  # -- Endpoint used to access the default backupstore. (Options: "NFS", "CIFS", "AWS", "GCP", "AZURE")
+  backupTarget: ~
+  # -- Name of the Kubernetes secret associated with the default backup target.
+  backupTargetCredentialSecret: ~
+  # -- Number of seconds that Longhorn waits before checking the default backupstore for new backups. The default value is "300". When the value is "0", polling is disabled.
+  pollInterval: ~
 
 privateRegistry:
   # -- Setting that allows you to create a private registry secret.

--- a/deploy/longhorn-okd.yaml
+++ b/deploy/longhorn-okd.yaml
@@ -54,6 +54,19 @@ metadata:
     app.kubernetes.io/instance: longhorn
     app.kubernetes.io/version: v1.8.0-dev
 ---
+# Source: longhorn/templates/default-resource.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: longhorn-default-resource
+  namespace: longhorn-system
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.0-dev
+data:
+  default-resource.yaml: |-
+---
 # Source: longhorn/templates/default-setting.yaml
 apiVersion: v1
 kind: ConfigMap

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -52,6 +52,19 @@ metadata:
     app.kubernetes.io/instance: longhorn
     app.kubernetes.io/version: v1.8.0-dev
 ---
+# Source: longhorn/templates/default-resource.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: longhorn-default-resource
+  namespace: longhorn-system
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.0-dev
+data:
+  default-resource.yaml: |-
+---
 # Source: longhorn/templates/default-setting.yaml
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#5411, longhorn/longhorn#10089

#### What this PR does / why we need it:

Separate the default backup related settings from default settings into a new yaml file `default-backupstore-setting.yaml`

Introduce a new category `defaultBackupStoreSettings` to control the default backupstore related settings with Helm.

#### Special notes for your reviewer:

#### Additional documentation or context
