### PR TITLE
docs: update Apache license link to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Copyright (c) 2014-2026 The Longhorn Authors
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 
-[http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+[https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 


### PR DESCRIPTION
Updated the Apache License 2.0 link in README.md from HTTP to HTTPS.