### PR TITLE
fix: adding required permissions to top level and jobs in the workflow

### DIFF
--- a/.github/workflows/add-issue-to-projects.yml
+++ b/.github/workflows/add-issue-to-projects.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened, reopened, milestoned]
 
+permissions:
+  contents: read
+
 jobs:
   longhorn:
     runs-on: ubuntu-latest

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -7,6 +7,9 @@ on:
     - master
     - "v*"
 
+permissions:
+  contents: read
+
 jobs:
   check-backport:
     runs-on: ubuntu-latest

--- a/.github/workflows/close-issue.yml
+++ b/.github/workflows/close-issue.yml
@@ -2,6 +2,10 @@ name: "[Issue Management] Close Issue"
 on:
   issues:
     types: [ unlabeled ]
+
+permissions:
+  contents: read
+
 jobs:
   backport:
     runs-on: ubuntu-latest

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -6,6 +6,9 @@ on:
     - master
     - "v*.*.*"
 
+permissions:
+  contents: read
+
 jobs:
   codespell:
     runs-on: ubuntu-latest

--- a/.github/workflows/create-issue.yml
+++ b/.github/workflows/create-issue.yml
@@ -3,6 +3,9 @@ on:
   issues:
     types: [ labeled ]
 
+permissions:
+  contents: read
+
 env:
   LONGHORN_SPRINT_PROJECT_URL: https://github.com/orgs/longhorn/projects/8
   QA_SPRINT_PROJECT_URL: https://github.com/orgs/longhorn/projects/4

--- a/.github/workflows/create-release-task-issues.yml
+++ b/.github/workflows/create-release-task-issues.yml
@@ -13,6 +13,9 @@ on:
         description: "GitHub Username of the QA Captain, formatted as @<github-username>"
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   create-release-task:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-review-reminder.yml
+++ b/.github/workflows/pr-review-reminder.yml
@@ -7,6 +7,9 @@ on:
     # Trigger every Monday at 10:00 GMT+8
     - cron: '0 2 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   pull-request-review-reminder:
     runs-on: ubuntu-latest

--- a/.github/workflows/scan-and-notify-testing-items.yml
+++ b/.github/workflows/scan-and-notify-testing-items.yml
@@ -19,6 +19,9 @@ on:
         default: "Longhorn Sprint"
         required: true
 
+permissions:
+  contents: read
+
 env:
   GITHUB_ORG: longhorn
   GITHUB_REPO: longhorn

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -6,6 +6,9 @@ on:
   schedule:
   - cron: '30 1 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-branch-image-tags.yaml
+++ b/.github/workflows/update-branch-image-tags.yaml
@@ -7,6 +7,9 @@ on:
         description: "Branch, ex: v1.7.x"
         required: true
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/update-community-issue.yml
+++ b/.github/workflows/update-community-issue.yml
@@ -5,6 +5,9 @@ on:
   issue_comment:
     types: [created, edited]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.issue.number }}
   cancel-in-progress: true

--- a/.github/workflows/update-longhorn-issue.yml
+++ b/.github/workflows/update-longhorn-issue.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [labeled, milestoned, assigned, unassigned]
 
+permissions:
+  contents: read
+
 env:
   LONGHORN_SPRINT_PROJECT_URL: https://github.com/orgs/longhorn/projects/8
 

--- a/.github/workflows/wont-fix.yml
+++ b/.github/workflows/wont-fix.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [closed]
 
+permissions:
+  contents: read
+
 jobs:
   add-wontfix-label:
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #12950

Fixes #12950

#### What this PR does / why we need it:

Currently the score for the Token Permissions is 0 because the top level permissions and a few job level permissions are missing in the workflows. With this change, the score will move to 10, since the workflow jobs will run with the minimal permissions. The PR retains conditions like `write` only at the job level, where it is necessary.

#### Special notes for your reviewer:

This change only touches `.github/workflows/*.yml` / `.yaml` files to add `permissions:` blocks (top-level `contents: read` by default, with elevated `write` permissions kept only at the job level where needed). No application code, docs, helm chart, or CHANGELOG changes are required.

#### Additional documentation or context

- OSSF Scorecard Token-Permissions check: https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
- GitHub docs on workflow permissions: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
