### PR TITLE
Feat: Helm chart add support for x503v3 SAN to ingress

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -32,6 +32,9 @@ spec:
   tls:
   - hosts:
     - {{ .Values.ingress.host }}
+    {{- range $i, $hosts := .Values.ingress.extraHosts }}
+    - {{ $hosts }}
+    {{- end }}
     secretName: {{ .Values.ingress.tlsSecret }}
 {{- end }}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -505,6 +505,8 @@ ingress:
   ingressClassName: ~
   # -- Hostname of the Layer 7 load balancer.
   host: sslip.io
+  # -- x503v3 SAN (Subject Alternative Name) Support 
+  extraHosts: []
   # -- Setting that allows you to enable TLS on ingress records.
   tls: false
   # -- Setting that allows you to enable secure connections to the Longhorn UI service via port 443.


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue #12127

#### What this PR does / why we need it:
Add support for x503v3 SAN to ingress

#### Special notes for your reviewer:


#### Additional documentation or context
