### PR TITLE
Added JTEKT to list of adopters

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -16,3 +16,4 @@
 | End-User | Child Rescue Coalition | https://childrescuecoalition.org/ | Kubernetes persistent replicated storage with automated backups. |
 | End-User | NAVER | https://www.navercorp.com/ | Production Kubernetes persistent storage supporting NAVER's internal platform and cloud-native services at scale. |
 | End-User | Walkbase | https://walkbase.com/ | Walkbase uses Longhorn for persistent storage in our bare metal kubernetes clusters. |
+| End-User | JTEKT | https://www.jtekt.co.jp | Longhorn is the storage solution for an on-premise K8s cluster used as internal developer platform |


### PR DESCRIPTION
JTEKT has been using Longhorn as storage solution for an on-premise K8s cluster which serves as internal developer platform.