### PR TITLE
feat: release v1.8.2 and v1.9.0 into upgrade responder server

### DIFF
--- a/deploy/upgrade_responder_server/chart-values.yaml
+++ b/deploy/upgrade_responder_server/chart-values.yaml
@@ -64,13 +64,19 @@ configMap:
           ]
         },
         {
-          "name": "v1.8.1",
-          "releaseDate": "2025-03-05T00:00:00Z",
+          "name": "v1.8.2",
+          "releaseDate": "2025-06-08T00:00:00Z",
           "tags": [
-            "latest",
             "stable"
           ]
-        } 
+        },
+        {
+          "name": "v1.9.0",
+          "releaseDate": "2025-05-27T00:00:00Z",
+          "tags": [
+            "latest"
+          ]
+        }    
       ]
     }
   requestSchema: |-


### PR DESCRIPTION
Server has updated data:
```
➜  ~/.kube curl -d {} https://longhorn-upgrade-responder.rancher.io/v1/checkupgrade | json_pp 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   858  100   856  100     2   4231      9 --:--:-- --:--:-- --:--:--  4268
{
   "requestIntervalInMinutes" : 60,
   "versions" : [
      {
         "extraInfo" : null,
         "minUpgradableVersion" : "",
         "name" : "v1.5.5",
         "releaseDate" : "2024-04-19T00:00:00Z",
         "tags" : [
            "stable"
         ]
      },
      {
         "extraInfo" : null,
         "minUpgradableVersion" : "",
         "name" : "v1.6.4",
         "releaseDate" : "2025-01-02T00:00:00Z",
         "tags" : [
            "stable"
         ]
      },
      {
         "extraInfo" : null,
         "minUpgradableVersion" : "",
         "name" : "v1.7.3",
         "releaseDate" : "2025-02-19T00:00:00Z",
         "tags" : [
            "stable"
         ]
      },
      {
         "extraInfo" : null,
         "minUpgradableVersion" : "",
         "name" : "v1.8.2",
         "releaseDate" : "2025-06-08T00:00:00Z",
         "tags" : [
            "stable"
         ]
      },
      {
         "extraInfo" : null,
         "minUpgradableVersion" : "",
         "name" : "v1.9.0",
         "releaseDate" : "2025-05-27T00:00:00Z",
         "tags" : [
            "latest"
         ]
      },
      {
         "extraInfo" : null,
         "minUpgradableVersion" : "",
         "name" : "v1.3.3",
         "releaseDate" : "2023-04-19T00:00:00Z",
         "tags" : [
            "stable"
         ]
      },
      {
         "extraInfo" : null,
         "minUpgradableVersion" : "",
         "name" : "v1.4.4",
         "releaseDate" : "2023-10-26T00:00:00Z",
         "tags" : [
            "stable"
         ]
      }
   ]
}
➜
```
