### PR TITLE
fix(workflow): exit with status 1 on invalid usage in check-sprint-last-day script

### DIFF
--- a/.github/workflows/check-sprint-last-day.py
+++ b/.github/workflows/check-sprint-last-day.py
@@ -110,7 +110,7 @@ def is_today_is_in_last_day_of_current_sprint(github_token, project_id):
 if __name__ == "__main__":
     if len(sys.argv) < 4:
         print('Usage: python check-sprint-last-day.py github_org github_repo github_project')
-        sys.exit()
+        sys.exit(1)
 
     github_token = os.getenv("GITHUB_TOKEN")
 


### PR DESCRIPTION
## What

- Use `sys.exit(1)` instead of `sys.exit()` when `check-sprint-last-day.py` is run without required arguments.

## Why

Invalid usage should fail with a non-zero exit code. A bare `sys.exit()` exits with status 0, which can hide misuse in scripts and CI.