### PR TITLE
fix(workflow): fix DCO error while executing update-branch-image-tags

### DIFF
--- a/.github/workflows/update-branch-image-tags.yaml
+++ b/.github/workflows/update-branch-image-tags.yaml
@@ -101,7 +101,7 @@ jobs:
         sign-commits: true
         signoff: true
         author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-        committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+        committer: Longhorn GitHub Bot 67932897+longhorn-io-github-bot@users.noreply.github.com
         commit-message: "chore: update image tags for branch ${{ inputs.branch }}"
         title: "chore: update image tags for branch ${{ inputs.branch }}"
         body: |


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:


```
Commit sha: e93b71f, Author: Longhorn GitHub Bot, Committer: Longhorn GitHub Bot;
Expected "Longhorn GitHub Bot 67932897+longhorn-io-github-bot@users.noreply.github.com",
but got "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>".
```

#### Special notes for your reviewer:

#### Additional documentation or context
