### PR TITLE
feat: expose shareManagerNodeSelector and shareManagerTolerations as Helm values

### DIFF
--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -1106,6 +1106,38 @@ questions:
         group: Longhorn Storage Class Settings
         type: string
         default: null
+  - variable: persistence.shareManagerNodeSelector.enable
+    description: >-
+      Setting that allows you to enable the share manager node selector for the default Longhorn StorageClass.
+    group: Longhorn Storage Class Settings
+    label: Enable Storage Class Share Manager Node Selector
+    type: boolean
+    default: false
+    show_subquestion_if: true
+    subquestions:
+      - variable: persistence.shareManagerNodeSelector.selector
+        label: Storage Class Share Manager Node Selector
+        description: >-
+          Node selector for the share manager pods of the default Longhorn StorageClass. Longhorn schedules share manager pods only on nodes with the specified tags. (Examples: "storage,fast")
+        group: Longhorn Storage Class Settings
+        type: string
+        default: null
+  - variable: persistence.shareManagerTolerations.enable
+    description: >-
+      Setting that allows you to enable the share manager tolerations for the default Longhorn StorageClass.
+    group: Longhorn Storage Class Settings
+    label: Enable Storage Class Share Manager Tolerations
+    type: boolean
+    default: false
+    show_subquestion_if: true
+    subquestions:
+      - variable: persistence.shareManagerTolerations.tolerations
+        label: Storage Class Share Manager Tolerations
+        description: >-
+          Tolerations for the share manager pods of the default Longhorn StorageClass. Specify values using a semicolon-separated list in `kubectl taint` syntax. (Example: "key1=value1:effect; key2=value2:effect")
+        group: Longhorn Storage Class Settings
+        type: string
+        default: null
   - variable: persistence.backingImage.enable
     description: Setting that allows you to use a backing image in a Longhorn StorageClass.
     group: Longhorn Storage Class Settings

--- a/chart/templates/storageclass.yaml
+++ b/chart/templates/storageclass.yaml
@@ -49,6 +49,12 @@ data:
       {{- if .Values.persistence.defaultNodeSelector.enable }}
       nodeSelector: "{{ .Values.persistence.defaultNodeSelector.selector }}"
       {{- end }}
+      {{- if .Values.persistence.shareManagerNodeSelector.enable }}
+      shareManagerNodeSelector: "{{ .Values.persistence.shareManagerNodeSelector.selector }}"
+      {{- end }}
+      {{- if .Values.persistence.shareManagerTolerations.enable }}
+      shareManagerTolerations: "{{ .Values.persistence.shareManagerTolerations.tolerations }}"
+      {{- end }}
       {{- if .Values.persistence.unmapMarkSnapChainRemoved }}
       unmapMarkSnapChainRemoved: "{{ .Values.persistence.unmapMarkSnapChainRemoved }}"
       {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -217,6 +217,16 @@ persistence:
     enable: false
     # -- Node selector for the default Longhorn StorageClass. Longhorn uses only nodes with the specified tags for storing volume data. (Examples: "storage,fast")
     selector: ""
+  shareManagerNodeSelector:
+    # -- Setting that allows you to enable the share manager node selector for the default Longhorn StorageClass.
+    enable: false
+    # -- Node selector for the share manager pods of the default Longhorn StorageClass. Longhorn schedules share manager pods only on nodes with the specified tags. (Examples: "storage,fast")
+    selector: ""
+  shareManagerTolerations:
+    # -- Setting that allows you to enable the share manager tolerations for the default Longhorn StorageClass.
+    enable: false
+    # -- Tolerations for the share manager pods of the default Longhorn StorageClass. Specify values using a semicolon-separated list in `kubectl taint` syntax. (Example: "key1=value1:effect; key2=value2:effect")
+    tolerations: ""
   # -- Setting that allows you to enable automatic snapshot removal during filesystem trim for a Longhorn StorageClass. (Options: "ignored", "enabled", "disabled")
   unmapMarkSnapChainRemoved: ignored
   # -- Setting that allows you to specify the data engine version for the default Longhorn StorageClass. (Options: "v1", "v2")


### PR DESCRIPTION
#### Which issue(s) this PR fixes:                                                                                                      
                                                                                                                                        
Issue longhorn/longhorn#9324
                                                                                                                                        
#### What this PR does / why we need it:                                                                                                 
   
Exposes `shareManagerNodeSelector` and `shareManagerTolerations` as configurable Helm values for the default Longhorn StorageClass.  Previously, these `StorageClass` parameters had to be patched in post-install via kubectl, requiring extra operational steps for users who need share manager pods constrained to specific nodes or tolerating specific taints.                                              
                  
Both values follow the existing enable/value pattern used by defaultNodeSelector and defaultDiskSelector:                             
   
  - `persistence.shareManagerNodeSelector.enable` / `persistence.shareManagerNodeSelector.selector`                                         
  - `persistence.shareManagerTolerations.enable` / `persistence.shareManagerTolerations.tolerations`
                                                                                                                                          
Changes are made to chart/values.yaml, chart/templates/storageclass.yaml, and chart/questions.yaml.                                   

#### Special notes for your reviewer:

Both new values default to disabled (enable: false) so there is no behavior change for existing deployments.

Happy to follow up with a docs PR against the Longhorn website repository if required given the require/doc label on the linked issue.
   

#### Additional documentation or context

Manual test plan:                                                                                                                     
  1. Install Longhorn with persistence.shareManagerNodeSelector.enable=true and
  persistence.shareManagerNodeSelector.selector="storage:true"                                                                          
  2. Confirm the longhorn-storageclass ConfigMap contains shareManagerNodeSelector: "storage:true" under parameters:
  3. Create an RWX volume and confirm share manager pod is only scheduled on nodes labeled storage=true                                 
  4. Repeat steps 1–3 for shareManagerTolerations using a node with a matching taint       

Add persistence.shareManagerNodeSelector and `persistence.shareManagerTolerations` to `values.yaml`, `storageclass.yaml`, and `questions.yaml`, following the same enable/value pattern used by existing StorageClass parameters such as `defaultNodeSelector` and `defaultDiskSelector`.

Note: allowedTopologies (also requested in #9324) is not addressed here as it requires a different template approach — it is a top-level StorageClass field rather than a parameters: entry.