### PR TITLE
feat(chart): add Gateway API HTTPRoute support

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -238,6 +238,17 @@ Longhorn consists of user-deployed components (for example, Longhorn Manager, Lo
 | ingress.tls | bool | `false` | Setting that allows you to enable TLS on ingress records. |
 | ingress.tlsSecret | string | `"longhorn.local-tls"` | TLS secret that contains the private key and certificate to be used for TLS. This setting applies only when TLS is enabled on ingress records. |
 
+### HTTPRoute Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| httproute.annotations | object | `{}` | Annotations for the HTTPRoute resource in the form of key-value pairs. |
+| httproute.enabled | bool | `false` | Setting that allows Longhorn to generate HTTPRoute records for the Longhorn UI service using Gateway API. |
+| httproute.hostnames | list | `[]` | List of hostnames for the HTTPRoute. Multiple hostnames are supported. |
+| httproute.parentRefs | list | `[]` | Gateway references for HTTPRoute. Specify which Gateway(s) should handle this route. |
+| httproute.path | string | `"/"` | Default path for HTTPRoute. You can access the Longhorn UI by following the full path. |
+| httproute.pathType | string | `"PathPrefix"` | Path match type for HTTPRoute. (Options: "Exact", "PathPrefix") |
+
 ### Private Registry Settings
 
 You can install Longhorn in an air-gapped environment with a private registry. For more information, see the **Air Gap Installation** section of the [documentation](https://longhorn.io/docs).

--- a/chart/README.md.gotmpl
+++ b/chart/README.md.gotmpl
@@ -175,6 +175,16 @@ Longhorn consists of user-deployed components (for example, Longhorn Manager, Lo
   {{- end }}
 {{- end }}
 
+### HTTPRoute Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+{{- range .Values }}
+  {{- if hasPrefix "httproute" .Key }}
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+  {{- end }}
+{{- end }}
+
 ### Private Registry Settings
 
 You can install Longhorn in an air-gapped environment with a private registry. For more information, see the **Air Gap Installation** section of the [documentation](https://longhorn.io/docs).
@@ -227,6 +237,7 @@ For more details, see the [ocp-readme](https://github.com/longhorn/longhorn/blob
   (hasPrefix "longhornUI" .Key)
   (hasPrefix "privateRegistry" .Key)
   (hasPrefix "ingress" .Key)
+  (hasPrefix "httproute" .Key)
   (hasPrefix "metrics" .Key)
   (hasPrefix "openshift" .Key)
   (hasPrefix "global" .Key)) }}

--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -1077,6 +1077,45 @@ questions:
           - Prefix
         required: true
         label: Ingress Path Type
+  - variable: httproute.enabled
+    default: 'false'
+    description: Expose app using Gateway API HTTPRoute
+    type: boolean
+    group: Services and Load Balancing
+    label: Expose app using Gateway API HTTPRoute
+    show_subquestion_if: true
+    subquestions:
+      - variable: httproute.parentRefs
+        default: '[]'
+        description: >-
+          Gateway references as JSON array (e.g., [{"name":"my-gateway","namespace":"default"}])
+        type: string
+        required: true
+        label: Gateway References (JSON array)
+      - variable: httproute.hostnames
+        default: '[]'
+        description: >-
+          Hostnames for HTTPRoute as JSON array (e.g., ["longhorn.example.com"])
+        type: string
+        required: true
+        label: Hostnames (JSON array)
+      - variable: httproute.path
+        default: /
+        description: >-
+          Default path for HTTPRoute. You can access the Longhorn UI by following the full path.
+        type: string
+        required: true
+        label: HTTPRoute Path
+      - variable: httproute.pathType
+        default: PathPrefix
+        description: >-
+          Path match type for HTTPRoute. (Options: "Exact", "PathPrefix")
+        type: enum
+        options:
+          - Exact
+          - PathPrefix
+        required: true
+        label: HTTPRoute Path Type
   - variable: service.ui.type
     default: Rancher-Proxy
     description: >-

--- a/chart/templates/httproute.yaml
+++ b/chart/templates/httproute.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.httproute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: longhorn-httproute
+  namespace: {{ include "release_namespace" . }}
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+    app: longhorn-httproute
+  {{- with .Values.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httproute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httproute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+  - matches:
+    - path:
+        type: {{ .Values.httproute.pathType | default "PathPrefix" }}
+        value: {{ .Values.httproute.path | default "/" }}
+    backendRefs:
+    - name: longhorn-frontend
+      port: 80
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -537,6 +537,26 @@ ingress:
   # - name: longhorn.local-tls
   #   key:
   #   certificate:
+httproute:
+  # -- Setting that allows Longhorn to generate HTTPRoute records for the Longhorn UI service using Gateway API.
+  enabled: false
+  # -- Gateway references for HTTPRoute. Specify which Gateway(s) should handle this route.
+  parentRefs: []
+  ## Example:
+  # - name: gateway-name
+  #   namespace: gateway-namespace
+  # -- List of hostnames for the HTTPRoute. Multiple hostnames are supported.
+  hostnames: []
+  ## Example:
+  # - longhorn.example.com
+  # -- Default path for HTTPRoute. You can access the Longhorn UI by following the full path.
+  path: /
+  # -- Path match type for HTTPRoute. (Options: "Exact", "PathPrefix")
+  pathType: PathPrefix
+  # -- Annotations for the HTTPRoute resource in the form of key-value pairs.
+  annotations: {}
+  ## Example:
+  #  annotation-key1: "annotation-value1"
 # -- Setting that allows you to enable pod security policies (PSPs) that allow privileged Longhorn pods to start. This setting applies only to clusters running Kubernetes 1.25 and earlier, and with the built-in Pod Security admission controller enabled.
 enablePSP: false
 # -- Specify override namespace, specifically this is useful for using longhorn as sub-chart and its release namespace is not the `longhorn-system`.


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue #

#### What this PR does / why we need it:
This PR adds support for Gateway API HTTPRoute resource as an alternative to Ingress for exposing the Longhorn UI. This provides users with more flexibility in choosing their preferred API Gateway solution, especially for those using modern Gateway API implementations like Istio, Envoy Gateway, or Cilium.

**Changes:**
- Add `chart/templates/httproute.yaml` template with conditional rendering
- Add `httproute` configuration section to `values.yaml` with full documentation
- Add HTTPRoute configuration questions to `questions.yaml` for Rancher UI
- Update `README.md.gotmpl` to include HTTPRoute settings documentation
- Regenerate `README.md` via helm-docs

**Features:**
- Multiple Gateway references via `parentRefs`
- Multiple hostnames support
- Path and pathType configuration (Exact, PathPrefix)
- Custom annotations support
- Follows the same pattern as existing Ingress resource

#### Special notes for your reviewer:
- The HTTPRoute implementation uses Gateway API v1 (stable version)
- All changes follow the existing Longhorn chart conventions
- The feature is disabled by default (`httproute.enabled: false`)
- Documentation has been generated using helm-docs v1.9.1
- Target service is `longhorn-frontend:80` (same as Ingress)
- **Note:** This PR was prepared with AI assistance (Claude Code) but has been reviewed and tested in production by @lexfrei before submission

#### Additional documentation or context
- Gateway API HTTPRoute specification: https://gateway-api.sigs.k8s.io/api-types/httproute/
- This is complementary to the existing Ingress support and does not replace it