### PR TITLE
fix: correct upgrade responder image tag

### DIFF
--- a/dev/upgrade-responder/install.sh
+++ b/dev/upgrade-responder/install.sh
@@ -4,7 +4,7 @@ UPGRADE_RESPONDER_REPO="https://github.com/longhorn/upgrade-responder.git"
 UPGRADE_RESPONDER_REPO_BRANCH="master"
 UPGRADE_RESPONDER_VALUE_YAML="upgrade-responder-value.yaml"
 UPGRADE_RESPONDER_IMAGE_REPO="longhornio/upgrade-responder"
-UPGRADE_RESPONDER_IMAGE_TAG="longhorn-head"
+UPGRADE_RESPONDER_IMAGE_TAG="master-head"
 
 INFLUXDB_URL="http://influxdb.default.svc.cluster.local:8086"
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

https://github.com/longhorn/longhorn/issues/12778

#### What this PR does / why we need it:

Currently, it seems that we build the image with the tag `master-head` instead `longhorn-head`

#### Special notes for your reviewer:

#### Additional documentation or context
