### PR TITLE
fix: mount manager data path from default-data-path

### DIFF
--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -308,7 +308,14 @@ questions:
       - variable: defaultSettings.defaultDataPath
         label: Default Data Path
         description: >-
-          Default path to use for storing data on a host. An absolute directory path indicates a filesystem-type disk used by the V1 Data Engine, while a path to a block device indicates a block-type disk used by the V2 Data Engine. The default value is "/var/lib/longhorn/".
+          Default path to use for storing data on a host. An absolute directory path indicates a filesystem-type disk used by the V1 Data Engine, while a path to a block device indicates a block-type disk used by the V2 Data Engine. When this setting is a block device path, runtime and control-plane paths are configured separately by default-control-path. The default value is "/var/lib/longhorn/".
+        group: Longhorn Default Settings
+        type: string
+        default: /var/lib/longhorn/
+      - variable: defaultSettings.defaultControlPath
+        label: Default Control Path
+        description: >-
+          Default path to use for storing runtime and control-plane artifacts on a host. This setting must be an absolute directory path. Engine binaries, metadata, sockets, and logs are stored under this path. The default value is "/var/lib/longhorn/".
         group: Longhorn Default Settings
         type: string
         default: /var/lib/longhorn/

--- a/chart/templates/daemonset-sa.yaml
+++ b/chart/templates/daemonset-sa.yaml
@@ -18,6 +18,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- $longhornDataPath := default "/var/lib/longhorn/" .Values.defaultSettings.defaultDataPath }}
+      {{- $longhornControlPath := default "/var/lib/longhorn/" .Values.defaultSettings.defaultControlPath }}
       containers:
       - name: longhorn-manager
         image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.manager.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
@@ -73,8 +75,12 @@ spec:
           mountPath: /host/etc/
           readOnly: true
         - name: longhorn
-          mountPath: /var/lib/longhorn/
+          mountPath: {{ $longhornDataPath | quote }}
           mountPropagation: Bidirectional
+        {{- if ne $longhornControlPath $longhornDataPath }}
+        - name: longhorn-control
+          mountPath: {{ $longhornControlPath | quote }}
+        {{- end }}
         - name: longhorn-grpc-tls
           mountPath: /tls-files/
         {{- if .Values.enableGoCoverDir }}
@@ -98,6 +104,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: LONGHORN_DATA_PATH
+          value: {{ $longhornDataPath | quote }}
+        - name: LONGHORN_CONTROL_PATH
+          value: {{ $longhornControlPath | quote }}
         {{- if .Values.longhornManager.distro }}
         - name: LONGHORN_DISTRO
           value: {{ .Values.longhornManager.distro | quote }}
@@ -130,7 +140,13 @@ spec:
           path: /etc/
       - name: longhorn
         hostPath:
-          path: /var/lib/longhorn/
+          path: {{ $longhornDataPath | quote }}
+      {{- if ne $longhornControlPath $longhornDataPath }}
+      - name: longhorn-control
+        hostPath:
+          path: {{ $longhornControlPath | quote }}
+          type: DirectoryOrCreate
+      {{- end }}
       {{- if .Values.enableGoCoverDir }}
       - name: go-cover-dir
         hostPath:

--- a/chart/templates/default-setting.yaml
+++ b/chart/templates/default-setting.yaml
@@ -15,6 +15,9 @@ data:
     {{- if not (kindIs "invalid" .Values.defaultSettings.defaultDataPath) }}
     default-data-path: {{ .Values.defaultSettings.defaultDataPath | quote }}
     {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.defaultControlPath) }}
