### PR TITLE
chore(ui): allow specifying affinity in values

### DIFF
--- a/chart/templates/deployment-ui.yaml
+++ b/chart/templates/deployment-ui.yaml
@@ -55,6 +55,9 @@ spec:
     spec:
       serviceAccountName: longhorn-ui-service-account
       affinity:
+      {{- if .Values.longhornUI.affinity }}
+      {{- toYaml .Values.longhornUI.affinity | nindent 8 }}
+      {{- else }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 1
@@ -66,6 +69,7 @@ spec:
                   values:
                   - longhorn-ui
               topologyKey: kubernetes.io/hostname
+      {{- end }}
       containers:
       {{- if .Values.openshift.enabled }}
       {{- if .Values.openshift.ui.route }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -422,6 +422,21 @@ longhornUI:
   replicas: 2
   # -- PriorityClass for Longhorn UI.
   priorityClass: *defaultPriorityClassNameRef
+  # -- Affinity for Longhorn UI pods. Specify the affinity you want to use for Longhorn UI.
+  affinity: {}
+  ## If you want to specify affinity for Longhorn UI Deployment, delete the `{}` in the line above
+  ## and uncomment this example block. Otherwise these defaults will be used.
+    # podAntiAffinity:
+    #   preferredDuringSchedulingIgnoredDuringExecution:
+    #   - weight: 1
+    #     podAffinityTerm:
+    #       labelSelector:
+    #         matchExpressions:
+    #         - key: app
+    #           operator: In
+    #           values:
+    #           - longhorn-ui
+    #       topologyKey: kubernetes.io/hostname
   # -- Toleration for Longhorn UI on nodes allowed to run Longhorn components.
   tolerations: []
   ## If you want to set tolerations for Longhorn UI Deployment, delete the `[]` in the line above


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #4987

#### What this PR does / why we need it:

Allow the user to override the affinity in the Longhorn UI deployment. 
In some case it is needed to tweak these settings, and currently the helm chart does not allow this.

The linked Issue is already closed, but the proposed solution in the issue was never addressed, which was to allow overriding of the affinity in the values.

#### Special notes for your reviewer:

The default output of the helm chart has not changed, which also means no changes to deploy.yaml are needed.

#### Additional documentation or context
