### PR TITLE
fix(scripts): clarify helm version in generate-longhorn-yaml error message

### DIFF
--- a/scripts/generate-longhorn-yaml.sh
+++ b/scripts/generate-longhorn-yaml.sh
@@ -10,7 +10,7 @@ DEPLOY_YAML_TMP="$PRJ_DIR/deploy/longhorn.yaml.tmp"
 NAMESPACE=${NAMESPACE:-longhorn-system}
 
 if ! command -v helm &> /dev/null || ! helm version --short | grep -q "v3\|v4"; then
-  echo "Please install helm v4 first before generating $DEPLOY_YAML!"
+  echo "Please install helm v4 (recommended) or v3 (backward compatible) before generating $DEPLOY_YAML!"
   exit 1
 fi
 
@@ -33,4 +33,3 @@ EOD
   mv "$DEPLOY_YAML_TMP" "$DEPLOY_YAML"
 
 done
-


### PR DESCRIPTION
## Summary

Clarify the Helm version error message in `scripts/generate-longhorn-yaml.sh` so it matches the existing version check behavior.

Fixes #12630

## Changes

1. Update the error message to: `Please install helm v4 (recommended) or v3 (backward compatible) before generating ...`
2. No logic change in version validation (it still checks `v3|v4`).

## Test plan

- [x] Confirm script behavior is unchanged when Helm v3 or v4 is installed.
- [x] Confirm the error message is now accurate when Helm is missing or unsupported.