### PR TITLE
fix: include enginefrontends in uninstall ClusterRole

### DIFF
--- a/uninstall/uninstall.yaml
+++ b/uninstall/uninstall.yaml
@@ -74,6 +74,7 @@ rules:
   - backups
   - backuptargets
   - backupvolumes
+  - enginefrontends
   - engineimages
   - engines
   - instancemanagers


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue #2035 (related)

#### What this PR does / why we need it:
`uninstall/uninstall.yaml` was one CRD behind `deploy/longhorn.yaml`.

`enginefrontends.longhorn.io` is shipped now, but the uninstall ClusterRole did not include `enginefrontends`. Tiny RBAC drift but yeah, it can bite during cleanup.

Repro:
```bash
python3 - <<'PY'
import yaml
from pathlib import Path

crds=[]
for doc in yaml.safe_load_all(Path("deploy/longhorn.yaml").read_text()):
    if doc and doc.get("kind") == "CustomResourceDefinition":
        name = doc.get("metadata", {}).get("name", "")
        if name.endswith(".longhorn.io"):
            crds.append(name.split(".")[0])

role=[]
for doc in yaml.safe_load_all(Path("uninstall/uninstall.yaml").read_text()):
    if doc and doc.get("kind") == "ClusterRole":
        for rule in doc.get("rules", []):
            if rule.get("apiGroups") == ["longhorn.io"]:
                role = rule.get("resources", [])

print("missing from uninstall role:", sorted(set(crds) - set(role)))
PY
```

Before this PR:
```text
missing from uninstall role: ['enginefrontends']
```

After this PR:
```text
missing from uninstall role: []
```

#### Special notes for your reviewer:
Generated with `python3 scripts/update-uninstall-manifest.py`.

No cloud/provider quota weirdness here, Kubernetes RBAC is API-server enforced, so any cluster with this CRD can hit it.

#### Additional documentation or context
Similar prior cleanup: #5135 and #7644.