### PR TITLE
ci: fix unmatched quotes in link backport pr action

### DIFF
--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -32,7 +32,7 @@ jobs:
         echo "BRANCH=$BRANCH" >> $GITHUB_ENV
         
         # Extract issue number from the PR description
-        ORIGINAL_ISSUE_NUMBER=$(echo '${{ github.event.pull_request.body }}'' | grep -oE 'longhorn/longhorn#[0-9]+' | cut -d'#' -f2)
+        ORIGINAL_ISSUE_NUMBER=$(echo "${{ github.event.pull_request.body }}" | grep -oE 'longhorn/longhorn#[0-9]+' | cut -d'#' -f2)
         echo "ORIGINAL_ISSUE_NUMBER=$ORIGINAL_ISSUE_NUMBER" >> $GITHUB_ENV
 
     - name: Link the PR with the backport issue


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue N/A

#### What this PR does / why we need it:

fix unmatched quotes in link backport pr action

#### Special notes for your reviewer:

#### Additional documentation or context
