### PR TITLE
feat(chart): add sampleLimit support to ServiceMonitor

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -278,7 +278,8 @@ You can install Longhorn in an air-gapped environment with a private registry. F
 | metrics.serviceMonitor.enabled | bool | `false` | Setting that allows the creation of a Prometheus ServiceMonitor resource for Longhorn Manager components. |
 | metrics.serviceMonitor.interval | string | `""` | Interval at which Prometheus scrapes the metrics from the target. |
 | metrics.serviceMonitor.metricRelabelings | list | `[]` | Configures the relabeling rules to apply to the samples before ingestion. See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.Endpoint) for formatting details. |
-| metrics.serviceMonitor.relabelings | list | `[]` | Configures the relabeling rules to apply the target’s metadata labels. See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.Endpoint) for formatting details. |
+| metrics.serviceMonitor.relabelings | list | `[]` | Configures the relabeling rules to apply the target's metadata labels. See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.Endpoint) for formatting details. |
+| metrics.serviceMonitor.sampleLimit | int | `0` | Per-scrape sample limit. A value of 0 (default) omits sampleLimit. |
 | metrics.serviceMonitor.scrapeTimeout | string | `""` | Timeout after which Prometheus considers the scrape to be failed. |
 
 ### OS/Kubernetes Distro Settings

--- a/chart/templates/servicemonitor.yaml
+++ b/chart/templates/servicemonitor.yaml
@@ -15,6 +15,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- with .Values.metrics.serviceMonitor.sampleLimit }}
+  sampleLimit: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       app: longhorn-manager

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -646,6 +646,8 @@ metrics:
     # documentation](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.Endpoint) for
     # formatting details.
     metricRelabelings: []
+    # -- Per-scrape sample limit. A value of 0 (default) omits sampleLimit.
+    sampleLimit: 0
 ## openshift settings
 openshift:
   # -- Setting that allows Longhorn to integrate with OpenShift.


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue #12671

#### What this PR does / why we need it:
Introduces `metrics.serviceMonitor.sampleLimit`, which allows specifying the `spec.sampleLimit` of the optional Prometheus ServiceMonitor.

This is useful when you want to specify per-scrape sample limits for the longhorn-manager scrape target.

In our environment we operate with a low default and give specific exemptions using this feature. This setting now being available means we cannot use the chart-provided `ServiceMonitor`.