### PR TITLE
feat(workflow): set Ready For Testing ticket's sprint to current

### DIFF
--- a/.github/workflows/add-issue-to-projects.yml
+++ b/.github/workflows/add-issue-to-projects.yml
@@ -1,4 +1,4 @@
-name: Add-To-Projects
+name: Add Issue To Projects
 on:
   issues:
     types: [opened]

--- a/.github/workflows/periodic-issue-sprint-update.yml
+++ b/.github/workflows/periodic-issue-sprint-update.yml
@@ -1,4 +1,4 @@
-name: Update-Issue-Sprint
+name: Periodic Issue Sprint Update
 
 on:
   schedule:
@@ -52,6 +52,18 @@ jobs:
         iteration: current
         new-iteration: next
         statuses: "Review"
+
+    - name: Longhorn Sprint Issues - Update None to Current Sprint
+      if: steps.check_sprint_build_required.outcome == 'success'
+      uses: derekbit/move-to-next-iteration@master
+      with:
+        owner: longhorn
+        number: 8
+        token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+        iteration-field: Sprint
+        iteration: none
+        new-iteration: current
+        statuses: "Ready For Testing"
 
     - name: QA Sprint - Clear Sprint
       uses: derekbit/move-to-next-iteration@master

--- a/.github/workflows/update-community-review-sprint-issue-status.yaml
+++ b/.github/workflows/update-community-review-sprint-issue-status.yaml
@@ -1,4 +1,4 @@
-name: Update-Projects
+name: Update Community Review Sprint Issue Status
 on:
   issues:
     types: [labeled, milestoned, reopened, closed]


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#10410

#### What this PR does / why we need it:

Set "Ready For Testing" ticket's sprint to current if it is not set.

#### Special notes for your reviewer:

#### Additional documentation or context
