### PR TITLE
Add https://nemlig.com as Longhorn adopters

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -12,3 +12,4 @@
 
 | Type | Name | Website | Use-Case |
 |:-|:-|:-|:-|
+| End-User | Nemlig | https://www.nemlig.com/ | All encompassing persistent storage solution on Kubernemlig > An operations and developer friendly self-developed Platform As A Service offering inside Nemlig.


### PR DESCRIPTION
Simple as adding https://nemlig.com as adopters and end-users of Longhorn.
