### PR TITLE
feat(k8s): deprecate v1beta1 CRDs

### DIFF
--- a/chart/templates/crds.yaml
+++ b/chart/templates/crds.yaml
@@ -39,6 +39,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 BackingImageDataSource is deprecated;
+      use longhorn.io/v1beta2 BackingImageDataSource instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -67,7 +70,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -228,6 +231,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 BackingImageManager is deprecated; use
+      longhorn.io/v1beta2 BackingImageManager instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -256,7 +262,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -417,6 +423,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 BackingImage is deprecated; use longhorn.io/v1beta2
+      BackingImage instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -444,7 +453,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -815,6 +824,9 @@ spec:
       jsonPath: .status.lastSyncedAt
       name: LastSyncedAt
       type: string
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 Backup is deprecated; use longhorn.io/v1beta2
+      Backup instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -842,7 +854,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -1057,6 +1069,9 @@ spec:
       jsonPath: .status.lastSyncedAt
       name: LastSyncedAt
       type: string
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 BackupTarget is deprecated; use longhorn.io/v1beta2
+      BackupTarget instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -1084,7 +1099,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -1242,6 +1257,9 @@ spec:
       jsonPath: .status.lastSyncedAt
       name: LastSyncedAt
       type: string
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 BackupVolume is deprecated; use longhorn.io/v1beta2
+      BackupVolume instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -1269,7 +1287,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -1448,6 +1466,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 EngineImage is deprecated; use longhorn.io/v1beta2
+      EngineImage instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -1475,7 +1496,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -1648,6 +1669,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 Engine is deprecated; use longhorn.io/v1beta2
+      Engine instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -1675,7 +1699,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -2040,6 +2064,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 InstanceManager is deprecated; use longhorn.io/v1beta2
+      InstanceManager instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -2067,7 +2094,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -2391,6 +2418,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 Node is deprecated; use longhorn.io/v1beta2
+      Node instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -2418,7 +2448,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -2786,6 +2816,9 @@ spec:
       jsonPath: .spec.labels
       name: Labels
       type: string
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 RecurringJob is deprecated; use longhorn.io/v1beta2
+      RecurringJob instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -2813,7 +2846,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -2979,6 +3012,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 Replica is deprecated; use longhorn.io/v1beta2
+      Replica instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -3006,7 +3042,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -3248,6 +3284,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 Setting is deprecated; use longhorn.io/v1beta2
+      Setting instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -3275,7 +3314,7 @@ spec:
         required:
         - value
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -3364,6 +3403,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 ShareManager is deprecated; use longhorn.io/v1beta2
+      ShareManager instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -3391,7 +3433,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -4166,6 +4208,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 Volume is deprecated; use longhorn.io/v1beta2
+      Volume instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -4193,7 +4238,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/deploy/longhorn-okd.yaml
+++ b/deploy/longhorn-okd.yaml
@@ -159,6 +159,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 BackingImageDataSource is deprecated;
+      use longhorn.io/v1beta2 BackingImageDataSource instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -187,7 +190,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -352,6 +355,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 BackingImageManager is deprecated; use
+      longhorn.io/v1beta2 BackingImageManager instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -380,7 +386,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -545,6 +551,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 BackingImage is deprecated; use longhorn.io/v1beta2
+      BackingImage instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -572,7 +581,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -951,6 +960,9 @@ spec:
       jsonPath: .status.lastSyncedAt
       name: LastSyncedAt
       type: string
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 Backup is deprecated; use longhorn.io/v1beta2
+      Backup instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -978,7 +990,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -1197,6 +1209,9 @@ spec:
       jsonPath: .status.lastSyncedAt
       name: LastSyncedAt
       type: string
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 BackupTarget is deprecated; use longhorn.io/v1beta2
+      BackupTarget instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -1224,7 +1239,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -1386,6 +1401,9 @@ spec:
       jsonPath: .status.lastSyncedAt
       name: LastSyncedAt
       type: string
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 BackupVolume is deprecated; use longhorn.io/v1beta2
+      BackupVolume instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -1413,7 +1431,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -1596,6 +1614,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 EngineImage is deprecated; use longhorn.io/v1beta2
+      EngineImage instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -1623,7 +1644,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -1800,6 +1821,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 Engine is deprecated; use longhorn.io/v1beta2
+      Engine instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -1827,7 +1851,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -2196,6 +2220,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 InstanceManager is deprecated; use longhorn.io/v1beta2
+      InstanceManager instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -2223,7 +2250,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -2551,6 +2578,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 Node is deprecated; use longhorn.io/v1beta2
+      Node instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -2578,7 +2608,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -2954,6 +2984,9 @@ spec:
       jsonPath: .spec.labels
       name: Labels
       type: string
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 RecurringJob is deprecated; use longhorn.io/v1beta2
+      RecurringJob instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -2981,7 +3014,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -3151,6 +3184,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 Replica is deprecated; use longhorn.io/v1beta2
+      Replica instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -3178,7 +3214,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -3424,6 +3460,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 Setting is deprecated; use longhorn.io/v1beta2
+      Setting instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -3451,7 +3490,7 @@ spec:
         required:
         - value
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -3544,6 +3583,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 ShareManager is deprecated; use longhorn.io/v1beta2
+      ShareManager instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -3571,7 +3613,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -4370,6 +4412,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 Volume is deprecated; use longhorn.io/v1beta2
+      Volume instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -4397,7 +4442,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -157,6 +157,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 BackingImageDataSource is deprecated;
+      use longhorn.io/v1beta2 BackingImageDataSource instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -185,7 +188,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -350,6 +353,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 BackingImageManager is deprecated; use
+      longhorn.io/v1beta2 BackingImageManager instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -378,7 +384,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -543,6 +549,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 BackingImage is deprecated; use longhorn.io/v1beta2
+      BackingImage instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -570,7 +579,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -949,6 +958,9 @@ spec:
       jsonPath: .status.lastSyncedAt
       name: LastSyncedAt
       type: string
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 Backup is deprecated; use longhorn.io/v1beta2
+      Backup instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -976,7 +988,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -1195,6 +1207,9 @@ spec:
       jsonPath: .status.lastSyncedAt
       name: LastSyncedAt
       type: string
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 BackupTarget is deprecated; use longhorn.io/v1beta2
+      BackupTarget instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -1222,7 +1237,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -1384,6 +1399,9 @@ spec:
       jsonPath: .status.lastSyncedAt
       name: LastSyncedAt
       type: string
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 BackupVolume is deprecated; use longhorn.io/v1beta2
+      BackupVolume instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -1411,7 +1429,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -1594,6 +1612,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 EngineImage is deprecated; use longhorn.io/v1beta2
+      EngineImage instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -1621,7 +1642,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -1798,6 +1819,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 Engine is deprecated; use longhorn.io/v1beta2
+      Engine instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -1825,7 +1849,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -2194,6 +2218,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 InstanceManager is deprecated; use longhorn.io/v1beta2
+      InstanceManager instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -2221,7 +2248,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -2549,6 +2576,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 Node is deprecated; use longhorn.io/v1beta2
+      Node instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -2576,7 +2606,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -2952,6 +2982,9 @@ spec:
       jsonPath: .spec.labels
       name: Labels
       type: string
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 RecurringJob is deprecated; use longhorn.io/v1beta2
+      RecurringJob instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -2979,7 +3012,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -3149,6 +3182,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 Replica is deprecated; use longhorn.io/v1beta2
+      Replica instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -3176,7 +3212,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -3422,6 +3458,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 Setting is deprecated; use longhorn.io/v1beta2
+      Setting instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -3449,7 +3488,7 @@ spec:
         required:
         - value
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -3542,6 +3581,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 ShareManager is deprecated; use longhorn.io/v1beta2
+      ShareManager instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -3569,7 +3611,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -4368,6 +4410,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 Volume is deprecated; use longhorn.io/v1beta2
+      Volume instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -4395,7 +4440,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue #10250

#### What this PR does / why we need it:

CRD longhorn.io/v1beta1 is deprecated since v1.9.0, and will be removed at v1.10.0

#### Special notes for your reviewer:

These YAML changes are synced from PR longhorn/longhorn-manager#3616

#### Additional documentation or context