### PR TITLE
fix(upgrade_responder): add backup target metric request schemas

### DIFF
--- a/deploy/upgrade_responder_server/chart-values.yaml
+++ b/deploy/upgrade_responder_server/chart-values.yaml
@@ -273,6 +273,21 @@ configMap:
         "longhornBackingImageCount": {
           "dataType": "float"
         },
+        "longhornBackupTargetAzblobCount": {
+          "dataType": "float"
+        },
+        "longhornBackupTargetCifsCount": {
+          "dataType": "float"
+        },
+        "longhornBackupTargetNfsCount": {
+          "dataType": "float"
+        },
+        "longhornBackupTargetS3Count": {
+          "dataType": "float"
+        },
+        "longhornBackupTargetUnknownCount": {
+          "dataType": "float"
+        },
         "longhornDiskBlockCount": {
           "dataType": "float"
         },

--- a/dev/upgrade-responder/install.sh
+++ b/dev/upgrade-responder/install.sh
@@ -126,10 +126,6 @@ configMap:
           "dataType": "string",
           "maxLen": 200
         },
-        "longhornSettingBackupTarget": {
-          "dataType": "string",
-          "maxLen": 200
-        },
         "longhornSettingCrdApiVersion": {
           "dataType": "string",
           "maxLen": 200
@@ -249,6 +245,21 @@ configMap:
       },
       "extraFieldInfoSchema": {
         "longhornBackingImageCount": {
+          "dataType": "float"
+        },
+        "longhornBackupTargetAzblobCount": {
+          "dataType": "float"
+        },
+        "longhornBackupTargetCifsCount": {
+          "dataType": "float"
+        },
+        "longhornBackupTargetNfsCount": {
+          "dataType": "float"
+        },
+        "longhornBackupTargetS3Count": {
+          "dataType": "float"
+        },
+        "longhornBackupTargetUnknownCount": {
           "dataType": "float"
         },
         "longhornDiskBlockCount": {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#5411, longhorn/longhorn#12073

#### What this PR does / why we need it:

Collect backup target drivers count:
- longhorn_backup_target_s3_count
- longhorn_backup_target_nfs_count
- longhorn_backup_target_cifs_count
- longhorn_backup_target_azblob_count
- longhorn_backup_target_unknown_count

#### Special notes for your reviewer:

#### Additional documentation or context
