### PR TITLE
chart: update the minimum Kubernetes version requirement to v1.34

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: longhorn
 version: 1.12.0-dev
 appVersion: v1.12.0-dev
-kubeVersion: ">=1.25.0-0"
+kubeVersion: ">=1.34.0-0"
 description: Longhorn is a distributed block storage system for Kubernetes.
 keywords:
 - longhorn

--- a/chart/README.md
+++ b/chart/README.md
@@ -20,7 +20,7 @@ Longhorn is 100% open source software. Project source code is spread across a nu
 ## Prerequisites
 
 1. A container runtime compatible with Kubernetes (Docker v1.13+, containerd v1.3.7+, etc.)
-2. Kubernetes >= v1.25
+2. Kubernetes >= v1.34
 3. Make sure `bash`, `curl`, `findmnt`, `grep`, `awk` and `blkid` has been installed in all nodes of the Kubernetes cluster.
 4. Make sure `open-iscsi` has been installed, and the `iscsid` daemon is running on all nodes of the Kubernetes cluster. For GKE, recommended Ubuntu as guest OS image since it contains `open-iscsi` already.
 

--- a/chart/README.md.gotmpl
+++ b/chart/README.md.gotmpl
@@ -20,7 +20,7 @@ Longhorn is 100% open source software. Project source code is spread across a nu
 ## Prerequisites
 
 1. A container runtime compatible with Kubernetes (Docker v1.13+, containerd v1.3.7+, etc.)
-2. Kubernetes >= v1.25
+2. Kubernetes >= v1.34
 3. Make sure `bash`, `curl`, `findmnt`, `grep`, `awk` and `blkid` has been installed in all nodes of the Kubernetes cluster.
 4. Make sure `open-iscsi` has been installed, and the `iscsid` daemon is running on all nodes of the Kubernetes cluster. For GKE, recommended Ubuntu as guest OS image since it contains `open-iscsi` already.
 

--- a/scripts/generate-longhorn-yaml.sh
+++ b/scripts/generate-longhorn-yaml.sh
@@ -28,7 +28,13 @@ EOD
     OKD_ENABLED_FLAG="--set openshift.enabled=true"
   fi
 
-  helm template longhorn "$CHART_DIR" --namespace "$NAMESPACE" $OKD_ENABLED_FLAG --create-namespace --no-hooks >>"$DEPLOY_YAML"
+  helm template longhorn "$CHART_DIR" \
+    --namespace "$NAMESPACE" \
+    $OKD_ENABLED_FLAG \
+    --create-namespace \
+    --no-hooks \
+    --kube-version 1.34.0 \
+    >>"$DEPLOY_YAML"
   < "$DEPLOY_YAML" grep -v 'helm.sh\|app.kubernetes.io/managed-by: Helm' | grep -v "helm.sh/chart:" > "$DEPLOY_YAML_TMP"
   mv "$DEPLOY_YAML_TMP" "$DEPLOY_YAML"
 


### PR DESCRIPTION



#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#13576

#### What this PR does / why we need it:

Update the minimum Kubernetes version requirement to v1.34 for Longhorn v1.11.3+, v1.12.1+ and v1.13.0+ because of the csi external provisioner v6.3.0+.


#### Special notes for your reviewer:

#### Additional documentation or context
