### PR TITLE
fix(workflow): set backport to New after adding it to Longhorn Sprint

### DIFF
--- a/.github/workflows/update-longhorn-issue.yml
+++ b/.github/workflows/update-longhorn-issue.yml
@@ -93,6 +93,18 @@ jobs:
         project-url: ${{ env.LONGHORN_SPRINT_PROJECT_URL }}
         github-token: ${{ steps.app-token.outputs.token }}
 
+    - name: Update Item To New
+      if: |
+        env.is_longhorn_member == 'true' &&
+        steps.add-project.outputs.itemId != ''
+      uses: titoportas/update-project-fields@v0.1.0
+      with:
+        project-url: ${{ env.LONGHORN_SPRINT_PROJECT_URL }}
+        github-token: ${{ steps.app-token.outputs.token }}
+        item-id: ${{ steps.add-project.outputs.itemId }}
+        field-keys: Status,Sprint
+        field-values: "New,[0]"
+
     - name: Set Milestone Backlog to Issue
       if: ${{
         env.is_longhorn_member == 'true' &&


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
