### PR TITLE
fix(chart): privateRegistry.registrySecret should not require secret to be created

### DIFF
--- a/chart/templates/daemonset-sa.yaml
+++ b/chart/templates/daemonset-sa.yaml
@@ -132,7 +132,7 @@ spec:
         secret:
           secretName: longhorn-grpc-tls
           optional: true
-      {{- with (coalesce .Values.global.imagePullSecrets (ternary "" .Values.privateRegistry.registrySecret (empty .Values.privateRegistry.createSecret))) }}
+      {{- with (coalesce .Values.global.imagePullSecrets .Values.privateRegistry.registrySecret) }}
       imagePullSecrets:
         {{- $imagePullSecrets := list }}
         {{- if kindIs "string" . }}

--- a/chart/templates/deployment-driver.yaml
+++ b/chart/templates/deployment-driver.yaml
@@ -98,7 +98,7 @@ spec:
             mountPath: /go-cover-dir/
           {{- end }}
 
-      {{- with (coalesce .Values.global.imagePullSecrets (ternary "" .Values.privateRegistry.registrySecret (empty .Values.privateRegistry.createSecret))) }}
+      {{- with (coalesce .Values.global.imagePullSecrets .Values.privateRegistry.registrySecret) }}
       imagePullSecrets:
         {{- $imagePullSecrets := list }}
         {{- if kindIs "string" . }}

--- a/chart/templates/deployment-ui.yaml
+++ b/chart/templates/deployment-ui.yaml
@@ -115,7 +115,7 @@ spec:
         name: nginx-config
       - emptyDir: {}
         name: var-run
-      {{- with (coalesce .Values.global.imagePullSecrets (ternary "" .Values.privateRegistry.registrySecret (empty .Values.privateRegistry.createSecret))) }}
+      {{- with (coalesce .Values.global.imagePullSecrets .Values.privateRegistry.registrySecret) }}
       imagePullSecrets:
         {{- $imagePullSecrets := list }}
         {{- if kindIs "string" . }}

--- a/chart/templates/postupgrade-job.yaml
+++ b/chart/templates/postupgrade-job.yaml
@@ -28,7 +28,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
       restartPolicy: OnFailure
-      {{- with (coalesce .Values.global.imagePullSecrets (ternary "" .Values.privateRegistry.registrySecret (empty .Values.privateRegistry.createSecret))) }}
+      {{- with (coalesce .Values.global.imagePullSecrets .Values.privateRegistry.registrySecret) }}
       imagePullSecrets:
         {{- $imagePullSecrets := list }}
         {{- if kindIs "string" . }}

--- a/chart/templates/preupgrade-job.yaml
+++ b/chart/templates/preupgrade-job.yaml
@@ -38,7 +38,7 @@ spec:
         hostPath:
           path: /proc/
       restartPolicy: OnFailure
-      {{- with (coalesce .Values.global.imagePullSecrets (ternary "" .Values.privateRegistry.registrySecret (empty .Values.privateRegistry.createSecret))) }}
+      {{- with (coalesce .Values.global.imagePullSecrets .Values.privateRegistry.registrySecret) }}
       imagePullSecrets:
         {{- $imagePullSecrets := list }}
         {{- if kindIs "string" . }}

--- a/chart/templates/uninstall-job.yaml
+++ b/chart/templates/uninstall-job.yaml
@@ -29,7 +29,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
       restartPolicy: Never
-      {{- with (coalesce .Values.global.imagePullSecrets (ternary "" .Values.privateRegistry.registrySecret (empty .Values.privateRegistry.createSecret))) }}
+      {{- with (coalesce .Values.global.imagePullSecrets .Values.privateRegistry.registrySecret) }}
       imagePullSecrets:
         {{- $imagePullSecrets := list }}
         {{- if kindIs "string" . }}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #11064

#### What this PR does / why we need it:

The `privateRegistry.registrySecret` value should not require a secret to be created (`--set privateRegistry.registrySecret=true`), it should also allow you to use an already created pull secret (`--set privateRegistry.registrySecret=false`).

#### Special notes for your reviewer:

Due to this fix, `privateRegistry.registrySecret` is effectively an alias for `global.imagePullSecrets`.

#### Additional documentation or context

See #11251