### PR TITLE
revert: "chore(gh): add issue type to issue templates"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,7 +1,6 @@
 name: Bug report
 description: Create a bug report
 title: "[BUG] "
-type: "Bug"
 labels: ["kind/bug", "require/qa-review-coverage", "require/backport"]
 assignees:
   - 

--- a/.github/ISSUE_TEMPLATE/ci.md
+++ b/.github/ISSUE_TEMPLATE/ci.md
@@ -2,7 +2,6 @@
 name: CI task
 about: Create a CI task
 title: "[CI] "
-type: "Task"
 labels: ["kind/task", "area/ci"]
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/doc.md
+++ b/.github/ISSUE_TEMPLATE/doc.md
@@ -2,7 +2,6 @@
 name: Document
 about: Create or update document
 title: "[DOC] "
-type: "Doc"
 labels: kind/doc
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/epic.yaml
+++ b/.github/ISSUE_TEMPLATE/epic.yaml
@@ -1,7 +1,6 @@
 name: Epic request
 description: Suggest an Epic for grouped features, enhancements or tasks
 title: "[EPIC] "
-type: "Epic"
 labels: [ "Epic" ]
 assignees:
 -

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -1,7 +1,6 @@
 name: Feature request
 description: Suggest an idea/feature
 title: "[FEATURE] "
-type: "Feature"
 labels: ["kind/feature", "require/lep", "require/doc", "require/auto-e2e-test", "require/manual-test-plan"]
 assignees:
   - 

--- a/.github/ISSUE_TEMPLATE/fix-cve-issues-for-release.md
+++ b/.github/ISSUE_TEMPLATE/fix-cve-issues-for-release.md
@@ -2,7 +2,6 @@
 name: Fix CVE Issues for Release
 about: Security issue fix task for a release
 title: "[RELEASE] Fix CVE Issues for {{ env.RELEASE_VERSION }}"
-type: "Task"
 labels: ["release/task", "area/security", "area/install-uninstall-upgrade"]
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/hotfix.md
+++ b/.github/ISSUE_TEMPLATE/hotfix.md
@@ -2,7 +2,6 @@
 name: Hotfix
 about: Create a hotfix task
 title: "[HOTFIX] "
-type: "Task"
 labels: ["kind/hotfix", "require/important-note"]
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/improvement.yaml
+++ b/.github/ISSUE_TEMPLATE/improvement.yaml
@@ -1,7 +1,6 @@
 name: Improvement request
 description: Suggest an improvement of an existing feature
 title: "[IMPROVEMENT] "
-type: "Improvement"
 labels: ["kind/improvement", "require/doc", "require/manual-test-plan", "require/backport"]
 assignees:
   - 

--- a/.github/ISSUE_TEMPLATE/infra.md
+++ b/.github/ISSUE_TEMPLATE/infra.md
@@ -2,7 +2,6 @@
 name: Infra
 about: Create a test/dev infra task
 title: "[INFRA] "
-type: "Task"
 labels: ["kind/task", "area/infra"]
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/performance-benchmark.md
+++ b/.github/ISSUE_TEMPLATE/performance-benchmark.md
@@ -2,7 +2,6 @@
 name: Performance Benchmark
 about: Performance benchmark task for feature release
 title: "[Benchmark] Performance Benchmark for {{ env.RELEASE_VERSION }}"
-type: "Task"
 labels: ["release/task", "area/benchmark"]
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/refactor.md
+++ b/.github/ISSUE_TEMPLATE/refactor.md
@@ -2,7 +2,6 @@
 name: Refactor task
 about: Suggest a refactoring request for an existing implementation
 title: "[REFACTOR] "
-type: "Task"
 labels: kind/refactoring
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/regular-tasks-for-feature-release.md
+++ b/.github/ISSUE_TEMPLATE/regular-tasks-for-feature-release.md
@@ -2,7 +2,6 @@
 name: Regular Tasks for Feature Release
 about: Regular tasks for a feature release
 title: "[RELEASE] Regular Tasks for Feature Release {{ env.RELEASE_VERSION }}"
-type: "Task"
 labels: ["release/task", "area/install-uninstall-upgrade"]
 assignees: ''
 ---

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -2,7 +2,6 @@
 name: Release Task
 about: Create a release task
 title: "[RELEASE] Release {{ env.RELEASE_VERSION }}"
-type: "Task"
 labels: ["release/task", "area/install-uninstall-upgrade"]
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -2,7 +2,6 @@
 name: Task
 about: Create a general task
 title: "[TASK] "
-type: "Task"
 labels: kind/task
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/test.md
+++ b/.github/ISSUE_TEMPLATE/test.md
@@ -2,7 +2,6 @@
 name: Test
 about: Create or update test
 title: "[TEST] "
-type: "Test"
 labels: kind/test
 assignees: ''
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

```
Run JasonEtco/create-an-issue@v2
⬤  debug     Reading from file .github/ISSUE_TEMPLATE/release.md
✖  error     An error occurred while parsing the issue. This might be caused by a malformed issue title, or a typo in the labels or assignees. Check .github/ISSUE_TEMPLATE/release.md!
✖  error     { _errors: [ "Unrecognized key(s) in object: 'type'" ] }
Error: An error occurred while parsing the issue. This might be caused by a malformed issue title, or a typo in the labels or assignees. Check .github/ISSUE_TEMPLATE/release.md
```
https://github.com/longhorn/longhorn/actions/runs/17200667248

#### What this PR does / why we need it:

Reverting 2a642d827e32c6dc706d393b0ea85bc823a390bc.

Even though GitHub's official issue forms support the `type` field, the third-party action [JasonEtco/create-an-issue@v2](https://github.com/JasonEtco/create-an-issue/tree/v2/) hasn't been updated to support it, which is causing the parsing error.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

https://github.com/JasonEtco/create-an-issue/blob/main/src/helpers.ts#L6-L11
