### PR TITLE
fix(networkpolicy): allow rke2 traefik ui ingress

### DIFF
--- a/chart/templates/network-policies/ui-frontend-network-policy.yaml
+++ b/chart/templates/network-policies/ui-frontend-network-policy.yaml
@@ -30,6 +30,12 @@ spec:
           app.kubernetes.io/component: controller
           app.kubernetes.io/instance: rke2-ingress-nginx
           app.kubernetes.io/name: rke2-ingress-nginx
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: rke2-traefik
     {{- else if eq .Values.networkPolicies.type "k3s" }}
     - namespaceSelector:
         matchLabels:


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#13653

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context

RKE2 official doc: https://docs.rke2.io/known_issues?_highlight=app.kubernetes.io%2Fname#ingress-in-cis-mode