### PR TITLE
feat: Add support for multiple TLS FQDNs in Helm chart ingress

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -230,6 +230,7 @@ Longhorn consists of user-deployed components (for example, Longhorn Manager, Lo
 |-----|------|---------|-------------|
 | ingress.annotations | string | `nil` | Ingress annotations in the form of key-value pairs. |
 | ingress.enabled | bool | `false` | Setting that allows Longhorn to generate ingress records for the Longhorn UI service. |
+| ingress.extraHosts | list | `[]` | Extra hostnames for TLS (Subject Alternative Names - SAN). Used when you need multiple FQDNs for the same ingress. Example: extraHosts:   - longhorn.example.com   - longhorn-ui.internal.local |
 | ingress.host | string | `"sslip.io"` | Hostname of the Layer 7 load balancer. |
 | ingress.ingressClassName | string | `nil` | IngressClass resource that contains ingress configuration, including the name of the Ingress controller. ingressClassName can replace the kubernetes.io/ingress.class annotation used in earlier Kubernetes releases. |
 | ingress.path | string | `"/"` | Default ingress path. You can access the Longhorn UI by following the full ingress path {{host}}+{{path}}. |

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -28,10 +28,25 @@ spec:
               name: longhorn-frontend
               port:
                 number: 80
+{{- range .Values.ingress.extraHosts }}
+  - host: {{ . }}
+    http:
+      paths:
+        - path: {{ default "" $.Values.ingress.path }}
+          pathType: {{ default "ImplementationSpecific" $.Values.ingress.pathType }}
+          backend:
+            service:
+              name: longhorn-frontend
+              port:
+                number: 80
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
   - hosts:
     - {{ .Values.ingress.host }}
+    {{- range .Values.ingress.extraHosts }}
+    - {{ . }}
+    {{- end }}
     secretName: {{ .Values.ingress.tlsSecret }}
 {{- end }}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -507,6 +507,12 @@ ingress:
   ingressClassName: ~
   # -- Hostname of the Layer 7 load balancer.
   host: sslip.io
+  # -- Extra hostnames for TLS (Subject Alternative Names - SAN). Used when you need multiple FQDNs for the same ingress.
+  # Example:
+  # extraHosts:
+  #   - longhorn.example.com
+  #   - longhorn-ui.internal.local
+  extraHosts: []
   # -- Setting that allows you to enable TLS on ingress records.
   tls: false
   # -- Setting that allows you to enable secure connections to the Longhorn UI service via port 443.


### PR DESCRIPTION
This pull request adds support for specifying multiple hostnames for the Longhorn UI ingress, allowing users to configure extra FQDNs (Subject Alternative Names) for TLS and ingress routing. The main changes introduce a new `extraHosts` option and update the ingress template to handle these additional hostnames.

**Ingress configuration enhancements:**

* Added a new `extraHosts` field to the ingress configuration in `values.yaml`, allowing users to specify additional hostnames for TLS and ingress records.
* Documented the new `extraHosts` option in `README.md`, including usage details and examples.

**Ingress template updates:**

* Updated `ingress.yaml` to generate ingress rules and TLS SAN entries for each hostname listed in `extraHosts`, ensuring proper routing and certificate coverage.- Add extraHosts field to values.yaml for Subject Alternative Names (SAN) support
- Update ingress template to include extra hosts in rules and TLS sections
- Maintain backward compatibility with existing single host configurations

Addresses GitHub issue #12127

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
