### PR TITLE
fix(chart): add explicit backendRef defaults to HTTPRoute to fix ArgoCD OutOfSync

### DIFF
--- a/chart/templates/httproute.yaml
+++ b/chart/templates/httproute.yaml
@@ -39,4 +39,7 @@ spec:
     backendRefs:
     - name: longhorn-frontend
       port: 80
+      group: ""
+      kind: Service
+      weight: 1
 {{- end }}


### PR DESCRIPTION
## Summary

- Add explicit `group: ""`, `kind: Service`, and `weight: 1` defaults to `backendRefs` in `chart/templates/httproute.yaml`
- Prevents ArgoCD from detecting a false diff between desired state and live state after Gateway API controller defaulting

## Motivation and Context

Fixes #13340

When Longhorn is deployed via Helm and `httproute.enabled=true`, the generated HTTPRoute resource omits `group`, `kind`, and `weight` from `backendRefs`. The Gateway API controller automatically adds these fields as defaults after the resource is applied. ArgoCD then sees a diff between the Helm-rendered manifest and the live resource, causing the Application to remain `OutOfSync`.

Explicitly declaring the defaults in the template ensures the rendered manifest matches the live state.

## Test Plan

1. Deploy Longhorn Helm chart with `httproute.enabled=true` and a valid `parentRefs` pointing to a Gateway
2. Verify ArgoCD Application shows `Synced` status
3. Run `helm template` to confirm rendered HTTPRoute contains `group: ""`, `kind: Service`, `weight: 1`

## Known Risks

None. Change only adds explicit values that the controller was already defaulting — behavior is identical, rendered manifest now matches live state.