### PR TITLE
chore(backupstore/nfs): update to image repo to longhornio/nfs-backupstore

### DIFF
--- a/deploy/backupstores/nfs-backupstore.yaml
+++ b/deploy/backupstores/nfs-backupstore.yaml
@@ -21,7 +21,7 @@ spec:
         emptyDir: {}
       containers:
       - name: longhorn-test-nfs-container
-        image: longhornio/nfs-ganesha:latest
+        image: longhornio/nfs-backupstore:latest
         imagePullPolicy: Always
         env:
         - name: EXPORT_ID


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#10878

#### What this PR does / why we need it:

Previously, Longhorn did not maintain a repository for the NFS backupstore image build. Now that we've introduced the [longhornio/nfs-backupstore](https://github.com/longhorn/nfs-backupstore), the image name will be aligned with the project name.

#### Special notes for your reviewer:

#### Additional documentation or context
