### PR TITLE
ci: fix creating issues error: Pagination with the page parameter is not supported for large datasets

### DIFF
--- a/.github/workflows/create-issue.yml
+++ b/.github/workflows/create-issue.yml
@@ -107,6 +107,8 @@ jobs:
         actions: 'find-issues'
         token: ${{ github.token }}
         issue-state: 'all'
+        labels: 'kind/test'
+        issue-creator: 'github-actions[bot]'
         title-includes: |
           [TEST]${{ github.event.issue.title }}
     - name: Create Automation Test Issue
@@ -149,6 +151,8 @@ jobs:
         actions: 'find-issues'
         token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
         issue-state: 'all'
+        labels: 'area/ui'
+        issue-creator: 'github-actions[bot]'
         title-includes: |
           [UI]${{ github.event.issue.title }}
     - name: Get Labels


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue N/A

#### What this PR does / why we need it:

fix creating issues error: Pagination with the page parameter is not supported for large datasets

#### Special notes for your reviewer:

#### Additional documentation or context
