### PR TITLE
feat(chart): improve configurability of mounts for the longhorn-manager DaemonSet

### DIFF
--- a/chart/templates/daemonset-sa.yaml
+++ b/chart/templates/daemonset-sa.yaml
@@ -81,6 +81,7 @@ spec:
         - name: go-cover-dir
           mountPath: /go-cover-dir/
         {{- end }}
+        {{- toYaml .Values.longhornManager.longhornManagerContainerVolumeMounts | nindent 8 }}
         env:
         - name: POD_NAME
           valueFrom:
@@ -132,6 +133,7 @@ spec:
         secret:
           secretName: longhorn-grpc-tls
           optional: true
+      {{- toYaml .Values.longhornManager.extraVolumes | nindent 6 }}
       {{- with (coalesce .Values.global.imagePullSecrets (ternary "" .Values.privateRegistry.registrySecret (empty .Values.privateRegistry.createSecret))) }}
       imagePullSecrets:
         {{- $imagePullSecrets := list }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -437,6 +437,22 @@ longhornManager:
   #  annotation-key2: "annotation-value2"
   # -- Host path on the nodes that will be mounted to `/var/lib/longhorn` inside the longhorn-manager pods. The default value is "/var/lib/longhorn/".
   dataVolumeHostPath: "/var/lib/longhorn/"
+  # -- Extra volume specs to add to the `longhorn-manager` pod. The values are directly inserted into the
+  # `volumes` key in the pod spec.
+  extraVolumes: []
+  ## To add extra volumes, delete the `[]` in the line above
+  ## and uncomment this example block:
+  # - name: longhorn
+  #   hostPath:
+  #     path: /var/mnt/my-bonus-data
+  # -- Extra volumeMount specs to add to the `longhorn-manager` container in the `longhorn-manager` pod.
+  # The values are directly inserted into the `volumes` key in the pod spec.
+  longhornManagerContainerVolumeMounts: []
+  ## To mount extra volumes defined above, delete the `[]` in the line above
+  ## and uncomment this example block:
+  # - name: my-bonus-data-volume
+  #   mountPath: /var/lib/longhorn-extra/my-bonus-data
+  #   mountPropagation: Bidirectional
 longhornDriver:
   log:
     # -- Format of longhorn-driver logs. (Options: "plain", "json")


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue longhorn/longhorn#11186

Additionally, adds the option for extra Volumes and extra VolumeMounts. Longhorn supports multiple disks, but can not mount multiple volumes into the container.

#### What this PR does / why we need it:
- add support for a custom hostPath for the data volume attached to the longhorn-manager pod
- add support for extra `volumes` entries and extra `volumeMounts` entries.

#### Special notes for your reviewer:
This change does not require any adjustments for existing users that don't need this feature. It should be 

#### Additional documentation or context
