### PR TITLE
fix(chart): re-implement imeage default registry

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -42,7 +42,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion }}
 {{- if .Values.global.cattle.systemDefaultRegistry -}}
 {{- .Values.global.cattle.systemDefaultRegistry -}}
 {{- else -}}
-{{- "" -}}
+{{- "docker.io" -}}
 {{- end -}}
 {{- end -}}
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 global:
   # -- Global override for container image registry.
-  imageRegistry: "docker.io"
+  imageRegistry: ""
   # -- Global override for image pull secrets for container registry.
   imagePullSecrets: []
   # -- Set container timezone (TZ env) for all Longhorn workloads. Leave empty to use container default.


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue longhorn/longhorn#13071

#### What this PR does / why we need it:
Restores Rancher Prime integration by fixing `global.cattle.systemDefaultRegistry` precedence while maintaining CRI-O short-name compliance.

**Root cause:** Commit 4becc06 changed `global.imageRegistry` default from `""` to `"docker.io"` to fix #12268 (CRI-O short-name enforcement). This caused Helm's `coalesce` function to return `"docker.io"` immediately, never evaluating the `systemDefaultRegistry` helper that contains Rancher's registry setting.

**Solution:** Move the `docker.io` default from `values.yaml` into the `system_default_registry` helper template. This preserves the precedence chain:
- When `global.cattle.systemDefaultRegistry` is set (Rancher deployments) → uses it
- When not set (kubectl/standalone deployments) → falls back to `docker.io`

Both use cases work correctly, and the final rendered manifests are identical to before.

#### Special notes for your reviewer:
**About `deploy/longhorn.yaml`:** The `docker.io` prefix is NOT missing. Our fix simply moves WHERE the default comes from (values.yaml → helper template) without changing the final rendered output. All images in `deploy/longhorn.yaml` still have the `docker.io` prefix when regenerated with `scripts/generate-longhorn-yaml.sh`.

**Testing:**
- ✅ Test 1 (kubectl deployment): Images use `docker.io` prefix (fixes #12268)  
- ✅ Test 2 (Rancher deployment): Images use `systemDefaultRegistry` value (fixes #13071)

Verified on local Vagrant K3s cluster with both scenarios.

#### Additional documentation or context
- Analysis report: [ticket/lh-13071_system_default_registry_not_applied/analysis_report.md](https://github.com/yunchang75/longhorn/blob/13071-cattle-system-registry/ticket/lh-13071_system_default_registry_not_applied/analysis_report.md)
- Investigation notes: [ticket/lh-13071_system_default_registry_not_applied/notes.md](https://github.com/yunchang75/longhorn/blob/13071-cattle-system-registry/ticket/lh-13071_system_default_registry_not_applied/notes.md)