### PR TITLE
feat(chart): add opt-in PodDisruptionBudget for Longhorn UI

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -234,6 +234,10 @@ Longhorn consists of user-deployed components (for example, Longhorn Manager, Lo
 |-----|------|---------|-------------|
 | longhornUI.affinity | object | `{"podAntiAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"podAffinityTerm":{"labelSelector":{"matchExpressions":[{"key":"app","operator":"In","values":["longhorn-ui"]}]},"topologyKey":"kubernetes.io/hostname"},"weight":1}]}}` | Affinity for Longhorn UI pods. Specify the affinity you want to use for Longhorn UI. |
 | longhornUI.nodeSelector | object | `{}` | Node selector for Longhorn UI. Specify the nodes allowed to run Longhorn UI. |
+| longhornUI.podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":"","minAvailable":1}` | Pod Disruption Budget for Longhorn UI. Keeps a minimum number of UI pods available during voluntary disruptions such as node drains. Effective only when `longhornUI.replicas` is greater than 1. |
+| longhornUI.podDisruptionBudget.enabled | bool | `false` | Setting that allows you to enable the Pod Disruption Budget for Longhorn UI. |
+| longhornUI.podDisruptionBudget.maxUnavailable | string | `""` | Maximum number or percentage of Longhorn UI pods that can be unavailable during a disruption. When set, it takes precedence over `longhornUI.podDisruptionBudget.minAvailable`. |
+| longhornUI.podDisruptionBudget.minAvailable | string | `1` | Minimum number or percentage of Longhorn UI pods that must remain available during a disruption. Mutually exclusive with `longhornUI.podDisruptionBudget.maxUnavailable`. |
 | longhornUI.priorityClass | string | `"longhorn-critical"` | PriorityClass for Longhorn UI. |
 | longhornUI.replicas | int | `2` | Replica count for Longhorn UI. |
 | longhornUI.tolerations | list | `[]` | Toleration for Longhorn UI on nodes allowed to run Longhorn components. |

--- a/chart/templates/poddisruptionbudget-ui.yaml
+++ b/chart/templates/poddisruptionbudget-ui.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.longhornUI.podDisruptionBudget.enabled (gt (int .Values.longhornUI.replicas) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+    app: longhorn-ui
+  name: longhorn-ui
+  namespace: {{ include "release_namespace" . }}
+spec:
+  {{- $pdb := .Values.longhornUI.podDisruptionBudget }}
+  {{- if ne (toString $pdb.maxUnavailable) "" }}
+  maxUnavailable: {{ $pdb.maxUnavailable }}
+  {{- else if ne (toString $pdb.minAvailable) "" }}
+  minAvailable: {{ $pdb.minAvailable }}
+  {{- else }}
+  minAvailable: 1
+  {{- end }}
+  selector:
+    matchLabels:
+      app: longhorn-ui
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -580,6 +580,14 @@ longhornUI:
   ## and uncomment this example block
   #  label-key1: "label-value1"
   #  label-key2: "label-value2"
+  # -- Pod Disruption Budget for Longhorn UI. Keeps a minimum number of UI pods available during voluntary disruptions such as node drains. Effective only when `longhornUI.replicas` is greater than 1.
+  podDisruptionBudget:
+    # -- Setting that allows you to enable the Pod Disruption Budget for Longhorn UI.
+    enabled: false
+    # -- (string) Minimum number or percentage of Longhorn UI pods that must remain available during a disruption. Mutually exclusive with `longhornUI.podDisruptionBudget.maxUnavailable`.
+    minAvailable: 1
+    # -- Maximum number or percentage of Longhorn UI pods that can be unavailable during a disruption. When set, it takes precedence over `longhornUI.podDisruptionBudget.minAvailable`.
+    maxUnavailable: ""
 ingress:
   # -- Setting that allows Longhorn to generate ingress records for the Longhorn UI service.
   enabled: false


### PR DESCRIPTION
Add an opt-in PodDisruptionBudget for the Longhorn UI Deployment, gated on
`longhornUI.podDisruptionBudget.enabled` (default false). The UI already defaults
to `replicas: 2` with pod anti-affinity, so this lets adopters keep a UI pod
available during voluntary disruptions such as node drains, with no change to
default behavior.

This is the Longhorn UI slice of #12889 (chart PDB gap). Other rendered
Deployments can follow in separate PRs.

Validation (helm lint + helm template, chart 1.12.0-dev):
- helm lint: 0 chart(s) failed
- default values: no PodDisruptionBudget rendered
- podDisruptionBudget.enabled=true: PDB renders with minAvailable: 1
- enabled=true + maxUnavailable set: PDB renders with maxUnavailable, minAvailable omitted (mutually exclusive)

related: #12889


related: #13466
