### PR TITLE
fix(chart): fix usage of privateRegistry.registrySecret

### DIFF
--- a/chart/templates/daemonset-sa.yaml
+++ b/chart/templates/daemonset-sa.yaml
@@ -132,11 +132,11 @@ spec:
         secret:
           secretName: longhorn-grpc-tls
           optional: true
-      {{- with (coalesce .Values.global.imagePullSecrets .Values.privateRegistry.registrySecret) }}
+      {{- with (coalesce .Values.global.imagePullSecrets (ternary "" .Values.privateRegistry.registrySecret (empty .Values.privateRegistry.createSecret))) }}
       imagePullSecrets:
         {{- $imagePullSecrets := list }}
         {{- if kindIs "string" . }}
-          {{- $imagePullSecrets = append (dict "name" .) }}
+          {{- $imagePullSecrets = append $imagePullSecrets (dict "name" .) }}
         {{- else }}
           {{- range . }}
             {{- if kindIs "string" . }}

--- a/chart/templates/deployment-driver.yaml
+++ b/chart/templates/deployment-driver.yaml
@@ -98,11 +98,11 @@ spec:
             mountPath: /go-cover-dir/
           {{- end }}
 
-      {{- with (coalesce .Values.global.imagePullSecrets .Values.privateRegistry.registrySecret) }}
+      {{- with (coalesce .Values.global.imagePullSecrets (ternary "" .Values.privateRegistry.registrySecret (empty .Values.privateRegistry.createSecret))) }}
       imagePullSecrets:
         {{- $imagePullSecrets := list }}
         {{- if kindIs "string" . }}
-          {{- $imagePullSecrets = append (dict "name" .) }}
+          {{- $imagePullSecrets = append $imagePullSecrets (dict "name" .) }}
         {{- else }}
           {{- range . }}
             {{- if kindIs "string" . }}

--- a/chart/templates/deployment-ui.yaml
+++ b/chart/templates/deployment-ui.yaml
@@ -115,11 +115,11 @@ spec:
         name: nginx-config
       - emptyDir: {}
         name: var-run
-      {{- with (coalesce .Values.global.imagePullSecrets .Values.privateRegistry.registrySecret) }}
+      {{- with (coalesce .Values.global.imagePullSecrets (ternary "" .Values.privateRegistry.registrySecret (empty .Values.privateRegistry.createSecret))) }}
       imagePullSecrets:
         {{- $imagePullSecrets := list }}
         {{- if kindIs "string" . }}
-          {{- $imagePullSecrets = append (dict "name" .) }}
+          {{- $imagePullSecrets = append $imagePullSecrets (dict "name" .) }}
         {{- else }}
           {{- range . }}
             {{- if kindIs "string" . }}

--- a/chart/templates/postupgrade-job.yaml
+++ b/chart/templates/postupgrade-job.yaml
@@ -28,11 +28,11 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
       restartPolicy: OnFailure
-      {{- with (coalesce .Values.global.imagePullSecrets .Values.privateRegistry.registrySecret) }}
+      {{- with (coalesce .Values.global.imagePullSecrets (ternary "" .Values.privateRegistry.registrySecret (empty .Values.privateRegistry.createSecret))) }}
       imagePullSecrets:
         {{- $imagePullSecrets := list }}
         {{- if kindIs "string" . }}
-          {{- $imagePullSecrets = append (dict "name" .) }}
+          {{- $imagePullSecrets = append $imagePullSecrets (dict "name" .) }}
         {{- else }}
           {{- range . }}
             {{- if kindIs "string" . }}

--- a/chart/templates/preupgrade-job.yaml
+++ b/chart/templates/preupgrade-job.yaml
@@ -38,11 +38,11 @@ spec:
         hostPath:
           path: /proc/
       restartPolicy: OnFailure
-      {{- with (coalesce .Values.global.imagePullSecrets .Values.privateRegistry.registrySecret) }}
+      {{- with (coalesce .Values.global.imagePullSecrets (ternary "" .Values.privateRegistry.registrySecret (empty .Values.privateRegistry.createSecret))) }}
       imagePullSecrets:
         {{- $imagePullSecrets := list }}
         {{- if kindIs "string" . }}
-          {{- $imagePullSecrets = append (dict "name" .) }}
+          {{- $imagePullSecrets = append $imagePullSecrets (dict "name" .) }}
         {{- else }}
           {{- range . }}
             {{- if kindIs "string" . }}

--- a/chart/templates/registry-secret.yaml
+++ b/chart/templates/registry-secret.yaml
@@ -1,5 +1,8 @@
 {{- if .Values.privateRegistry.createSecret }}
 {{- if .Values.privateRegistry.registrySecret }}
+{{- if not (kindIs "string" .Values.privateRegistry.registrySecret) }}
+{{- fail "The privateRegistry.registrySecret value must be a string" }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/chart/templates/uninstall-job.yaml
+++ b/chart/templates/uninstall-job.yaml
@@ -29,11 +29,11 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
       restartPolicy: Never
-      {{- with (coalesce .Values.global.imagePullSecrets .Values.privateRegistry.registrySecret) }}
+      {{- with (coalesce .Values.global.imagePullSecrets (ternary "" .Values.privateRegistry.registrySecret (empty .Values.privateRegistry.createSecret))) }}
       imagePullSecrets:
         {{- $imagePullSecrets := list }}
         {{- if kindIs "string" . }}
-          {{- $imagePullSecrets = append (dict "name" .) }}
+          {{- $imagePullSecrets = append $imagePullSecrets (dict "name" .) }}
         {{- else }}
           {{- range . }}
             {{- if kindIs "string" . }}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue #11064

#### What this PR does / why we need it:

In #11063 we originally added some logic to support `global.imagePullSecrets`, but this broke the usage of `privateRegistry.registrySecret`.

#### Special notes for your reviewer:

We are fixing it in the following way:

* Fix usage of `privateRegistry.registrySecret` when it is a string. This was caused by the `$imagePullSecrets = append ...` line, which was implemented incorrectly.
* If `privateRegistry.registrySecret` is set but not `privateRegistry.createSecret`, no image pull secret will be used for the pods, as this is what is mentioned in the README: "This setting applies only when creation of private registry secrets is enabled."
* If `privateRegistry.registrySecret` is defined but not a string, an error is thrown. This is because the template currently expects it to be a string.

#### Additional documentation or context

See the original issue.