### PR TITLE
fix(workflow): no need to set Sprint if ticket is labeled, milestoned, and so on

### DIFF
--- a/.github/workflows/update-longhorn-issue.yml
+++ b/.github/workflows/update-longhorn-issue.yml
@@ -102,8 +102,8 @@ jobs:
         project-url: ${{ env.LONGHORN_SPRINT_PROJECT_URL }}
         github-token: ${{ steps.app-token.outputs.token }}
         item-id: ${{ steps.add-project.outputs.itemId }}
-        field-keys: Status,Sprint
-        field-values: "New,[0]"
+        field-keys: Status
+        field-values: "New"
 
     - name: Set Milestone Backlog to Issue
       if: ${{


### PR DESCRIPTION




#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:

Sprint should be set by developer

#### Special notes for your reviewer:

#### Additional documentation or context
