### PR TITLE
feat(chart): add "loadBalancerClass" setting for ui service

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -146,6 +146,7 @@ The `values.yaml` contains items used to tweak a deployment of this chart.
 | service.manager.nodePort | NodePort port number for Longhorn Manager. When unspecified, Longhorn selects a free port between 30000 and 32767. |
 | service.manager.type | Service type for Longhorn Manager. |
 | service.ui.annotations | Annotation for the Longhorn UI service. |
+| service.ui.loadBalancerClass | Class of a load balancer implementation |
 | service.ui.nodePort | NodePort port number for Longhorn UI. When unspecified, Longhorn selects a free port between 30000 and 32767. |
 | service.ui.type | Service type for Longhorn UI. (Options: "ClusterIP", "NodePort", "LoadBalancer", "Rancher-Proxy") |
 

--- a/chart/templates/deployment-ui.yaml
+++ b/chart/templates/deployment-ui.yaml
@@ -179,6 +179,9 @@ spec:
   {{- if and (eq .Values.service.ui.type "LoadBalancer") .Values.service.ui.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{- toYaml .Values.service.ui.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
+  {{- if and (eq .Values.service.ui.type "LoadBalancer") .Values.service.ui.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.service.ui.loadBalancerClass }}
+  {{- end }}
   selector:
     app: longhorn-ui
   ports:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -145,6 +145,8 @@ service:
     type: ClusterIP
     # -- NodePort port number for Longhorn UI. When unspecified, Longhorn selects a free port between 30000 and 32767.
     nodePort: null
+    # -- Class of a load balancer implementation
+    loadBalancerClass: ""
     # -- Annotation for the Longhorn UI service.
     annotations: {}
     ## If you want to set annotations for the Longhorn UI service, delete the `{}` in the line above


### PR DESCRIPTION
Allow setting loadBalancerClass helm chart value for ui service.

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #12273

#### What this PR does / why we need it:

It allows setting `loadBalancerClass` value for a helm chart. It's useful for example for configuring Tailscale Operator.

#### Special notes for your reviewer:

#### Additional documentation or context
