### PR TITLE
fix(workflow): exit with status 1 on invalid usage in scan-and-notify script

### DIFF
--- a/.github/workflows/scan-and-notify-testing-items.py
+++ b/.github/workflows/scan-and-notify-testing-items.py
@@ -303,5 +303,6 @@ def scan_and_notify(github_org, github_repo, github_project):
 if __name__ == "__main__":
     if len(sys.argv) < 4:
         print('Usage: python scan-and-notify-testing-items.py <github_org> <github_repo> <github_project>')
+        sys.exit(1)
 
     scan_and_notify(sys.argv[1], sys.argv[2], sys.argv[3])


### PR DESCRIPTION
## What

- Call `sys.exit(1)` when the scan-and-notify-testing-items script is invoked without required arguments.

## Why

Invalid usage should fail with a non-zero exit code instead of continuing and erroring later with missing argv.