### PR TITLE
feat(chart): add twoMinorUpgradeDistros env var for n-2 upgrade support

### DIFF
--- a/chart/templates/daemonset-sa.yaml
+++ b/chart/templates/daemonset-sa.yaml
@@ -102,6 +102,8 @@ spec:
         - name: LONGHORN_DISTRO
           value: {{ .Values.longhornManager.distro | quote }}
         {{- end }}
+        - name: LONGHORN_TWO_MINOR_UPGRADE_DISTROS
+          value: {{ .Values.longhornManager.twoMinorUpgradeDistros | quote }}
         {{- if .Values.enableGoCoverDir }}
         - name: GOCOVERDIR
           value: /go-cover-dir/

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -479,6 +479,8 @@ longhornManager:
     format: plain
   # -- Optional distro identifier used for upgrade responder reporting. Supported values: "oss", "prime", "dev".
   distro: "oss"
+  # -- Comma-separated list of distro identifiers that support upgrading from two minor versions back (n-2 to n). When a distro is listed, the upgrade path validation allows skipping one minor version.
+  twoMinorUpgradeDistros: ""
   # -- PriorityClass for Longhorn Manager.
   priorityClass: *defaultPriorityClassNameRef
   # -- Toleration for Longhorn Manager on nodes allowed to run Longhorn components.

--- a/deploy/longhorn-okd.yaml
+++ b/deploy/longhorn-okd.yaml
@@ -4867,6 +4867,8 @@ spec:
               fieldPath: spec.nodeName
         - name: LONGHORN_DISTRO
           value: "oss"
+        - name: LONGHORN_TWO_MINOR_UPGRADE_DISTROS
+          value: ""
         
       - name: pre-pull-share-manager-image
         imagePullPolicy: IfNotPresent

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -4804,6 +4804,8 @@ spec:
               fieldPath: spec.nodeName
         - name: LONGHORN_DISTRO
           value: "oss"
+        - name: LONGHORN_TWO_MINOR_UPGRADE_DISTROS
+          value: ""
         
       - name: pre-pull-share-manager-image
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION


#### Which issue(s) this PR fixes:

Issue #

#### What this PR does / why we need it:

Add LONGHORN_TWO_MINOR_UPGRADE_DISTROS environment variable to the longhorn-manager DaemonSet. This allows specifying a comma-separated list of distro identifiers that support upgrading directly from two minor versions back (n-2 to n), skipping one minor version in the upgrade path validation.

#### Special notes for your reviewer:

#### Additional documentation or context