+    default-control-path: {{ .Values.defaultSettings.defaultControlPath | quote }}
+    {{- end }}
     {{- if not (kindIs "invalid" .Values.defaultSettings.replicaSoftAntiAffinity) }}
     replica-soft-anti-affinity: {{ .Values.defaultSettings.replicaSoftAntiAffinity }}
     {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -260,6 +260,8 @@ defaultSettings:
   createDefaultDiskLabeledNodes: ~
   # -- Default path to use for storing data on a host. An absolute directory path indicates a filesystem-type disk used by the V1 Data Engine, while a path to a block device indicates a block-type disk used by the V2 Data Engine. The default value is "/var/lib/longhorn/".
   defaultDataPath: ~
+  # -- Default path to use for storing runtime and control-plane artifacts on a host. This setting must be an absolute directory path. The default value is "/var/lib/longhorn/".
+  defaultControlPath: ~
   # -- Default data locality. A Longhorn volume has data locality if a local replica of the volume exists on the same node as the pod that is using the volume.
   defaultDataLocality: ~
   # -- Setting that allows scheduling on nodes with healthy replicas of the same volume. This setting is disabled by default.

--- a/deploy/longhorn-okd.yaml
+++ b/deploy/longhorn-okd.yaml
@@ -79,6 +79,7 @@ metadata:
     app.kubernetes.io/version: v1.12.0-dev
 data:
   default-setting.yaml: |-
+    default-control-path: "/var/lib/longhorn/"
     priority-class: "longhorn-critical"
     disable-revision-counter: "{\"v1\":\"true\"}"
 ---
@@ -4849,7 +4850,7 @@ spec:
           mountPath: /host/etc/
           readOnly: true
         - name: longhorn
-          mountPath: /var/lib/longhorn/
+          mountPath: "/var/lib/longhorn/"
           mountPropagation: Bidirectional
         - name: longhorn-grpc-tls
           mountPath: /tls-files/
@@ -4870,6 +4871,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: LONGHORN_DATA_PATH
+          value: "/var/lib/longhorn/"
+        - name: LONGHORN_CONTROL_PATH
+          value: "/var/lib/longhorn/"
         - name: LONGHORN_DISTRO
           value: "longhorn"
         
@@ -4892,7 +4897,7 @@ spec:
           path: /etc/
       - name: longhorn
         hostPath:
-          path: /var/lib/longhorn/
+          path: "/var/lib/longhorn/"
       - name: longhorn-grpc-tls
         secret:
           secretName: longhorn-grpc-tls

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -77,6 +77,7 @@ metadata:
     app.kubernetes.io/version: v1.12.0-dev
 data:
   default-setting.yaml: |-
+    default-control-path: "/var/lib/longhorn/"
     priority-class: "longhorn-critical"
     disable-revision-counter: "{\"v1\":\"true\"}"
 ---
@@ -4786,7 +4787,7 @@ spec:
           mountPath: /host/etc/
           readOnly: true
         - name: longhorn
-          mountPath: /var/lib/longhorn/
+          mountPath: "/var/lib/longhorn/"
           mountPropagation: Bidirectional
         - name: longhorn-grpc-tls
           mountPath: /tls-files/
@@ -4807,6 +4808,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: LONGHORN_DATA_PATH
+          value: "/var/lib/longhorn/"
+        - name: LONGHORN_CONTROL_PATH
+          value: "/var/lib/longhorn/"
         - name: LONGHORN_DISTRO
           value: "longhorn"
         
@@ -4829,7 +4834,7 @@ spec:
           path: /etc/
       - name: longhorn
         hostPath:
-          path: /var/lib/longhorn/
+          path: "/var/lib/longhorn/"
       - name: longhorn-grpc-tls
         secret:
           secretName: longhorn-grpc-tls


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

https://github.com/longhorn/longhorn/issues/9083

#### What this PR does / why we need it:

This change updates the Longhorn deployment chart so the manager pod mount path and `LONGHORN_DATA_PATH` environment variable follow the configured `defaultSettings.defaultDataPath`.

Previously, even when users set `default-data-path` to a custom location, the manager DaemonSet still mounted `/var/lib/longhorn`. This prevented the manager and related runtime components from fully following the configured data path. This PR ensures the installation manifest passes the configured path through consistently.


#### Special notes for your reviewer:

#### Additional documentation or context
