### PR TITLE
feat(chart): add always-on longhorn-global-manager Deployment

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -251,6 +251,24 @@ Longhorn consists of user-deployed components (for example, Longhorn Manager, Lo
 | longhornUI.tolerations | list | `[]` | Toleration for Longhorn UI on nodes allowed to run Longhorn components. |
 | longhornUI.topologySpreadConstraints | list | `[]` | Topology spread constraints for Longhorn UI pods. Unlike `longhornUI.affinity`, these can guarantee that replicas stay spread across a topology domain during a rolling update or a mass reschedule. |
 
+### Longhorn Global Manager Settings
+
+The following settings apply to the longhorn-global-manager Deployment, which hosts the cluster-wide Pod controllers (KubernetesPVController and KubernetesPodController) instead of running them in every Longhorn Manager DaemonSet pod.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| longhornGlobalManager.affinity | object | `{"podAntiAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"podAffinityTerm":{"labelSelector":{"matchExpressions":[{"key":"app","operator":"In","values":["longhorn-global-manager"]}]},"topologyKey":"kubernetes.io/hostname"},"weight":1}]}}` | Affinity for global manager pods. The default spreads replicas across nodes. |
+| longhornGlobalManager.annotations | object | `{}` | Annotations for global manager pods. |
+| longhornGlobalManager.nodeSelector | object | `{}` | Node selector for global manager pods. |
+| longhornGlobalManager.podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":"","minAvailable":1}` | Pod Disruption Budget for the global manager. Keeps a minimum number of global manager pods available during voluntary disruptions such as node drains. Effective only when `longhornGlobalManager.replicas` is greater than 1. |
+| longhornGlobalManager.podDisruptionBudget.enabled | bool | `false` | Setting that allows you to enable the Pod Disruption Budget for the global manager. |
+| longhornGlobalManager.podDisruptionBudget.maxUnavailable | string | `""` | Maximum number or percentage of global manager pods that can be unavailable during a disruption. When set, it takes precedence over `longhornGlobalManager.podDisruptionBudget.minAvailable`. |
+| longhornGlobalManager.podDisruptionBudget.minAvailable | int | `1` | Minimum number or percentage of global manager pods that must remain available during a disruption. Mutually exclusive with `longhornGlobalManager.podDisruptionBudget.maxUnavailable`. |
+| longhornGlobalManager.priorityClass | string | `"longhorn-critical"` | PriorityClass for the global manager. |
+| longhornGlobalManager.replicas | int | `3` | Replica count for the global manager. One replica is the active leader; the others are warm standbys. |
+| longhornGlobalManager.resources | string | `nil` | Resource requests and limits for global manager pods. Memory scales with the cluster's Pod count (cluster-wide Pod informer cache). |
+| longhornGlobalManager.tolerations | list | `[]` | Node tolerations for global manager pods. |
+
 ### Ingress Settings
 
 | Key | Type | Default | Description |

--- a/chart/README.md
+++ b/chart/README.md
@@ -243,6 +243,24 @@ Longhorn consists of user-deployed components (for example, Longhorn Manager, Lo
 | longhornUI.replicas | int | `2` | Replica count for Longhorn UI. |
 | longhornUI.tolerations | list | `[]` | Toleration for Longhorn UI on nodes allowed to run Longhorn components. |
 
+### Longhorn Global Manager Settings
+
+The following settings apply to the longhorn-global-manager Deployment, which hosts the cluster-wide Pod controllers (KubernetesPVController and KubernetesPodController) instead of running them in every Longhorn Manager DaemonSet pod.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| longhornGlobalManager.affinity | object | `{"podAntiAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"podAffinityTerm":{"labelSelector":{"matchExpressions":[{"key":"app","operator":"In","values":["longhorn-global-manager"]}]},"topologyKey":"kubernetes.io/hostname"},"weight":1}]}}` | Affinity for global manager pods. The default spreads replicas across nodes. |
+| longhornGlobalManager.annotations | object | `{}` | Annotations for global manager pods. |
+| longhornGlobalManager.nodeSelector | object | `{}` | Node selector for global manager pods. |
+| longhornGlobalManager.podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":"","minAvailable":1}` | Pod Disruption Budget for the global manager. Keeps a minimum number of global manager pods available during voluntary disruptions such as node drains. Effective only when `longhornGlobalManager.replicas` is greater than 1. |
+| longhornGlobalManager.podDisruptionBudget.enabled | bool | `false` | Setting that allows you to enable the Pod Disruption Budget for the global manager. |
+| longhornGlobalManager.podDisruptionBudget.maxUnavailable | string | `""` | Maximum number or percentage of global manager pods that can be unavailable during a disruption. When set, it takes precedence over `longhornGlobalManager.podDisruptionBudget.minAvailable`. |
+| longhornGlobalManager.podDisruptionBudget.minAvailable | int | `1` | Minimum number or percentage of global manager pods that must remain available during a disruption. Mutually exclusive with `longhornGlobalManager.podDisruptionBudget.maxUnavailable`. |
+| longhornGlobalManager.priorityClass | string | `"longhorn-critical"` | PriorityClass for the global manager. |
+| longhornGlobalManager.replicas | int | `3` | Replica count for the global manager. One replica is the active leader; the others are warm standbys. |
+| longhornGlobalManager.resources | string | `nil` | Resource requests and limits for global manager pods. Memory scales with the cluster's Pod count (cluster-wide Pod informer cache). |
+| longhornGlobalManager.tolerations | list | `[]` | Node tolerations for global manager pods. |
+
 ### Ingress Settings
 
 | Key | Type | Default | Description |

--- a/chart/README.md.gotmpl
+++ b/chart/README.md.gotmpl
@@ -165,6 +165,18 @@ Longhorn consists of user-deployed components (for example, Longhorn Manager, Lo
   {{- end }}
 {{- end }}
 
+### Longhorn Global Manager Settings
+
+The following settings apply to the longhorn-global-manager Deployment, which hosts the cluster-wide Pod controllers (KubernetesPVController and KubernetesPodController) instead of running them in every Longhorn Manager DaemonSet pod.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+{{- range .Values }}
+  {{- if hasPrefix "longhornGlobalManager" .Key }}
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+  {{- end }}
+{{- end }}
+
 ### Ingress Settings
 
 | Key | Type | Default | Description |
@@ -233,6 +245,7 @@ For more details, see the [ocp-readme](https://github.com/longhorn/longhorn/blob
   (hasPrefix "persistence" .Key)
   (hasPrefix "csi" .Key)
   (hasPrefix "longhornManager" .Key)
+  (hasPrefix "longhornGlobalManager" .Key)
   (hasPrefix "longhornDriver" .Key)
   (hasPrefix "longhornUI" .Key)
   (hasPrefix "privateRegistry" .Key)

--- a/chart/templates/deployment-global-manager.yaml
+++ b/chart/templates/deployment-global-manager.yaml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+    app: longhorn-global-manager
+  name: longhorn-global-manager
+  namespace: {{ include "release_namespace" . }}
+spec:
+  replicas: {{ .Values.longhornGlobalManager.replicas }}
+  selector:
+    matchLabels:
+      app: longhorn-global-manager
+  template:
+    metadata:
+      labels: {{- include "longhorn.labels" . | nindent 8 }}
+        app: longhorn-global-manager
+      {{- with .Values.longhornGlobalManager.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      containers:
+      - name: longhorn-global-manager
+        image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.manager.registry "docker.io") }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        - longhorn-manager
+        - -d
+        {{- if eq .Values.longhornManager.log.format "json" }}
+        - -j
+        {{- end }}
+        - global
+        ports:
+        - containerPort: 9505
+          name: healthz
+        readinessProbe:
+          httpGet:
+            path: /v1/healthz
+            port: 9505
+        livenessProbe:
+          httpGet:
+            path: /v1/healthz
+            port: 9505
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        {{- if .Values.longhornManager.distro }}
+        - name: LONGHORN_DISTRO
+          value: {{ .Values.longhornManager.distro | quote }}
+        {{- end }}
+        {{- include "longhorn.timezoneEnv" . | nindent 8 }}
+        {{- with .Values.longhornGlobalManager.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- with (coalesce .Values.global.imagePullSecrets .Values.privateRegistry.registrySecret) }}
+      imagePullSecrets:
+        {{- $imagePullSecrets := list }}
+        {{- if kindIs "string" . }}
+          {{- $imagePullSecrets = append $imagePullSecrets (dict "name" .) }}
+        {{- else }}
+          {{- range . }}
+            {{- if kindIs "string" . }}
+                {{- $imagePullSecrets = append $imagePullSecrets (dict "name" .) }}
+            {{- else }}
+                {{- $imagePullSecrets = append $imagePullSecrets . }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+        {{- toYaml $imagePullSecrets | nindent 8 }}
+      {{- end }}
+      {{- if .Values.longhornGlobalManager.priorityClass }}
+      priorityClassName: {{ .Values.longhornGlobalManager.priorityClass | quote }}
+      {{- end }}
+      {{- if or .Values.global.tolerations .Values.longhornGlobalManager.tolerations .Values.global.cattle.windowsCluster.enabled }}
+      tolerations:
+        {{- if and .Values.global.cattle.windowsCluster.enabled .Values.global.cattle.windowsCluster.tolerations }}
+{{ toYaml .Values.global.cattle.windowsCluster.tolerations | indent 6 }}
+        {{- end }}
+        {{- if or .Values.global.tolerations .Values.longhornGlobalManager.tolerations }}
+{{ default .Values.global.tolerations .Values.longhornGlobalManager.tolerations | toYaml | indent 6 }}
+        {{- end }}
+      {{- end }}
+      {{- if or .Values.global.nodeSelector .Values.longhornGlobalManager.nodeSelector .Values.global.cattle.windowsCluster.enabled }}
+      nodeSelector:
+        {{- if and .Values.global.cattle.windowsCluster.enabled .Values.global.cattle.windowsCluster.nodeSelector }}
+{{ toYaml .Values.global.cattle.windowsCluster.nodeSelector | indent 8 }}
+        {{- end }}
+        {{- if or .Values.global.nodeSelector .Values.longhornGlobalManager.nodeSelector }}
+{{ default .Values.global.nodeSelector .Values.longhornGlobalManager.nodeSelector | toYaml | indent 8 }}
+        {{- end }}
+      {{- end }}
+      affinity:
+      {{- toYaml .Values.longhornGlobalManager.affinity | nindent 8 }}
+      serviceAccountName: longhorn-service-account

--- a/chart/templates/deployment-global-manager.yaml
+++ b/chart/templates/deployment-global-manager.yaml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+    app: longhorn-global-manager
+  name: longhorn-global-manager
+  namespace: {{ include "release_namespace" . }}
+spec:
+  replicas: {{ .Values.longhornGlobalManager.replicas }}
+  selector:
+    matchLabels:
+      app: longhorn-global-manager
+  template:
+    metadata:
+      labels: {{- include "longhorn.labels" . | nindent 8 }}
+        app: longhorn-global-manager
+      {{- with .Values.longhornGlobalManager.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      containers:
+      - name: longhorn-global-manager
+        image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.manager.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        - longhorn-manager
+        - -d
+        {{- if eq .Values.longhornManager.log.format "json" }}
+        - -j
+        {{- end }}
+        - global
+        ports:
+        - containerPort: 9505
+          name: healthz
+        readinessProbe:
+          httpGet:
+            path: /v1/healthz
+            port: 9505
+        livenessProbe:
+          httpGet:
+            path: /v1/healthz
+            port: 9505
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        {{- if .Values.longhornManager.distro }}
+        - name: LONGHORN_DISTRO
+          value: {{ .Values.longhornManager.distro | quote }}
+        {{- end }}
+        {{- include "longhorn.timezoneEnv" . | nindent 8 }}
+        {{- with .Values.longhornGlobalManager.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- with (coalesce .Values.global.imagePullSecrets .Values.privateRegistry.registrySecret) }}
+      imagePullSecrets:
+        {{- $imagePullSecrets := list }}
+        {{- if kindIs "string" . }}
+          {{- $imagePullSecrets = append $imagePullSecrets (dict "name" .) }}
+        {{- else }}
+          {{- range . }}
+            {{- if kindIs "string" . }}
+                {{- $imagePullSecrets = append $imagePullSecrets (dict "name" .) }}
+            {{- else }}
+                {{- $imagePullSecrets = append $imagePullSecrets . }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+        {{- toYaml $imagePullSecrets | nindent 8 }}
+      {{- end }}
+      {{- if .Values.longhornGlobalManager.priorityClass }}
+      priorityClassName: {{ .Values.longhornGlobalManager.priorityClass | quote }}
+      {{- end }}
+      {{- if or .Values.global.tolerations .Values.longhornGlobalManager.tolerations .Values.global.cattle.windowsCluster.enabled }}
+      tolerations:
+        {{- if and .Values.global.cattle.windowsCluster.enabled .Values.global.cattle.windowsCluster.tolerations }}
+{{ toYaml .Values.global.cattle.windowsCluster.tolerations | indent 6 }}
+        {{- end }}
+        {{- if or .Values.global.tolerations .Values.longhornGlobalManager.tolerations }}
+{{ default .Values.global.tolerations .Values.longhornGlobalManager.tolerations | toYaml | indent 6 }}
+        {{- end }}
+      {{- end }}
+      {{- if or .Values.global.nodeSelector .Values.longhornGlobalManager.nodeSelector .Values.global.cattle.windowsCluster.enabled }}
+      nodeSelector:
+        {{- if and .Values.global.cattle.windowsCluster.enabled .Values.global.cattle.windowsCluster.nodeSelector }}
+{{ toYaml .Values.global.cattle.windowsCluster.nodeSelector | indent 8 }}
+        {{- end }}
+        {{- if or .Values.global.nodeSelector .Values.longhornGlobalManager.nodeSelector }}
+{{ default .Values.global.nodeSelector .Values.longhornGlobalManager.nodeSelector | toYaml | indent 8 }}
+        {{- end }}
+      {{- end }}
+      affinity:
+      {{- toYaml .Values.longhornGlobalManager.affinity | nindent 8 }}
+      serviceAccountName: longhorn-service-account

--- a/chart/templates/poddisruptionbudget-global-manager.yaml
+++ b/chart/templates/poddisruptionbudget-global-manager.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.longhornGlobalManager.podDisruptionBudget.enabled (gt (int .Values.longhornGlobalManager.replicas) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+    app: longhorn-global-manager
+  name: longhorn-global-manager
+  namespace: {{ include "release_namespace" . }}
+spec:
+  {{- $pdb := .Values.longhornGlobalManager.podDisruptionBudget }}
+  {{- if ne (toString $pdb.maxUnavailable) "" }}
+  maxUnavailable: {{ $pdb.maxUnavailable }}
+  {{- else if ne (toString $pdb.minAvailable) "" }}
+  minAvailable: {{ $pdb.minAvailable }}
+  {{- else }}
+  minAvailable: 1
+  {{- end }}
+  selector:
+    matchLabels:
+      app: longhorn-global-manager
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -548,6 +548,40 @@ longhornManager:
   updateStrategy:
     rollingUpdate:
       maxUnavailable: "100%"
+longhornGlobalManager:
+  # -- Replica count for the global manager. One replica is the active leader; the others are warm standbys.
+  replicas: 3
+  # -- PriorityClass for the global manager.
+  priorityClass: *defaultPriorityClassNameRef
+  # -- Affinity for global manager pods. The default spreads replicas across nodes.
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                    - longhorn-global-manager
+            topologyKey: kubernetes.io/hostname
+  # -- Resource requests and limits for global manager pods. Memory scales with the cluster's Pod count (cluster-wide Pod informer cache).
+  resources: ~
+  # -- Node tolerations for global manager pods.
+  tolerations: []
+  # -- Node selector for global manager pods.
+  nodeSelector: {}
+  # -- Annotations for global manager pods.
+  annotations: {}
+  # -- Pod Disruption Budget for the global manager. Keeps a minimum number of global manager pods available during voluntary disruptions such as node drains. Effective only when `longhornGlobalManager.replicas` is greater than 1.
+  podDisruptionBudget:
+    # -- Setting that allows you to enable the Pod Disruption Budget for the global manager.
+    enabled: false
+    # -- Minimum number or percentage of global manager pods that must remain available during a disruption. Mutually exclusive with `longhornGlobalManager.podDisruptionBudget.maxUnavailable`.
+    minAvailable: 1
+    # -- Maximum number or percentage of global manager pods that can be unavailable during a disruption. When set, it takes precedence over `longhornGlobalManager.podDisruptionBudget.minAvailable`.
+    maxUnavailable: ""
 longhornDriver:
   log:
     # -- Format of longhorn-driver logs. (Options: "plain", "json")

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -530,6 +530,40 @@ longhornManager:
   updateStrategy:
     rollingUpdate:
       maxUnavailable: "100%"
+longhornGlobalManager:
+  # -- Replica count for the global manager. One replica is the active leader; the others are warm standbys.
+  replicas: 3
+  # -- PriorityClass for the global manager.
+  priorityClass: *defaultPriorityClassNameRef
+  # -- Affinity for global manager pods. The default spreads replicas across nodes.
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                    - longhorn-global-manager
+            topologyKey: kubernetes.io/hostname
+  # -- Resource requests and limits for global manager pods. Memory scales with the cluster's Pod count (cluster-wide Pod informer cache).
+  resources: ~
+  # -- Node tolerations for global manager pods.
+  tolerations: []
+  # -- Node selector for global manager pods.
+  nodeSelector: {}
+  # -- Annotations for global manager pods.
+  annotations: {}
+  # -- Pod Disruption Budget for the global manager. Keeps a minimum number of global manager pods available during voluntary disruptions such as node drains. Effective only when `longhornGlobalManager.replicas` is greater than 1.
+  podDisruptionBudget:
+    # -- Setting that allows you to enable the Pod Disruption Budget for the global manager.
+    enabled: false
+    # -- Minimum number or percentage of global manager pods that must remain available during a disruption. Mutually exclusive with `longhornGlobalManager.podDisruptionBudget.maxUnavailable`.
+    minAvailable: 1
+    # -- Maximum number or percentage of global manager pods that can be unavailable during a disruption. When set, it takes precedence over `longhornGlobalManager.podDisruptionBudget.minAvailable`.
+    maxUnavailable: ""
 longhornDriver:
   log:
     # -- Format of longhorn-driver logs. (Options: "plain", "json")

--- a/deploy/longhorn-okd.yaml
+++ b/deploy/longhorn-okd.yaml
@@ -6144,6 +6144,76 @@ spec:
       securityContext:
         runAsUser: 0
 ---
+# Source: longhorn/templates/deployment-global-manager.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.12.0-dev
+    app: longhorn-global-manager
+  name: longhorn-global-manager
+  namespace: longhorn-system
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: longhorn-global-manager
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: longhorn
+        app.kubernetes.io/instance: longhorn
+        app.kubernetes.io/version: v1.12.0-dev
+        app: longhorn-global-manager
+    spec:
+      containers:
+      - name: longhorn-global-manager
+        image: docker.io/longhornio/longhorn-manager:master-head
+        imagePullPolicy: IfNotPresent
+        command:
+        - longhorn-manager
+        - -d
+        - global
+        ports:
+        - containerPort: 9505
+          name: healthz
+        readinessProbe:
+          httpGet:
+            path: /v1/healthz
+            port: 9505
+        livenessProbe:
+          httpGet:
+            path: /v1/healthz
+            port: 9505
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LONGHORN_DISTRO
+          value: "longhorn"
+        
+      priorityClassName: "longhorn-critical"
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - longhorn-global-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 1
+      serviceAccountName: longhorn-service-account
+---
 # Source: longhorn/templates/deployment-ui.yaml
 apiVersion: apps/v1
 kind: Deployment

--- a/deploy/longhorn-okd.yaml
+++ b/deploy/longhorn-okd.yaml
@@ -5780,6 +5780,76 @@ spec:
       securityContext:
         runAsUser: 0
 ---
+# Source: longhorn/templates/deployment-global-manager.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.12.0-dev
+    app: longhorn-global-manager
+  name: longhorn-global-manager
+  namespace: longhorn-system
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: longhorn-global-manager
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: longhorn
+        app.kubernetes.io/instance: longhorn
+        app.kubernetes.io/version: v1.12.0-dev
+        app: longhorn-global-manager
+    spec:
+      containers:
+      - name: longhorn-global-manager
+        image: docker.io/longhornio/longhorn-manager:master-head
+        imagePullPolicy: IfNotPresent
+        command:
+        - longhorn-manager
+        - -d
+        - global
+        ports:
+        - containerPort: 9505
+          name: healthz
+        readinessProbe:
+          httpGet:
+            path: /v1/healthz
+            port: 9505
+        livenessProbe:
+          httpGet:
+            path: /v1/healthz
+            port: 9505
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LONGHORN_DISTRO
+          value: "longhorn"
+        
+      priorityClassName: "longhorn-critical"
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - longhorn-global-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 1
+      serviceAccountName: longhorn-service-account
+---
 # Source: longhorn/templates/deployment-ui.yaml
 apiVersion: apps/v1
 kind: Deployment

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -6081,6 +6081,76 @@ spec:
       securityContext:
         runAsUser: 0
 ---
+# Source: longhorn/templates/deployment-global-manager.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.12.0-dev
+    app: longhorn-global-manager
+  name: longhorn-global-manager
+  namespace: longhorn-system
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: longhorn-global-manager
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: longhorn
+        app.kubernetes.io/instance: longhorn
+        app.kubernetes.io/version: v1.12.0-dev
+        app: longhorn-global-manager
+    spec:
+      containers:
+      - name: longhorn-global-manager
+        image: docker.io/longhornio/longhorn-manager:master-head
+        imagePullPolicy: IfNotPresent
+        command:
+        - longhorn-manager
+        - -d
+        - global
+        ports:
+        - containerPort: 9505
+          name: healthz
+        readinessProbe:
+          httpGet:
+            path: /v1/healthz
+            port: 9505
+        livenessProbe:
+          httpGet:
+            path: /v1/healthz
+            port: 9505
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LONGHORN_DISTRO
+          value: "longhorn"
+        
+      priorityClassName: "longhorn-critical"
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - longhorn-global-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 1
+      serviceAccountName: longhorn-service-account
+---
 # Source: longhorn/templates/deployment-ui.yaml
 apiVersion: apps/v1
 kind: Deployment

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -5717,6 +5717,76 @@ spec:
       securityContext:
         runAsUser: 0
 ---
+# Source: longhorn/templates/deployment-global-manager.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.12.0-dev
+    app: longhorn-global-manager
+  name: longhorn-global-manager
+  namespace: longhorn-system
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: longhorn-global-manager
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: longhorn
+        app.kubernetes.io/instance: longhorn
+        app.kubernetes.io/version: v1.12.0-dev
+        app: longhorn-global-manager
+    spec:
+      containers:
+      - name: longhorn-global-manager
+        image: docker.io/longhornio/longhorn-manager:master-head
+        imagePullPolicy: IfNotPresent
+        command:
+        - longhorn-manager
+        - -d
+        - global
+        ports:
+        - containerPort: 9505
+          name: healthz
+        readinessProbe:
+          httpGet:
+            path: /v1/healthz
+            port: 9505
+        livenessProbe:
+          httpGet:
+            path: /v1/healthz
+            port: 9505
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LONGHORN_DISTRO
+          value: "longhorn"
+        
+      priorityClassName: "longhorn-critical"
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - longhorn-global-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 1
+      serviceAccountName: longhorn-service-account
+---
 # Source: longhorn/templates/deployment-ui.yaml
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Add a `globalManager` block in values.yaml and a templated
longhorn-global-manager Deployment that owns the cluster-wide Pod informer.
The cluster-wide Pod controllers (KubernetesPVController,
KubernetesPodController) run in this leader-elected Deployment as a singleton
instead of in every longhorn-manager DaemonSet pod, collapsing the cluster-wide
Pod watch fan-out from O(node count) to one active leader.

The split is the only topology (single-mode): the Deployment is always
rendered and the DaemonSet no longer hosts those controllers. There is no
opt-in toggle; the longhorn-manager binary excludes the migrated controllers
from `daemon` unconditionally. Multiple replicas with hostname anti-affinity
provide hot standby; a livenessProbe hits /v1/healthz (port 9505), which
reports process liveness regardless of leader status so standby replicas stay
Ready.

See enhancements/20260506-global-longhorn-manager.md.

longhorn-13059
