### PR TITLE
refactor(scripts): update shebang to use env bash

### DIFF
--- a/dev/scale-test/sample.sh
+++ b/dev/scale-test/sample.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 requested=${1:-0}
 node_count=${2:-1}

--- a/dev/scripts/lm-update.sh
+++ b/dev/scripts/lm-update.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #set -x
 set -e

--- a/dev/scripts/update-image-pull-policy.sh
+++ b/dev/scripts/update-image-pull-policy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 NS=longhorn-system
 KINDS="daemonset deployments"

--- a/dev/upgrade-responder/install.sh
+++ b/dev/upgrade-responder/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 UPGRADE_RESPONDER_REPO="https://github.com/longhorn/upgrade-responder.git"
 UPGRADE_RESPONDER_REPO_BRANCH="master"

--- a/scripts/helm-docs.sh
+++ b/scripts/helm-docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ## Reference: https://github.com/norwoodj/helm-docs
 
 set -o errexit

--- a/scripts/load-images.sh
+++ b/scripts/load-images.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 list="longhorn-images.txt"
 CONTAINER_CLI=${CONTAINER_CLI:-docker}
 

--- a/scripts/longhorn_rancher_chart_migration.sh
+++ b/scripts/longhorn_rancher_chart_migration.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #set -x
 
 kubectl get-all version &> /dev/null

--- a/scripts/restore-backup-to-file.sh
+++ b/scripts/restore-backup-to-file.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export RED='\x1b[0;31m'
 export NO_COLOR='\x1b[0m'

--- a/scripts/save-images.sh
+++ b/scripts/save-images.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 list="longhorn-images.txt"
 CONTAINER_CLI=${CONTAINER_CLI:-docker}
 

--- a/scripts/update-chart-questions.sh
+++ b/scripts/update-chart-questions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function die() {
   echo >&2 "$@"

--- a/scripts/update-chart-readme.sh
+++ b/scripts/update-chart-readme.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 while IFS= read -r line; do
   image="$line"

--- a/scripts/update-chart-values.sh
+++ b/scripts/update-chart-values.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function die() {
   echo >&2 "$@"


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue #

#### What this PR does / why we need it:
This pull request standardizes the shebang lines across multiple shell scripts in the repository. All scripts now use `#!/usr/bin/env bash` instead of `#!/bin/bash`, improving portability across different environments where the location of `bash` may vary.

**Shebang Standardization:**

* Updated the shebang from `#!/bin/bash` to `#!/usr/bin/env bash` in the following scripts to enhance portability:
  * `dev/scale-test/sample.sh`
  * `dev/scripts/lm-update.sh`
  * `dev/scripts/update-image-pull-policy.sh`
  * `dev/upgrade-responder/install.sh`
  * `scripts/helm-docs.sh`
  * `scripts/load-images.sh`
  * `scripts/longhorn_rancher_chart_migration.sh`
  * `scripts/restore-backup-to-file.sh`
  * `scripts/save-images.sh`
  * `scripts/update-chart-questions.sh`
  * `scripts/update-chart-readme.sh`
  * `scripts/update-chart-values.sh`