### PR TITLE
ci: fix creating backport issue error: Pagination with the page parameter is not supported for large datasets

### DIFF
--- a/.github/workflows/create-issue.yml
+++ b/.github/workflows/create-issue.yml
@@ -29,6 +29,8 @@ jobs:
         actions: 'find-issues'
         token: ${{ github.token }}
         issue-state: 'all'
+        labels: 'kind/backport'
+        issue-creator: 'github-actions[bot]'
         title-includes: |
           [BACKPORT][v${{ steps.split.outputs._1 }}]${{ github.event.issue.title }}
     - name: Get Milestone Object


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue N/A

#### What this PR does / why we need it:

fix creating backport issue error: Pagination with the page parameter is not supported for large datasets

#### Special notes for your reviewer:

#### Additional documentation or context
