### PR TITLE
feat(setting): add engine image pod liveness probe settings

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -364,6 +364,9 @@ During installation, you can either allow Longhorn to use the default system set
 | defaultSettings.fastReplicaRebuildEnabled | Setting that allows fast rebuilding of replicas using the checksum of snapshot disk files. Before enabling this setting, you must set the snapshot-data-integrity value to "enable" or "fast-check". |
 | defaultSettings.freezeFilesystemForSnapshot | Setting that freezes the filesystem on the root partition before a snapshot is created. |
 | defaultSettings.guaranteedInstanceManagerCPU | Percentage of the total allocatable CPU resources on each node to be reserved for each instance manager pod. The default value is {"v1":"12","v2":"12"}. |
+| defaultSettings.engineImagePodLivenessProbePeriod | Interval (in seconds) between liveness probes for engine image pods. The default value is 5 seconds. |
+| defaultSettings.engineImagePodLivenessProbeTimeout | Timeout (in seconds) for each liveness probe. The default value is 4 seconds. |
+| defaultSettings.engineImagePodLivenessProbeFailureThreshold | Number of consecutive failed probes before the pod is restarted. The default value is 3. |
 | defaultSettings.instanceManagerPodLivenessProbeTimeout | In seconds. The setting specifies the timeout for the instance manager pod liveness probe. The default value is 10 seconds. |
 | defaultSettings.kubernetesClusterAutoscalerEnabled | Setting that notifies Longhorn that the cluster is using the Kubernetes Cluster Autoscaler. |
 | defaultSettings.logLevel | Log levels that indicate the type and severity of logs in Longhorn Manager. The default value is "Info". (Options: "Panic", "Fatal", "Error", "Warn", "Info", "Debug", "Trace") |

--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -919,6 +919,33 @@ questions:
         min: 1
         max: 60
         default: 10
+      - variable: defaultSettings.engineImagePodLivenessProbePeriod
+        label: Engine Image Pod Liveness Probe Period
+        description: >-
+          Interval (in seconds) between liveness probes for engine image pods.
+        group: Longhorn Default Settings
+        type: int
+        min: 1
+        max: 60
+        default: 5
+      - variable: defaultSettings.engineImagePodLivenessProbeTimeout
+        label: Engine Image Pod Liveness Probe Timeout
+        description: >-
+          Time (in seconds) to wait for a liveness probe to complete before marking it as failed.
+        group: Longhorn Default Settings
+        type: int
+        min: 1
+        max: 60
+        default: 4
+      - variable: defaultSettings.engineImagePodLivenessProbeFailureThreshold
+        label: Engine Image Pod Liveness Probe Failure Threshold
+        description: >-
+          Number of consecutive failed probes required to trigger a pod restart.
+        group: Longhorn Default Settings
+        type: int
+        min: 1
+        max: 60
+        default: 3
       - variable: defaultSettings.snapshotHeavyTaskConcurrentLimit
         label: Snapshot Heavy Task Concurrent Limit
         description: >-

--- a/chart/templates/default-setting.yaml
+++ b/chart/templates/default-setting.yaml
@@ -281,6 +281,15 @@ data:
     {{- if not (kindIs "invalid" .Values.defaultSettings.defaultUblkNumberOfQueue) }}
     default-ublk-number-of-queue: {{ include "longhorn.multiTypeSetting" .Values.defaultSettings.defaultUblkNumberOfQueue }}
     {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.engineImagePodLivenessProbePeriod) }}
+    engine-image-pod-liveness-probe-period: {{ .Values.defaultSettings.engineImagePodLivenessProbePeriod | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.engineImagePodLivenessProbeTimeout) }}
+    engine-image-pod-liveness-probe-timeout: {{ .Values.defaultSettings.engineImagePodLivenessProbeTimeout | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.engineImagePodLivenessProbeFailureThreshold) }}
+    engine-image-pod-liveness-probe-failure-threshold: {{ .Values.defaultSettings.engineImagePodLivenessProbeFailureThreshold | quote }}
+    {{- end }}
     {{- if not (kindIs "invalid" .Values.defaultSettings.instanceManagerPodLivenessProbeTimeout) }}
     instance-manager-pod-liveness-probe-timeout: {{ .Values.defaultSettings.instanceManagerPodLivenessProbeTimeout | quote }}
     {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -402,6 +402,12 @@ defaultSettings:
   defaultUblkQueueDepth: ~
   # -- This setting specifies the default the number of queues for ublk frontend. This setting applies to volumes using the V2 Data Engine with Ublk front end. Individual volumes can override this setting by specifying their own number of queues for ublk.
   defaultUblkNumberOfQueue: ~
+  # -- In seconds. The setting specifies the interval between liveness probes for engine image pods. The default value is 5 seconds.
+  engineImagePodLivenessProbePeriod: ~
+  # -- In seconds. The setting specifies the timeout for the engine image pod liveness probe. The default value is 4 seconds.
+  engineImagePodLivenessProbeTimeout: ~
+  # -- The setting specifies the number of consecutive failed liveness probes before an engine image pod is restarted. The default value is 3.
+  engineImagePodLivenessProbeFailureThreshold: ~
   # -- In seconds. The setting specifies the timeout for the instance manager pod liveness probe. The default value is 10 seconds.
   instanceManagerPodLivenessProbeTimeout: ~
   # -- Setting that allows scheduling of empty node selector volumes to any node.


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#12846

#### What this PR does / why we need it:

This PR exposes the engine image DaemonSet liveness probe settings through Helm `defaultSettings`.

It adds support for configuring these settings from the chart:

- `engineImagePodLivenessProbePeriod`
- `engineImagePodLivenessProbeTimeout`
- `engineImagePodLivenessProbeFailureThreshold`

The change updates the Helm values, default setting template, Rancher questions, and chart README so operators can persist these probe values across upgrades instead of reapplying manual DaemonSet patches.

#### Special notes for your reviewer:

This PR is the chart-side part of the fix only.

The runtime behavior that reads these settings and updates existing engine image DaemonSets lives in the corresponding `longhorn-manager` PR for the same issue.

Companion PR:

- `longhorn-manager`: [longhorn/longhorn-manager#4623](https://github.com/longhorn/longhorn-manager/pull/4623)

This repo only exposes the settings through Helm in the same pattern already used for other Longhorn default settings.

#### Additional documentation or context

This change is intended to address clusters where the current hardcoded engine image liveness probe values are too aggressive during upgrades or under transient resource pressure.
