### PR TITLE
feat(lep): client-side backup encryption

### DIFF
--- a/enhancements/20260810-backup-store-s3-encryption.md
+++ b/enhancements/20260810-backup-store-s3-encryption.md
@@ -1,255 +1,421 @@
-# Client-Side Encryption for S3 Volume Backups
+# Backup Store Encryption for S3 Targets
 
 ## Summary
 
-Longhorn currently supports volume encryption inside the Kubernetes cluster. When an encrypted volume is backed up, the backup data stored in the remote backup target is also protected because the source volume data is already encrypted.
+Longhorn currently supports encryption for in-cluster volumes. When an encrypted Longhorn volume is backed up, the backup data is also protected because the source volume data is already encrypted.
 
-However, this couples backup-at-rest encryption to in-cluster volume encryption. Users who do not need or do not want the runtime overhead and operational complexity of encrypted Longhorn volumes cannot independently protect their remote backups with client-side encryption.
+However, this couples backup-at-rest encryption with in-cluster volume encryption.
 
-This enhancement introduces **client-side encryption for Longhorn S3 backups**, independent of Longhorn in-cluster volume encryption.
+Some users want to keep Longhorn volumes unencrypted inside the Kubernetes cluster while independently encrypting backup data before sending it to a remote S3 backup store.
 
-When enabled, Longhorn encrypts backup data locally before sending it to the S3 or S3-compatible backup target and decrypts it locally while restoring. The S3 provider only receives encrypted data and does not receive the encryption key.
+This enhancement introduces **client-side encryption for Longhorn backups stored in S3 or S3-compatible backup targets**, independently of Longhorn in-cluster volume encryption.
 
-The feature is disabled by default to preserve the existing behavior.
+When client-side backup encryption is enabled:
 
-The initial implementation supports:
+```text
+Volume data
+    |
+    v
+Backup processing
+    |
+    v
+Compression
+    |
+    v
+Client-side encryption
+    |
+    v
+Existing S3 backupstore
+    |
+    v
+Remote S3-compatible storage
+```
 
-* S3 and S3-compatible backup targets only.
-* Client-side authenticated encryption using AES-256.
-* Encryption keys stored in a Kubernetes Secret.
-* Transparent backup, restore, backup listing, synchronization, and deletion.
-* Existing unencrypted backups without migration.
-* AWS S3 and MinIO interoperability.
-* An extensible key-provider design so external KMS integration can be added later.
+The remote object-storage provider receives ciphertext instead of plaintext backup data.
+
+The feature supports encryption configuration at three levels:
+
+1. Global
+2. BackupTarget
+3. Volume
+
+The configuration precedence is:
+
+```text
+Volume > BackupTarget > Global
+```
+
+The feature is disabled by default for backward compatibility.
+
+The initial implementation applies only to S3 and S3-compatible backup targets.
 
 ### Related Issues
 
 * #5220 - Encrypt volume backup to remote backup store without in-cluster volume encryption
 * #8453 - Backup encryption
-* #12297 - Automated test coverage for backup encryption
+* #12297 - Backup encryption automated test
 * #4883 - Block volume encryption
 
 ---
 
-## Motivation
+# Motivation
 
-Longhorn currently provides encryption at the volume level. This is useful when data must be encrypted on Longhorn storage nodes, but volume encryption and backup encryption serve different security requirements.
+Longhorn volume encryption and backup encryption address different security requirements.
 
-For example, a user might trust the storage nodes running inside their Kubernetes cluster but use an external S3-compatible provider for disaster-recovery backups.
+A user may trust the Kubernetes cluster and the Longhorn storage nodes but store disaster-recovery backups in external object storage.
 
-In this case, enabling volume encryption solely to secure remote backups introduces unnecessary coupling.
-
-Other applications commonly encrypt their backup data locally before sending it to object storage. Longhorn should provide the same option so users do not have to depend on storage-provider-specific server-side encryption or an additional encryption proxy.
-
-Server-side encryption such as SSE-S3, SSE-KMS, or SSE-C does not completely address this use case because encryption is still implemented by the object-storage service. It may also differ between AWS S3 and other S3-compatible providers.
-
-The intended security boundary for this enhancement is:
+For example:
 
 ```text
-Longhorn
-   |
-   | plaintext
-   v
-Compression
-   |
-   | compressed plaintext
-   v
-Client-side encryption
-   |
-   | ciphertext only
-   v
-S3 client
-   |
-   | ciphertext
-   v
-Remote S3 / S3-compatible storage
+Kubernetes cluster
+    |
+    | trusted
+    v
+Longhorn volume
+    |
+    | unencrypted
+    v
+Longhorn backup
+    |
+    | encrypted locally
+    v
+External S3 provider
 ```
 
-The remote backup provider must never need access to the plaintext backup payload or the Longhorn backup encryption key.
+Without independent backup encryption, users need to enable in-cluster volume encryption even if their only requirement is protecting data stored outside the cluster.
 
-### Goals
+This introduces unnecessary coupling between two separate security policies.
 
-1. Allow users to encrypt remote S3 backups without enabling Longhorn volume encryption.
+Client-side backup encryption allows users to define:
 
-2. Encrypt backup data before it leaves the Longhorn backup process.
+```text
+Volume encryption:
+    disabled
 
-3. Decrypt backup data only after it is downloaded from the remote backup target.
+Backup encryption:
+    enabled
+```
 
-4. Use authenticated encryption so corruption or malicious modification of encrypted objects is detected.
+The S3 provider receives encrypted data and does not need to implement any Longhorn-specific encryption capability.
 
-5. Support a user-managed AES-256 key stored in a Kubernetes Secret.
+This is also useful when users do not fully trust an external storage provider or when encryption must happen before data leaves the Kubernetes cluster.
 
-6. Remain compatible with AWS S3 and S3-compatible storage such as MinIO.
+---
 
-7. Preserve Longhorn's existing incremental backup and block deduplication behavior.
+# Goals
 
-8. Preserve compatibility with existing plaintext backups.
+The goals of this enhancement are:
 
-9. Keep encryption disabled by default.
+* Support client-side encryption for Longhorn S3 backups.
+* Make backup encryption independent of Longhorn volume encryption.
+* Encrypt backup data before it leaves Longhorn.
+* Support AWS S3 and S3-compatible backup targets through the existing Longhorn S3 implementation.
+* Keep the encryption layer independent from the S3 provider.
+* Allow encryption to be configured globally.
+* Allow a BackupTarget to override the global configuration.
+* Allow a Volume to override the BackupTarget and global configuration.
+* Use the following configuration precedence:
 
-10. Design the encryption metadata and key-provider abstraction so support for external KMS providers can be added without changing the encrypted data format unnecessarily.
+```text
+Volume > BackupTarget > Global
+```
 
-11. Ensure encryption keys and plaintext key material are never written to backup-store objects, logs, events, Backup CRs, or support bundles.
+* Allow users to explicitly disable encryption for a specific BackupTarget or Volume.
+* Use authenticated encryption to provide both confidentiality and integrity protection.
+* Store encryption keys in Kubernetes Secrets for the initial implementation.
+* Design key handling so external KMS providers can be supported in the future.
+* Preserve Longhorn incremental backup behavior where encryption contexts are compatible.
+* Preserve support for existing unencrypted backups.
+* Ensure existing configurations remain unchanged after upgrade.
+* Persist enough non-sensitive encryption information with every backup so existing backups remain restorable after configuration changes.
+* Never store plaintext encryption keys in backup metadata, CR status, logs, events, or support bundles.
+* Fail closed when encryption cannot be performed.
 
-### Non-goals
+---
 
-The following are outside the scope of the initial implementation:
+# Non-Goals
 
-* Client-side encryption for NFS, CIFS, Azure Blob, or other non-S3 backup targets.
+The following are outside the scope of this enhancement:
+
+* Server-side encryption.
+* SSE-S3.
+* SSE-KMS.
+* SSE-C.
+* Combining client-side encryption with server-side encryption.
+* Backup encryption for NFS or CIFS backup targets.
+* Backup encryption for non-S3 backupstore drivers.
 * Changing Longhorn in-cluster volume encryption.
-* SSE-S3, SSE-KMS, or SSE-C support as the implementation of this feature.
-* Encrypting S3 object names, object sizes, timestamps, or other storage-provider-visible metadata.
-* Automatic migration of existing plaintext backups to encrypted backups.
-* Automatic migration of encrypted backups back to plaintext.
-* In-place encryption-key rotation or re-encryption of existing backup data.
-* Generic external KMS support in the first implementation.
-* Recovering backups when the user has lost the encryption key.
-* Allowing older Longhorn versions that do not understand this encryption format to restore encrypted backups.
+* Automatically encrypting existing plaintext backups.
+* Automatically decrypting existing encrypted backups.
+* Automatically re-encrypting existing backups when the key changes.
+* Online key rotation for existing backup objects.
+* Recovering data after the encryption key is lost.
+* Hiding S3 object names, sizes, timestamps, or access patterns.
+* Implementing external KMS integration in the initial implementation.
+
+Server-side encryption can be discussed and implemented separately in a future enhancement if required.
 
 ---
 
-## Proposal
+# User Stories
 
-### User Stories
+## User Story 1 - Encrypt all backups globally
 
-#### User Story 1: Protect backups stored by an external provider
+A user requires all Longhorn backups to use client-side encryption.
 
-A user runs Longhorn on infrastructure they control and does not need encryption for the running Longhorn volume.
+The administrator enables backup encryption globally.
 
-The user sends Longhorn backups to a third-party S3-compatible object-storage service.
+BackupTargets and Volumes that do not explicitly override the configuration inherit the global policy.
 
-The user wants Longhorn to encrypt the backup locally so the object-storage provider cannot access the original volume data.
-
-The user enables client-side backup encryption on the BackupTarget and provides a Kubernetes Secret containing the encryption key.
-
-Longhorn encrypts every new backup object before uploading it.
-
-#### User Story 2: Separate volume and backup encryption policies
-
-A user has different compliance requirements for production storage and disaster-recovery storage.
-
-The Longhorn volume may be:
+Example:
 
 ```text
-unencrypted volume -> encrypted backup
+Global:
+    enabled
+
+BackupTarget:
+    inherit
+
+Volume:
+    inherit
+
+Effective:
+    enabled
 ```
-
-or:
-
-```text
-encrypted volume -> independently encrypted backup
-```
-
-Backup encryption does not depend on whether Longhorn volume encryption is enabled.
-
-#### User Story 3: Restore into another cluster
-
-A disaster occurs and the original Kubernetes cluster is unavailable.
-
-The administrator installs Longhorn in another cluster, configures the same S3 backup target, and creates the Kubernetes Secret containing the correct backup encryption key.
-
-Longhorn discovers the encrypted backups and restores them transparently.
-
-Without the correct encryption key, Longhorn reports that the backup is encrypted and cannot be restored.
-
-#### User Story 4: Use MinIO or another S3-compatible provider
-
-A user stores Longhorn backups in MinIO or another S3-compatible service.
-
-Because encryption happens before data reaches the S3 API, the storage service does not need to implement Longhorn-specific encryption or SSE-C.
-
-The existing S3 compatibility layer remains responsible only for storing and retrieving ciphertext objects.
 
 ---
 
-## Analysis
+## User Story 2 - Encrypt backups for one BackupTarget
 
-### Existing Longhorn S3 implementation
+A user has multiple backup destinations but only one requires encryption.
 
-Longhorn's `backupstore` already uses `aws-sdk-go-v2` for S3 operations. It also supports custom S3 endpoints using `AWS_ENDPOINTS` and configures path-style addressing when necessary for S3-compatible providers.
-
-Therefore, this enhancement does not require replacing the existing S3 client.
-
-The existing transport architecture should remain:
+Example:
 
 ```text
-Longhorn backupstore
-        |
-        +-- encryption/decryption layer
-        |
-        +-- existing aws-sdk-go-v2 S3 implementation
-        |
-        +-- AWS S3 / MinIO / S3-compatible provider
+Global:
+    disabled
+
+BackupTarget A:
+    enabled
+
+BackupTarget B:
+    inherit
 ```
 
-The current `BackupStoreDriver` exposes generic operations such as `Read`, `Write`, `Upload`, and `Download`, which makes it possible to place the encryption functionality between Longhorn's backup logic and the existing S3 implementation.
+Backups written to BackupTarget A are encrypted.
 
-Longhorn's S3 implementation also already contains special compatibility handling for multipart uploads, single-part uploads, custom endpoints, path-style access, checksum behavior, and provider-specific S3 differences. The encryption feature should preserve this code rather than introduce another S3 transport implementation.
-
-### Option 1: S3 server-side encryption
-
-Examples include:
-
-* SSE-S3
-* SSE-KMS
-* SSE-C
-
-This is relatively simple to implement but does not satisfy the primary requirement.
-
-With server-side encryption, Longhorn must trust the remote S3 implementation to correctly protect the data. It also introduces differences between S3 providers.
-
-SSE-C additionally sends the customer-provided key to the storage server as part of each applicable request.
-
-This option is therefore not selected as the solution for #5220.
-
-Server-side encryption can be considered separately in the future.
-
-### Option 2: `minio/sio`
-
-`github.com/minio/sio` implements the Data At Rest Encryption (DARE) format.
-
-The library provides streaming authenticated encryption and is explicitly intended for use cases including files, backups, and large object storage.
-
-It supports authenticated encryption algorithms including AES-256-GCM and supports long streams without requiring the complete object to be held in memory.
-
-Because the library operates on an `io.Reader`/`io.Writer` data stream rather than implementing the S3 protocol itself, the existing AWS SDK v2 S3 code remains unchanged.
-
-The resulting architecture is:
-
-```text
-                    Longhorn backup logic
-                             |
-                             | compressed data
-                             v
-                    +------------------+
-                    | Encryption layer |
-                    |    minio/sio     |
-                    +------------------+
-                             |
-                             | encrypted stream
-                             v
-                   Existing S3 backupstore
-                    aws-sdk-go-v2
-                             |
-                  +----------+----------+
-                  |                     |
-                  v                     v
-               AWS S3                MinIO
-                                      / other
-                                  S3-compatible
-```
-
-This is the proposed implementation approach.
+Backups using BackupTarget B remain unencrypted.
 
 ---
 
-## User Experience In Detail
+## User Story 3 - Encrypt backups for specific volumes
 
-### Enabling backup encryption
+A user requires encryption only for volumes containing sensitive data.
 
-Encryption should be configured on the `BackupTarget`, because encryption is a property of the backup destination rather than of the running Longhorn volume.
+Example:
 
-A proposed configuration is:
+```text
+Global:
+    disabled
+
+BackupTarget:
+    inherit
+
+Database Volume:
+    enabled
+
+Log Volume:
+    inherit
+```
+
+The database backup is encrypted while the log-volume backup remains unencrypted.
+
+---
+
+## User Story 4 - Opt out from globally enabled encryption
+
+A user enables backup encryption globally but wants a particular Volume to remain unencrypted.
+
+Example:
+
+```text
+Global:
+    enabled
+
+BackupTarget:
+    inherit
+
+Volume:
+    disabled
+```
+
+The explicit Volume configuration overrides the inherited encryption policy.
+
+---
+
+## User Story 5 - Use different encryption keys
+
+A user wants different encryption keys for different BackupTargets or Volumes.
+
+Example:
+
+```text
+Production BackupTarget:
+    enabled
+    keyID: production-key
+
+Development BackupTarget:
+    enabled
+    keyID: development-key
+```
+
+Or:
+
+```text
+Global:
+    enabled
+    keyID: default-key
+
+Database Volume:
+    enabled
+    keyID: database-key
+```
+
+The higher-priority configuration provides the complete effective encryption policy.
+
+---
+
+## User Story 6 - Disaster recovery
+
+A user creates encrypted backups in cluster A.
+
+Cluster A is lost.
+
+The administrator installs Longhorn in cluster B and configures the same S3 backup target.
+
+The administrator also restores the Kubernetes Secret containing the required backup encryption key.
+
+Longhorn synchronizes the remote backups and determines from the backup metadata which key is required.
+
+The backup is restored successfully.
+
+If the required encryption key is unavailable, Longhorn reports a clear encryption-related error.
+
+---
+
+# Configuration Model
+
+Client-side backup encryption can be configured at three levels:
+
+```text
++-------------------+
+|      Volume       |
++---------+---------+
+          |
+          | inherit
+          v
++-------------------+
+|   BackupTarget    |
++---------+---------+
+          |
+          | inherit
+          v
++-------------------+
+|      Global       |
++-------------------+
+```
+
+The precedence is:
+
+```text
+Volume > BackupTarget > Global
+```
+
+---
+
+# Encryption States
+
+Because this LEP covers only client-side encryption, the configuration can use three states:
+
+```text
+inherit
+disabled
+enabled
+```
+
+`inherit` is valid only for Volume and BackupTarget.
+
+The global configuration supports:
+
+```text
+disabled
+enabled
+```
+
+The default global state is:
+
+```text
+disabled
+```
+
+This ensures existing installations preserve their current behavior after upgrade.
+
+---
+
+# Global Configuration
+
+The global configuration defines the default backup encryption policy.
+
+Example:
+
+```text
+backup-encryption = enabled
+backup-encryption-secret = longhorn-backup-encryption
+```
+
+If encryption is disabled globally:
+
+```text
+backup-encryption = disabled
+```
+
+No key is required.
+
+The exact Longhorn setting names should follow existing naming conventions.
+
+Conceptually, the required settings are:
+
+```text
+backup-encryption
+
+backup-encryption-key-provider
+
+backup-encryption-secret
+```
+
+The initial key provider is:
+
+```text
+secret
+```
+
+The encryption key itself is never stored in a Setting CR.
+
+Only the Secret name and non-sensitive configuration are stored.
+
+---
+
+# BackupTarget Configuration
+
+A BackupTarget may:
+
+```text
+inherit
+disabled
+enabled
+```
+
+Example:
 
 ```yaml
 apiVersion: longhorn.io/v1beta2
@@ -259,23 +425,550 @@ metadata:
   namespace: longhorn-system
 spec:
   backupTargetURL: s3://backup-bucket@region/
-  credentialSecret: longhorn-backup-credential
-  clientSideEncryption: true
-  encryptionSecret: longhorn-backup-encryption
+  credentialSecret: backup-credential
+
+  backupEncryption:
+    state: enabled
+    keyProvider: secret
+    secretName: longhorn-backup-encryption
 ```
 
-The exact API field names can be adjusted during implementation.
+To inherit the global configuration:
 
-When `clientSideEncryption` is false or omitted, Longhorn behaves exactly as it does today.
+```yaml
+backupEncryption:
+  state: inherit
+```
 
-When `clientSideEncryption` is true:
+To explicitly disable encryption:
 
-1. The backup target must use the `s3` driver.
-2. `encryptionSecret` must be specified.
-3. The encryption Secret must exist and contain a valid 256-bit key.
-4. Longhorn validates the configuration before allowing encrypted backup operations.
+```yaml
+backupEncryption:
+  state: disabled
+```
 
-### Encryption Secret
+If the field is omitted, the behavior is equivalent to:
+
+```text
+state = inherit
+```
+
+---
+
+# Volume Configuration
+
+A Volume may also:
+
+```text
+inherit
+disabled
+enabled
+```
+
+Example:
+
+```yaml
+apiVersion: longhorn.io/v1beta2
+kind: Volume
+metadata:
+  name: database-volume
+  namespace: longhorn-system
+spec:
+  backupEncryption:
+    state: enabled
+    keyProvider: secret
+    secretName: database-backup-encryption
+```
+
+A Volume can explicitly opt out:
+
+```yaml
+spec:
+  backupEncryption:
+    state: disabled
+```
+
+If the field is omitted:
+
+```text
+state = inherit
+```
+
+---
+
+# Complete Policy Inheritance
+
+Encryption configuration is inherited as a complete policy.
+
+It is not inherited field by field.
+
+For example:
+
+```text
+Global:
+    state: enabled
+    secret: global-key
+
+BackupTarget:
+    state: inherit
+```
+
+The BackupTarget inherits:
+
+```text
+enabled
++
+global-key
+```
+
+However:
+
+```text
+Global:
+    state: enabled
+    secret: global-key
+
+BackupTarget:
+    state: enabled
+```
+
+does not automatically reuse `global-key`.
+
+Once the BackupTarget explicitly enables encryption, it owns the complete encryption configuration and must specify its own valid key configuration.
+
+The same rule applies to Volume.
+
+This avoids ambiguous configurations where the encryption state comes from one level and the key configuration comes from another.
+
+---
+
+# Effective Configuration Resolution
+
+Before a backup starts, Longhorn resolves the effective encryption policy.
+
+Conceptually:
+
+```go
+func resolveBackupEncryption(
+    volumePolicy *BackupEncryptionSpec,
+    backupTargetPolicy *BackupEncryptionSpec,
+    globalPolicy BackupEncryptionSpec,
+) BackupEncryptionSpec {
+
+    if volumePolicy != nil &&
+        volumePolicy.State != BackupEncryptionStateInherit {
+        return *volumePolicy
+    }
+
+    if backupTargetPolicy != nil &&
+        backupTargetPolicy.State != BackupEncryptionStateInherit {
+        return *backupTargetPolicy
+    }
+
+    return globalPolicy
+}
+```
+
+Example:
+
+```text
+Global:
+    enabled / global-key
+
+BackupTarget:
+    inherit
+
+Volume:
+    inherit
+```
+
+Effective:
+
+```text
+enabled / global-key
+```
+
+Another example:
+
+```text
+Global:
+    enabled / global-key
+
+BackupTarget:
+    enabled / target-key
+
+Volume:
+    inherit
+```
+
+Effective:
+
+```text
+enabled / target-key
+```
+
+Another example:
+
+```text
+Global:
+    enabled
+
+BackupTarget:
+    enabled
+
+Volume:
+    disabled
+```
+
+Effective:
+
+```text
+disabled
+```
+
+---
+
+# API and CRD Changes
+
+## Common API Type
+
+Introduce a reusable configuration structure.
+
+Conceptually:
+
+```go
+type BackupEncryptionState string
+
+const (
+    BackupEncryptionStateInherit  BackupEncryptionState = "inherit"
+    BackupEncryptionStateDisabled BackupEncryptionState = "disabled"
+    BackupEncryptionStateEnabled  BackupEncryptionState = "enabled"
+)
+```
+
+And:
+
+```go
+type BackupEncryptionSpec struct {
+    State BackupEncryptionState `json:"state,omitempty"`
+
+    KeyProvider string `json:"keyProvider,omitempty"`
+
+    SecretName string `json:"secretName,omitempty"`
+}
+```
+
+The exact Go naming should follow Longhorn API conventions.
+
+---
+
+# BackupTarget CRD Changes
+
+Add:
+
+```go
+type BackupTargetSpec struct {
+    BackupTargetURL  string `json:"backupTargetURL"`
+    CredentialSecret string `json:"credentialSecret,omitempty"`
+
+    ...
+
+    BackupEncryption *BackupEncryptionSpec `json:"backupEncryption,omitempty"`
+}
+```
+
+Existing BackupTarget resources do not contain this field.
+
+They are interpreted as:
+
+```text
+state = inherit
+```
+
+This preserves backward compatibility.
+
+---
+
+# Volume CRD Changes
+
+Add:
+
+```go
+type VolumeSpec struct {
+    ...
+
+    BackupEncryption *BackupEncryptionSpec `json:"backupEncryption,omitempty"`
+}
+```
+
+Existing Volume resources are interpreted as:
+
+```text
+state = inherit
+```
+
+---
+
+# Backup CRD Changes
+
+The Backup CR needs to record the effective encryption information used when that backup was created.
+
+Current Volume, BackupTarget, or Global configuration must not be treated as the source of truth for an existing backup because those settings may change later.
+
+Conceptually:
+
+```go
+type BackupEncryptionStatus struct {
+    Enabled       bool   `json:"enabled,omitempty"`
+    FormatVersion string `json:"formatVersion,omitempty"`
+    Algorithm     string `json:"algorithm,omitempty"`
+    KeyProvider   string `json:"keyProvider,omitempty"`
+    KeyID         string `json:"keyID,omitempty"`
+}
+```
+
+Add it to Backup status:
+
+```go
+type BackupStatus struct {
+    ...
+
+    Encryption *BackupEncryptionStatus `json:"encryption,omitempty"`
+}
+```
+
+Example:
+
+```yaml
+status:
+  encryption:
+    enabled: true
+    formatVersion: "1"
+    algorithm: AES-256-GCM-DARE
+    keyProvider: secret
+    keyID: production-backup-key
+```
+
+Only non-sensitive information is stored.
+
+The encryption key is never included in Backup status.
+
+---
+
+# BackupVolume CRD
+
+Encryption configuration must not be inferred only from `BackupVolume`.
+
+Different backups belonging to the same backup volume may have different encryption histories.
+
+For example:
+
+```text
+backup-1:
+    unencrypted
+
+backup-2:
+    key-A
+
+backup-3:
+    key-B
+```
+
+Therefore, the individual Backup metadata is authoritative.
+
+If useful for the UI, BackupVolume may expose summary information such as whether encrypted backups exist, but it must not represent one encryption configuration as applying to all backups.
+
+---
+
+# Admission and Validation Changes
+
+The admission webhook and controllers must validate the new configuration.
+
+## Global Validation
+
+When global encryption is enabled:
+
+* the key provider must be supported;
+* a Secret must be configured;
+* the Secret must contain valid key information.
+
+---
+
+## BackupTarget Validation
+
+Valid states:
+
+```text
+inherit
+disabled
+enabled
+```
+
+When explicitly enabled:
+
+* the BackupTarget must use the S3 backupstore driver;
+* the key provider must be supported;
+* the configured Secret must be valid.
+
+If encryption is enabled for a non-S3 target:
+
+```text
+client-side backup encryption is currently supported only for S3 backup targets
+```
+
+The effective policy must also be validated before backup execution because inherited global configuration can change after the BackupTarget was created.
+
+---
+
+## Volume Validation
+
+The Volume webhook validates the encryption-policy structure.
+
+For example:
+
+```text
+state = enabled
+```
+
+requires valid key-provider configuration.
+
+The S3 BackupTarget compatibility is validated when an actual backup operation resolves the target.
+
+---
+
+# Client-Side Encryption Design
+
+## Backup Flow
+
+The backup pipeline is:
+
+```text
+Volume data
+    |
+    v
+Changed-block processing
+    |
+    v
+Compression
+    |
+    v
+Client-side encryption
+    |
+    v
+Existing S3 backupstore
+    |
+    v
+Remote object storage
+```
+
+Encryption happens after compression.
+
+Compressing ciphertext would provide little or no useful compression.
+
+---
+
+# Restore Flow
+
+Restore performs the reverse processing:
+
+```text
+Remote object storage
+    |
+    v
+Existing S3 backupstore
+    |
+    v
+Client-side decryption
+    |
+    v
+Decompression
+    |
+    v
+Restore
+```
+
+The encrypted data must be authenticated before it is accepted.
+
+Modified or corrupted encrypted data must result in a restore failure.
+
+---
+
+# Encryption Algorithm
+
+The implementation must use authenticated encryption.
+
+The current candidate is:
+
+```text
+Content encryption:
+    AES-256 authenticated encryption
+
+Streaming format:
+    DARE
+
+Candidate library:
+    github.com/minio/sio
+```
+
+The exact implementation should be validated through a POC before the persistent encryption format is finalized.
+
+Authenticated encryption is required so Longhorn can detect:
+
+* ciphertext modification;
+* corruption;
+* truncation;
+* incorrect keys;
+* invalid encrypted chunks.
+
+AES-CTR without an authentication mechanism is not sufficient.
+
+---
+
+# Why Streaming Encryption
+
+Backup objects can be large.
+
+The encryption implementation must not require Longhorn to load an entire backup object into memory.
+
+The desired processing model is:
+
+```text
+Reader
+   |
+   v
+Compression
+   |
+   v
+Streaming encryption
+   |
+   v
+S3 upload
+```
+
+And for restore:
+
+```text
+S3 download
+   |
+   v
+Streaming decryption
+   |
+   v
+Decompression
+   |
+   v
+Writer
+```
+
+The POC must verify compatibility with the existing backupstore reader/writer requirements.
+
+---
+
+# Key Management
+
+## Initial Key Provider
+
+The initial key provider is a Kubernetes Secret.
 
 Example:
 
@@ -286,447 +979,74 @@ metadata:
   name: longhorn-backup-encryption
   namespace: longhorn-system
 type: Opaque
-data:
-  key: <base64-encoded-32-byte-key>
 stringData:
   keyID: backup-key-2026-01
+data:
+  key: <base64-encoded-key>
 ```
 
-`key` contains exactly 32 bytes after base64 decoding.
+`keyID` is non-sensitive.
 
-`keyID` is a non-sensitive identifier used to identify which key was used for encryption. It can be stored with encrypted objects and exposed in Longhorn status information.
+It identifies the encryption context used for a backup.
 
-The actual key must never be stored in:
-
-* BackupTarget status,
-* Backup status,
-* BackupVolume status,
-* backup metadata,
-* S3 object metadata in plaintext,
-* logs,
-* events,
-* support bundles.
-
-### BackupTarget-level configuration instead of per-volume configuration
-
-The first version should configure encryption at the BackupTarget level.
-
-This has several advantages:
-
-* all backups written to the destination follow a consistent policy;
-* key management is simpler;
-* incremental backup blocks do not unexpectedly cross different encryption policies;
-* disaster-recovery configuration is easier to understand;
-* the BackupTarget is already responsible for the remote destination and its credential Secret.
-
-A per-volume encryption override can be added in a later enhancement if there is sufficient demand.
+The actual encryption key is sensitive and must never be exposed.
 
 ---
 
-## API Changes
+# Envelope Encryption
 
-### BackupTarget
+The design uses envelope encryption.
 
-Proposed additions to `BackupTargetSpec`:
+The Kubernetes Secret contains a Key Encryption Key, or KEK.
 
-```go
-type BackupTargetSpec struct {
-    BackupTargetURL      string
-    CredentialSecret     string
-    PollInterval         metav1.Duration
+For each encrypted object, Longhorn generates a random Data Encryption Key, or DEK.
 
-    // ClientSideEncryption enables encryption before data is uploaded
-    // to the backup target.
-    ClientSideEncryption bool
+The DEK encrypts the backup payload.
 
-    // EncryptionSecret references the Secret containing the
-    // backup encryption key.
-    EncryptionSecret string
-}
-```
-
-The actual Go structure must follow Longhorn API conventions.
-
-### BackupTarget status
-
-BackupTarget status should expose only non-sensitive information.
-
-For example:
-
-```yaml
-status:
-  available: true
-  encryption:
-    enabled: true
-    algorithm: AES-256-GCM
-    keyID: backup-key-2026-01
-```
-
-This allows users and support engineers to identify encryption configuration without exposing key material.
-
-### Backup and BackupVolume
-
-The backup status should indicate whether the remote backup is encrypted.
-
-For example:
-
-```yaml
-status:
-  encrypted: true
-  encryptionKeyID: backup-key-2026-01
-```
-
-This information must also be persisted in the remote backup metadata so a new cluster can recognize encrypted backups.
-
----
-
-## Design
-
-### Encryption location
-
-Encryption should be implemented inside the `backupstore` data path rather than in the S3 provider itself.
-
-The order for backup processing should be:
-
-```text
-Volume data
-    |
-    v
-Changed-block detection
-    |
-    v
-Compression
-    |
-    v
-Client-side encryption
-    |
-    v
-S3 upload
-```
-
-Encryption must happen **after compression**.
-
-Compressing ciphertext is ineffective and would increase backup size and processing cost.
-
-Encryption must also happen after Longhorn has performed the calculations needed for incremental backup and block deduplication. Otherwise, randomized encryption could cause identical blocks to appear different and break the existing deduplication behavior.
-
-Restore uses the reverse flow:
-
-```text
-S3 download
-    |
-    v
-Client-side decryption/authentication
-    |
-    v
-Decompression
-    |
-    v
-Longhorn restore
-```
-
-### Encryption algorithm
-
-The initial encrypted-object format uses:
-
-```text
-Content encryption: AES-256-GCM
-Streaming format:    DARE
-Key size:            256 bits
-Implementation:      github.com/minio/sio
-```
-
-Authenticated encryption is required.
-
-If ciphertext, authentication data, or block ordering has been modified, decryption must fail rather than return potentially corrupted plaintext.
-
-### Key hierarchy
-
-The Kubernetes Secret contains a Key Encryption Key (KEK).
-
-Longhorn should not directly encrypt every backup object with the same key.
-
-Instead, each encrypted object receives a randomly generated 256-bit Data Encryption Key (DEK).
+The KEK wraps the DEK.
 
 Conceptually:
 
 ```text
 Kubernetes Secret
-      |
-      | 256-bit KEK
-      v
+       |
+       | KEK
+       v
 +------------------+
-| Key wrapping     |
+|    Wrap DEK      |
 +------------------+
-      |
-      +-------------------------+
-                                |
-                     random 256-bit DEK
-                                |
-                                v
-                      +------------------+
-                      | AES-256-GCM/DARE |
-                      +------------------+
-                                |
-                                v
-                         Backup ciphertext
+       ^
+       |
+Random DEK
+       |
+       +----------------------------+
+       |                            |
+       v                            v
+Encrypt backup data           Wrapped DEK
+                                   |
+                                   v
+                             Backup metadata
 ```
 
-The plaintext DEK exists only in memory during encryption/decryption.
+The plaintext KEK is never stored in the backup store.
 
-The DEK is wrapped using the KEK and the wrapped value is stored in the Longhorn encryption header.
+The plaintext DEK is never persisted either.
 
-This design provides a clean extension point for future KMS support.
-
-For example:
-
-```text
-Secret provider:
-    KEK from Kubernetes Secret
-        -> wrap/unwrap DEK locally
-
-Future KMS provider:
-    External KMS
-        -> generate/wrap/unwrap DEK
-```
-
-Both providers can produce the same encrypted backup payload format.
-
-### Encrypted object format
-
-Longhorn should add a small self-describing envelope before the DARE ciphertext.
-
-Conceptually:
-
-```text
-+------------------------------------------------+
-| Longhorn encryption magic                     |
-| Format version                                 |
-| Cipher / encryption format                    |
-| Key provider                                   |
-| Key ID                                         |
-| Wrapped data-key length                        |
-| Wrapped data key                               |
-| Key-wrap nonce / required metadata             |
-+------------------------------------------------+
-|                                                |
-| DARE encrypted data stream                     |
-|                                                |
-+------------------------------------------------+
-```
-
-For example:
-
-```text
-Magic:       LHBE
-Version:     1
-Algorithm:   AES-256-GCM-DARE
-KeyProvider: secret
-KeyID:       backup-key-2026-01
-WrappedDEK:  ...
-Ciphertext:  ...
-```
-
-The exact binary encoding should be defined in the implementation and documented so future Longhorn versions can maintain compatibility.
-
-The header must contain no plaintext encryption key.
-
-### Detecting encrypted and plaintext objects
-
-Existing backup targets may contain plaintext objects.
-
-Longhorn must therefore distinguish:
-
-```text
-Legacy plaintext object
-```
-
-from:
-
-```text
-Longhorn encrypted object
-```
-
-The encryption magic and format version provide this distinction.
-
-On read:
-
-1. Read enough bytes to inspect the Longhorn encryption header.
-2. If the encryption magic is present, initialize the decrypting reader.
-3. If the object is a known legacy plaintext object, process it using the existing path.
-4. Never fall back to plaintext processing after authentication of an encrypted object fails.
-
-Step 4 is important.
-
-For example, if an encrypted object has been corrupted, Longhorn must return:
-
-```text
-failed to decrypt backup object: authentication failed
-```
-
-rather than attempting to interpret the corrupted ciphertext as a legacy plaintext object.
-
-### Metadata encryption
-
-Backup data blocks are not the only potentially sensitive information in the backup target.
-
-Objects such as:
-
-```text
-volume.cfg
-backup_*.cfg
-```
-
-can expose volume-related metadata.
-
-Therefore, data written through the normal S3 `Write` path should also be encrypted when backup encryption is enabled.
-
-Object names and directory/prefix structure remain visible. Encrypting S3 keys or directory layout is outside the scope of this enhancement.
-
-### S3 integration
-
-The encryption layer should wrap the existing input/output streams.
-
-Conceptually:
-
-```go
-func (s *service) PutObject(...) {
-    reader := originalReader
-
-    if encryptionEnabled {
-        reader = encryption.EncryptReader(originalReader)
-    }
-
-    // Existing aws-sdk-go-v2 upload path.
-    upload(reader)
-}
-```
-
-For read:
-
-```go
-func (s *service) GetObject(...) {
-    reader := existingS3GetObject()
-
-    if isEncrypted(reader) {
-        return encryption.DecryptReader(reader)
-    }
-
-    return reader
-}
-```
-
-The actual implementation needs to preserve the `io.ReadSeeker` requirements of the current `BackupStoreDriver.Write` and the retry behavior of the AWS SDK uploader.
-
-If an encryption reader cannot provide seek semantics safely, the implementation can provide an encrypted temporary/spooled reader or introduce an encryption-aware wrapper before the final S3 call.
-
-This must be covered by unit and S3 interoperability tests, especially multipart retry cases.
-
-### Multipart uploads
-
-Longhorn currently uses AWS SDK v2's uploader, which can switch to multipart upload for sufficiently large objects.
-
-The encrypted stream must therefore continue to work through the existing multipart implementation.
-
-Encryption is performed before the stream is divided into S3 multipart pieces:
-
-```text
-plaintext
-   |
-   v
-compression
-   |
-   v
-DARE encryption stream
-   |
-   v
-+--------+--------+--------+
-| part 1 | part 2 | part 3 |
-+--------+--------+--------+
-           |
-           v
-          S3
-```
-
-The remote provider only sees parts of one encrypted object.
-
-The multipart boundary is an S3 transport detail and must not become part of the encryption format.
-
-### Incremental backup compatibility
-
-Longhorn backups reuse unchanged blocks between backup revisions.
-
-Client-side encryption must not change the identity used by Longhorn to determine whether a block already exists.
-
-For example:
-
-```text
-Backup 1:
-    block A -> encrypt -> object A
-    block B -> encrypt -> object B
-
-Backup 2:
-    block A unchanged -> reuse existing object A
-    block C new       -> encrypt -> object C
-```
-
-Longhorn should not create a new randomized ciphertext object for block A merely because another backup references the same block.
-
-This preserves the storage efficiency of incremental backups.
-
-### Key changes
-
-Changing the key while existing encrypted backups are present is dangerous because incremental backups can share blocks.
-
-For the initial implementation, Longhorn should reject changing the effective encryption key for a BackupTarget containing encrypted backup data.
-
-For example:
-
-```text
-Current target:
-    encryption enabled
-    keyID = key-A
-    existing backups = yes
-
-User changes:
-    keyID = key-B
-
-Result:
-    reject configuration / mark BackupTarget unavailable
-```
-
-Users who need a new key can initially:
-
-1. create/use another backup target or S3 prefix;
-2. configure the new encryption key;
-3. create new backups there;
-4. retire the old target according to their retention policy.
-
-Online key rotation and re-wrapping existing DEKs can be designed as a separate enhancement.
-
-### Key loss
-
-If the key is lost, encrypted backup data cannot be recovered.
-
-The UI and documentation should clearly warn users about this.
-
-For example:
-
-> Losing the backup encryption key permanently prevents Longhorn from restoring backups encrypted with that key. Store the key securely outside the Longhorn cluster as part of the disaster-recovery plan.
-
-Longhorn must not generate a replacement key automatically if the configured Secret disappears.
+Only the wrapped DEK is stored with the encrypted object.
 
 ---
 
-## External KMS Design
+# Key Provider Abstraction
 
-External KMS integration is not required for the first implementation, but the design must leave a clean extension point.
+Although the initial implementation uses a Kubernetes Secret, key management should use an abstraction so a future enhancement can support an external KMS.
 
-The encryption code should use a key-provider interface similar to:
+Conceptually:
 
 ```go
 type DataKeyProvider interface {
-    GenerateDataKey(ctx context.Context) (
+    GenerateDataKey(
+        ctx context.Context,
+    ) (
         plaintextKey []byte,
         encryptedKey []byte,
         keyID string,
@@ -737,7 +1057,10 @@ type DataKeyProvider interface {
         ctx context.Context,
         encryptedKey []byte,
         keyID string,
-    ) ([]byte, error)
+    ) (
+        []byte,
+        error,
+    )
 }
 ```
 
@@ -749,487 +1072,1295 @@ DataKeyProvider
     +-- KubernetesSecretKeyProvider
 ```
 
-Possible future implementations:
+Possible future providers:
 
 ```text
-DataKeyProvider
-    |
-    +-- KubernetesSecretKeyProvider
-    |
-    +-- AWSKMSKeyProvider
-    |
-    +-- VaultKeyProvider
-    |
-    +-- other external KMS provider
+AWS KMS
+Vault
+other KMS providers
 ```
 
-This prevents the backup encryption format from being coupled directly to AWS KMS even though the backup destination is S3.
-
-A user using MinIO should not be forced to use AWS KMS.
+External KMS implementation itself is outside the scope of this LEP.
 
 ---
 
-## Backup and Restore Behavior
+# Encrypted Object Format
 
-### Backup
+To avoid creating an unnecessary Longhorn-specific binary container, the encrypted object can use a standard archive/container format together with explicit JSON metadata.
 
-For every new object requiring encryption:
-
-1. Load the effective backup-encryption configuration.
-2. Validate the Secret and key.
-3. Generate a cryptographically secure random DEK.
-4. Wrap the DEK using the configured key provider.
-5. Compress backup data using the existing Longhorn behavior.
-6. Encrypt the compressed stream using the DEK.
-7. Add the Longhorn encryption envelope.
-8. Upload the encrypted object using the existing S3 implementation.
-9. Clear temporary plaintext key material as soon as practical.
-10. Record non-sensitive encryption information such as encryption version and key ID.
-
-### Restore
-
-For each object:
-
-1. Download the object using the existing S3 client.
-2. Inspect the object header.
-3. Detect whether the object is encrypted.
-4. Read the key provider and key ID.
-5. Obtain the required KEK/KMS configuration.
-6. Unwrap the DEK.
-7. Authenticate and decrypt the encrypted stream.
-8. Decompress the resulting backup data.
-9. Restore the data using the existing Longhorn restore path.
-
-A missing or incorrect key must result in a clear restore failure.
-
-### Backup synchronization
-
-BackupTarget synchronization must be able to discover encrypted backup volumes.
-
-If reading backup configuration requires the encryption key and the Secret is unavailable, Longhorn should report the BackupTarget as unavailable or degraded with an explicit reason such as:
+A possible representation is:
 
 ```text
-BackupEncryptionKeyUnavailable
+encrypted-object.tar
+|
++-- metadata.json
+|
++-- data.enc
 ```
 
-rather than reporting that the backup is corrupt or missing.
+Example `metadata.json`:
 
-### Delete
+```json
+{
+  "version": 1,
+  "algorithm": "AES-256-GCM-DARE",
+  "keyProvider": "secret",
+  "keyID": "backup-key-2026-01",
+  "wrappedDEK": "...",
+  "keyWrapAlgorithm": "...",
+  "keyWrapMetadata": {}
+}
+```
 
-Deletion is based primarily on S3 object keys and does not require plaintext object contents where possible.
+`data.enc` contains the encrypted data stream.
 
-Encrypted objects should be deleted using the existing S3 deletion implementation.
+The metadata may include:
+
+* encryption-format version;
+* algorithm;
+* key-provider identifier;
+* key ID;
+* wrapped DEK;
+* key-wrapping algorithm;
+* non-sensitive information required to unwrap the DEK.
+
+The metadata must not contain:
+
+* plaintext KEK;
+* plaintext DEK;
+* Kubernetes Secret contents.
+
+The exact archive format should be finalized only after validating its interaction with:
+
+* streaming;
+* multipart uploads;
+* retries;
+* backupstore Read/Write APIs;
+* incremental backup data paths.
 
 ---
 
-## Failure Handling
+# Encryption Metadata Authentication
 
-Longhorn must fail closed for encryption errors.
+Encryption metadata affects how ciphertext is decrypted.
 
-Examples include:
+Therefore, metadata that affects cryptographic processing must not be silently modifiable.
 
-### Missing Secret
+The implementation must ensure that security-sensitive metadata is either:
 
-```text
-backup encryption is enabled but Secret
-"longhorn-backup-encryption" does not exist
-```
+* cryptographically authenticated together with the encrypted content; or
+* included as authenticated associated data where supported.
 
-### Invalid key length
+For example, changing:
 
 ```text
-backup encryption key must contain exactly 32 bytes
+algorithm
+key ID
+wrapped DEK
+format information
 ```
 
-### Wrong key
+must not allow encrypted data to be accepted incorrectly.
+
+---
+
+# S3 Integration
+
+Longhorn should continue using the existing S3 backupstore implementation.
+
+The encryption layer should sit above the S3 transport.
+
+Conceptually:
+
+```text
+Longhorn backup logic
+        |
+        v
+Client-side encryption
+        |
+        v
+Existing S3 backupstore
+        |
+        v
+AWS S3 / MinIO / S3-compatible storage
+```
+
+There should not be another S3 SDK introduced specifically for encryption.
+
+The existing S3 implementation remains responsible for:
+
+* credentials;
+* endpoint configuration;
+* path-style access;
+* retries;
+* multipart uploads;
+* provider compatibility;
+* object operations.
+
+The encryption layer only transforms plaintext into ciphertext and back.
+
+---
+
+# S3-Compatible Providers
+
+Client-side encryption is intentionally implemented independently from the provider.
+
+Conceptually:
+
+```text
+                 Client-side encryption
+                           |
+                           v
+                  Existing S3 client
+                           |
+          +----------------+----------------+
+          |                |                |
+          v                v                v
+       AWS S3           MinIO          GCS S3
+                                      compatible
+                                       endpoint
+```
+
+The remote storage service sees ordinary object data, but that object data is encrypted before upload.
+
+Therefore, the provider does not need to understand Longhorn's encryption format.
+
+Provider-specific S3 compatibility concerns such as multipart behavior and checksums remain the responsibility of the existing S3 backupstore.
+
+AWS S3 and MinIO should be included in the primary E2E test matrix.
+
+Existing supported S3-compatible providers should be regression-tested where practical.
+
+---
+
+# Backup Metadata
+
+The effective encryption information used when creating the backup must be recorded with the remote backup metadata.
+
+For example:
+
+```json
+{
+  "encryption": {
+    "enabled": true,
+    "formatVersion": "1",
+    "algorithm": "AES-256-GCM-DARE",
+    "keyProvider": "secret",
+    "keyID": "backup-key-2026-01"
+  }
+}
+```
+
+The effective policy is persisted because the current configuration can later change.
+
+For example:
+
+```text
+Backup 1:
+    key-A
+
+Configuration changed
+
+Backup 2:
+    key-B
+```
+
+Backup 1 must continue to identify that it requires key-A.
+
+Backup 2 identifies key-B.
+
+Restore must not infer this information from the current Volume or BackupTarget configuration.
+
+---
+
+# Backup Creation Behavior
+
+Before starting a backup:
+
+1. Determine the BackupTarget.
+2. Read the global backup-encryption policy.
+3. Read the BackupTarget policy.
+4. Read the Volume policy.
+5. Resolve:
+
+```text
+Volume > BackupTarget > Global
+```
+
+6. Validate the effective configuration.
+7. If encryption is enabled, verify the target uses the S3 backupstore.
+8. Load the required key configuration.
+9. Perform the backup.
+
+---
+
+## Encryption Disabled
+
+The current backup behavior is unchanged:
+
+```text
+Backup data
+    |
+    v
+Compression
+    |
+    v
+S3 upload
+```
+
+---
+
+## Encryption Enabled
+
+The backup flow becomes:
+
+```text
+Backup data
+    |
+    v
+Compression
+    |
+    v
+Client-side encryption
+    |
+    v
+S3 upload
+```
+
+Longhorn records the encryption metadata with the backup.
+
+---
+
+# Restore Behavior
+
+Restore uses the encryption metadata belonging to the backup.
+
+It does not use the current effective backup-encryption policy to determine whether the backup is encrypted.
+
+Conceptually:
+
+```text
+Backup metadata
+      |
+      v
+Encrypted?
+   /     \
+ no       yes
+ |         |
+ v         v
+Normal    Resolve key
+restore       |
+              v
+          Decrypt
+              |
+              v
+           Restore
+```
+
+For an encrypted backup:
+
+1. Read the encryption metadata.
+2. Determine the encryption format and key ID.
+3. Locate the required key-provider configuration.
+4. Load the required key.
+5. Unwrap the DEK.
+6. Authenticate and decrypt the encrypted data.
+7. Decompress the result.
+8. Restore the volume.
+
+If the required key is unavailable:
+
+```text
+required backup encryption key "backup-key-2026-01" is unavailable
+```
+
+If authentication fails:
+
+```text
+failed to decrypt backup data: authentication failed
+```
+
+Longhorn must not attempt to interpret authentication-failed ciphertext as plaintext.
+
+---
+
+# Backup Synchronization
+
+A single BackupTarget may contain backups created using different policies over time.
+
+For example:
+
+```text
+Backup 1:
+    unencrypted
+
+Backup 2:
+    encrypted with key-A
+
+Backup 3:
+    encrypted with key-B
+```
+
+During synchronization, Longhorn must use each backup's remote metadata to determine its encryption requirements.
+
+The current BackupTarget encryption configuration does not describe historical backups.
+
+---
+
+# Incremental Backup and Encryption Context
+
+This is an important design consideration.
+
+Longhorn incremental backups reuse unchanged blocks where possible.
+
+Different client-side encryption keys create different encryption contexts.
+
+For example:
+
+```text
+Backup A:
+    keyID = key-A
+
+Backup B:
+    keyID = key-B
+```
+
+A block encrypted under key-A must not be assumed to be reusable by a backup that only has access to key-B.
+
+Therefore, Longhorn must ensure backup-block reuse only occurs when the encryption contexts are compatible.
+
+One possible design is to isolate blocks by encryption context.
+
+Conceptually:
+
+```text
+backup blocks
+    |
+    +-- encryption-context-key-A/
+    |       |
+    |       +-- block-1
+    |       +-- block-2
+    |
+    +-- encryption-context-key-B/
+            |
+            +-- block-1
+            +-- block-3
+```
+
+The exact object-path or identity mechanism should be determined during the POC.
+
+The required behavior is:
+
+> A backup object encrypted with one client-side encryption context must not be reused by another backup unless that backup can correctly decrypt the same encryption context.
+
+Backups using the same encryption context can continue to benefit from block reuse.
+
+---
+
+# Encryption Key Changes
+
+Changing the configured key does not modify existing backups.
+
+Example:
+
+```text
+Backup 1:
+    key-A
+
+Backup 2:
+    key-A
+
+Change configuration to key-B
+
+Backup 3:
+    key-B
+```
+
+Backup 1 and Backup 2 still require key-A.
+
+Backup 3 requires key-B.
+
+Users must retain key-A as long as backups depending on key-A remain in the backup store.
+
+Automatic re-encryption of existing backups is outside the scope of this enhancement.
+
+Changing the actual key material while keeping the same key ID is unsupported and should be documented as unsafe.
+
+A new encryption key should use a new key ID.
+
+---
+
+# Key Loss
+
+If a client-side encryption key is lost, backups encrypted using that key cannot be recovered.
+
+Longhorn cannot generate a replacement key for those existing backups.
+
+The UI and documentation must clearly warn users:
+
+> Losing the backup encryption key permanently prevents Longhorn from restoring backups encrypted with that key. Keep backup encryption keys securely as part of the disaster-recovery procedure.
+
+---
+
+# Secret Handling
+
+Encryption Secret data must never be:
+
+* logged;
+* written to Backup CR status;
+* written to Volume status;
+* written to BackupTarget status;
+* stored as plaintext in remote backup metadata;
+* emitted in Kubernetes Events;
+* exposed by UI APIs;
+* included as plaintext in support bundles.
+
+Errors may identify:
+
+* Secret name;
+* key ID;
+* key provider.
+
+They must not include the key contents.
+
+For example:
+
+```text
+failed to load backup encryption key "backup-key-2026-01"
+from Secret "longhorn-backup-encryption"
+```
+
+---
+
+# Failure Handling
+
+Encryption must fail closed.
+
+If encryption is enabled and Longhorn cannot satisfy the encryption requirement, the backup must fail.
+
+Longhorn must never silently fall back to plaintext backup.
+
+---
+
+## Missing Secret
+
+Example:
+
+```text
+client-side backup encryption is enabled but
+Secret "longhorn-backup-encryption" was not found
+```
+
+The backup does not start.
+
+---
+
+## Invalid Key
+
+Example:
+
+```text
+invalid client-side backup encryption key
+```
+
+The backup does not start.
+
+---
+
+## Non-S3 BackupTarget
+
+Example:
+
+```text
+client-side backup encryption is currently supported only for S3 backup targets
+```
+
+---
+
+## Incorrect Restore Key
+
+Example:
 
 ```text
 failed to decrypt backup object:
-authentication failed for encryption key "backup-key-2026-01"
+authentication failed
 ```
 
-### Corrupt object
+No plaintext fallback occurs.
+
+---
+
+## Corrupted Ciphertext
+
+Example:
 
 ```text
 failed to decrypt backup object:
 ciphertext authentication failed
 ```
 
-### Unsupported encryption format
+---
+
+## Unsupported Format
+
+Example:
 
 ```text
-backup uses unsupported encryption format version 2
+unsupported Longhorn backup encryption format version
 ```
-
-### Unsupported backup target
-
-```text
-client-side backup encryption is supported only for S3 backup targets
-```
-
-Errors must never print:
-
-* key contents;
-* unwrapped DEKs;
-* Secret data;
-* KMS plaintext responses.
 
 ---
 
-## Backward Compatibility
+# Backward Compatibility
 
-### Existing unencrypted backups
+## Existing Global Configuration
 
-The feature is disabled by default.
-
-Existing S3 backup targets and existing plaintext backups continue to work without modification.
-
-Longhorn must continue to detect and restore legacy plaintext backup objects.
-
-### Upgrade
-
-Upgrading Longhorn does not automatically encrypt existing backups.
-
-For example:
+The new global setting defaults to:
 
 ```text
-Before upgrade:
-    backup-1 -> plaintext
-
-After upgrade and encryption enabled:
-    backup-1 -> remains plaintext
-    backup-2 -> encrypted
+disabled
 ```
 
-However, to avoid ambiguity and shared-block issues, enabling encryption for a BackupTarget containing existing backup data should initially require either:
-
-* an empty/new S3 prefix, or
-* explicit validation that the backup volume can safely use the selected policy.
-
-The safest initial behavior is to recommend or require a new backup-target prefix when transitioning an existing target from plaintext to encrypted backups.
-
-### Downgrade
-
-Longhorn versions that predate this feature cannot restore the new encrypted backup format.
-
-Documentation must clearly state this limitation.
-
-Downgrading Longhorn does not decrypt existing backup objects.
+Therefore, upgrading does not automatically enable encryption.
 
 ---
 
-## Security Considerations
+## Existing BackupTarget CRs
 
-### Threats addressed
+Existing BackupTarget CRs do not contain the new encryption field.
 
-The feature protects backup payloads against:
+They behave as:
 
-* unauthorized reading of objects from the S3 bucket;
-* a compromised S3 storage provider reading Longhorn backup data;
-* accidental exposure of backup objects;
-* modification of encrypted backup data, because authenticated encryption detects tampering.
-
-### Threats not addressed
-
-The feature does not hide:
-
-* bucket name;
-* object names;
-* Longhorn backup prefix layout;
-* object sizes;
-* modification timestamps;
-* backup access patterns.
-
-It also does not protect backup data if:
-
-* the Kubernetes encryption Secret is compromised;
-* the Longhorn process performing backup/restore is compromised;
-* an attacker has access to both encrypted backup data and the encryption key.
-
-### Key handling
-
-Key material must:
-
-* only be loaded when needed;
-* never be logged;
-* never be included in errors;
-* never be persisted in CR status;
-* never be included in support bundles as plaintext;
-* be passed only to processes/components participating in backup or restore;
-* use Kubernetes RBAC to restrict Secret access.
+```text
+state = inherit
+```
 
 ---
 
-## Implementation Overview
+## Existing Volume CRs
 
-### backupstore
-
-Add a client-side encryption package, for example:
+Existing Volume CRs also behave as:
 
 ```text
-backupstore/
-    encryption/
-        encryption.go
-        header.go
-        key_provider.go
-        secret_key_provider.go
-        reader.go
-        writer.go
+state = inherit
 ```
+
+---
+
+## Existing Backups
+
+Legacy backup metadata does not contain client-side encryption information.
+
+Such backups are treated as:
+
+```text
+encryption disabled
+```
+
+No existing backup data is automatically changed.
+
+---
+
+# Mixed Backup History
+
+After encryption is enabled, a backup target may contain:
+
+```text
+backup-1:
+    legacy plaintext
+
+backup-2:
+    encrypted / key-A
+
+backup-3:
+    encrypted / key-A
+
+backup-4:
+    encrypted / key-B
+```
+
+Longhorn must correctly synchronize and restore each supported format.
+
+---
+
+# Upgrade
+
+During an upgrade:
+
+* add the new Setting definitions;
+* add BackupTarget CRD fields;
+* add Volume CRD fields;
+* add Backup status fields;
+* update generated CRD YAML;
+* update deep-copy and generated client code;
+* preserve existing CR behavior through inheritance;
+* leave global encryption disabled;
+* do not rewrite existing backups.
+
+No backup data migration is required.
+
+---
+
+# Downgrade
+
+Longhorn versions released before this feature will not understand the new client-side encrypted backup format.
+
+Therefore, encrypted backups created by a newer Longhorn version may not be restorable after downgrade.
+
+Downgrading does not automatically decrypt encrypted backup objects.
+
+This limitation must be documented in release notes.
+
+---
+
+# Implementation Overview
+
+## longhorn-manager
 
 Responsibilities:
 
-* define the encrypted object format;
-* generate DEKs;
-* wrap/unwrap DEKs;
-* create streaming encryption readers;
-* create streaming decryption readers;
-* identify encrypted objects;
-* validate encryption headers;
-* validate authentication;
+* introduce global backup-encryption settings;
+* validate the global configuration;
+* handle BackupTarget encryption configuration;
+* handle Volume encryption configuration;
+* resolve effective encryption policy using:
+
+```text
+Volume > BackupTarget > Global
+```
+
+* load the required Secret securely;
+* validate S3 compatibility;
+* pass the effective configuration to the backup process;
+* expose non-sensitive encryption information;
+* synchronize encrypted backups;
 * return sanitized errors.
-
-Add `github.com/minio/sio` as the streaming authenticated-encryption dependency.
-
-### S3 driver
-
-Modify the S3 driver to optionally insert encryption/decryption around object I/O.
-
-Existing:
-
-```text
-Write -> PutObject
-Read  -> GetObject
-```
-
-New:
-
-```text
-Write -> Encrypt -> PutObject
-Read  -> GetObject -> Detect -> Decrypt
-```
-
-Similarly:
-
-```text
-Upload   -> Encrypt -> existing S3 upload
-Download -> existing S3 download -> Decrypt
-```
-
-The existing AWS SDK v2 client remains responsible for:
-
-* AWS authentication;
-* S3-compatible endpoints;
-* path-style addressing;
-* custom CAs;
-* retries;
-* multipart upload;
-* provider-specific compatibility workarounds.
-
-### longhorn-manager
-
-Longhorn Manager responsibilities include:
-
-* validating BackupTarget encryption configuration;
-* reading the encryption Secret;
-* ensuring the S3 target uses a supported configuration;
-* securely passing encryption information into the backup operation;
-* exposing non-sensitive encryption status;
-* rejecting unsafe key changes.
-
-### longhorn-engine / backup process
-
-Extend the existing backup credential/configuration plumbing so the process performing the backup can obtain the encryption configuration.
-
-No persistent plaintext key should be written to disk as part of the configuration transfer.
-
-### Longhorn UI
-
-Add BackupTarget encryption configuration:
-
-```text
-Client-Side Backup Encryption
-    [ ] Enable
-
-Encryption Secret
-    [ longhorn-backup-encryption ]
-```
-
-When enabled, show a warning:
-
-```text
-The encryption key is required to restore these backups.
-Longhorn cannot recover the data if the key is lost.
-```
-
-Backup detail pages can show:
-
-```text
-Encryption: Client-side
-Algorithm:  AES-256-GCM
-Key ID:     backup-key-2026-01
-```
-
-The key itself is never displayed.
-
-### Documentation
-
-Documentation must cover:
-
-* generating a secure 256-bit key;
-* creating the Kubernetes Secret;
-* enabling backup encryption;
-* creating encrypted backups;
-* restoring encrypted backups into another cluster;
-* disaster-recovery handling of the Secret;
-* key-loss consequences;
-* upgrade/downgrade behavior;
-* supported S3 providers;
-* current key-rotation limitations.
 
 ---
 
-## Test Plan
+## longhorn-engine / Backup Process
 
-### Unit Tests
+Responsibilities:
 
-#### Encryption/decryption
+* receive the resolved encryption configuration;
+* perform encryption/decryption;
+* generate DEKs;
+* wrap/unwrap DEKs;
+* generate/read encryption metadata;
+* preserve incremental backup semantics;
+* prevent incompatible encryption-context block reuse;
+* fail restore when the required key is unavailable.
+
+---
+
+## backupstore
+
+The S3 backupstore continues to handle S3 operations.
+
+Conceptually:
+
+```text
+Current:
+
+Backup data
+    |
+    v
+S3 backupstore
+
+
+New:
+
+Backup data
+    |
+    v
+Encryption layer
+    |
+    v
+S3 backupstore
+```
+
+For restore:
+
+```text
+S3 backupstore
+    |
+    v
+Decryption layer
+    |
+    v
+Backup data
+```
+
+The POC must validate the interaction with:
+
+* `Read`;
+* `Write`;
+* `Upload`;
+* `Download`;
+* reader seek requirements;
+* retries;
+* multipart uploads.
+
+---
+
+# UI Changes
+
+## Global Setting
+
+Add:
+
+```text
+Client-Side Backup Encryption
+
+Enabled:
+    Yes / No
+
+Key Provider:
+    Kubernetes Secret
+
+Encryption Secret:
+    <secret-name>
+```
+
+---
+
+## BackupTarget
+
+Add:
+
+```text
+Client-Side Backup Encryption
+
+State:
+    Inherit Global
+    Disabled
+    Enabled
+```
+
+When enabled:
+
+```text
+Key Provider:
+    Kubernetes Secret
+
+Encryption Secret:
+    <secret-name>
+```
+
+---
+
+## Volume
+
+Add:
+
+```text
+Client-Side Backup Encryption
+
+State:
+    Inherit
+    Disabled
+    Enabled
+```
+
+When enabled, the Volume can specify its own encryption key configuration.
+
+The UI should show both configured and effective policies.
+
+Example:
+
+```text
+Configured:
+    Inherit
+
+Effective:
+    Enabled
+
+Source:
+    BackupTarget/default
+
+Key ID:
+    production-key
+```
+
+The actual key must never be displayed.
+
+---
+
+# Test Plan
+
+## Unit Tests - Configuration Resolution
+
+Test:
+
+```text
+Volume:
+    inherit
+
+BackupTarget:
+    inherit
+
+Global:
+    disabled
+```
+
+Expected:
+
+```text
+disabled
+```
+
+Test:
+
+```text
+Volume:
+    inherit
+
+BackupTarget:
+    inherit
+
+Global:
+    enabled
+```
+
+Expected:
+
+```text
+enabled
+```
+
+Test:
+
+```text
+Volume:
+    inherit
+
+BackupTarget:
+    enabled
+
+Global:
+    disabled
+```
+
+Expected:
+
+```text
+enabled
+```
+
+Test:
+
+```text
+Volume:
+    disabled
+
+BackupTarget:
+    enabled
+
+Global:
+    enabled
+```
+
+Expected:
+
+```text
+disabled
+```
+
+Test:
+
+```text
+Volume:
+    enabled
+
+BackupTarget:
+    disabled
+
+Global:
+    disabled
+```
+
+Expected:
+
+```text
+enabled
+```
 
 Verify:
 
-1. plaintext encrypts successfully;
-2. ciphertext decrypts to the original plaintext;
-3. ciphertext does not contain the original plaintext;
-4. encrypting the same content multiple times results in different ciphertext because random key/nonce material is used;
-5. zero-length input is supported;
-6. small input is supported;
-7. large streaming input is supported.
+```text
+Volume > BackupTarget > Global
+```
 
-#### Authentication
+---
 
-Verify decryption fails when:
+# Unit Tests - CRDs
 
-* ciphertext bytes are modified;
-* ciphertext is truncated;
-* encrypted chunks are reordered;
-* header information is corrupted;
-* the wrong DEK is supplied;
-* the wrong KEK is supplied.
+Verify valid states:
 
-No unauthenticated plaintext should be returned.
-
-#### Encryption header
+```text
+inherit
+disabled
+enabled
+```
 
 Verify:
 
-* correct magic is recognized;
-* version 1 is parsed;
-* unsupported versions are rejected;
-* invalid field lengths are rejected;
-* unknown algorithm identifiers are rejected;
-* plaintext legacy objects are not incorrectly recognized as encrypted objects.
+* omitted Volume field behaves as inherit;
+* omitted BackupTarget field behaves as inherit;
+* Global defaults to disabled;
+* enabled state requires key configuration;
+* unsupported key providers are rejected;
+* non-S3 effective configuration is rejected before backup;
+* CRD serialization/deserialization preserves the new fields.
 
-#### Key handling
+---
+
+# Unit Tests - Encryption
 
 Verify:
 
-* 32-byte key succeeds;
-* shorter keys fail;
-* longer keys fail;
-* missing Secret data fails;
-* missing key ID behavior follows the API contract;
-* wrong Secret fails during restore;
-* sensitive values do not appear in returned errors.
+* plaintext can be encrypted;
+* ciphertext decrypts to the original plaintext;
+* ciphertext does not contain the original plaintext;
+* encrypting the same plaintext multiple times uses appropriate randomness;
+* zero-length input is handled;
+* small input is handled;
+* large streaming input is handled;
+* modified ciphertext fails authentication;
+* truncated ciphertext fails;
+* reordered encrypted data fails where applicable;
+* incorrect DEK fails;
+* incorrect KEK fails;
+* invalid wrapped DEK fails;
+* unsupported format version fails;
+* unsupported algorithm fails.
 
-#### S3 write/read
+---
+
+# Unit Tests - Key Handling
+
+Verify:
+
+* valid key succeeds;
+* malformed key fails;
+* missing Secret fails;
+* invalid Secret data fails;
+* missing key ID fails if required;
+* old key and new key are distinguishable;
+* key material never appears in errors;
+* key material never appears in logs.
+
+---
+
+# Unit Tests - S3 Integration
 
 With encryption disabled:
 
 ```text
-Write -> S3 object == original input
-Read  -> original input
+Write -> normal S3 object
+Read  -> original data
 ```
 
 With encryption enabled:
 
 ```text
-Write -> S3 object != original input
-Read  -> original input
+Write -> encrypted S3 object
+Read  -> original data after decryption
 ```
-
-#### Multipart upload
-
-Test encrypted objects large enough to trigger the current AWS SDK multipart uploader.
 
 Verify:
 
-* backup succeeds;
-* retry succeeds;
-* resulting object decrypts correctly;
-* encryption boundaries are independent from multipart boundaries.
-
-#### Existing single-part fallback
-
-Test S3 provider paths that use `PutObjectAsSinglePart` or the existing single-part compatibility fallback.
-
-Encryption must work with both multipart and single-part paths.
-
-#### Legacy compatibility
-
-Store an existing unencrypted backup object.
-
-Enable the new encryption-capable Longhorn code.
-
-Verify the plaintext object remains readable.
+* normal upload;
+* multipart upload;
+* retries;
+* read;
+* deletion;
+* backup metadata operations;
+* existing provider-specific fallback paths.
 
 ---
 
-## Automated E2E Tests
+# Automated E2E Tests
 
-Add or update automated test coverage associated with #12297.
+## Test 1 - Existing Behavior
 
+1. Install Longhorn.
+2. Leave global backup encryption disabled.
+3. Create a Volume.
+4. Write known data.
+5. Create backup.
+6. Restore.
+7. Verify checksum.
 
-## Manual Test Plan
+Expected:
 
-### Security inspection
+Existing behavior is unchanged.
 
-After creating an encrypted backup:
+---
 
-1. Download objects directly from S3 without using Longhorn.
-2. Search for known filesystem/application contents.
-3. Verify plaintext content cannot be found.
-4. Verify backup configuration payloads protected by the encryption layer are not readable.
-5. Confirm object keys and sizes remain visible as documented.
+## Test 2 - Global Encryption
 
-### Log inspection
+1. Enable global backup encryption.
+2. Configure encryption Secret.
+3. Leave BackupTarget as inherit.
+4. Leave Volume as inherit.
+5. Create backup.
+6. Inspect remote data.
+7. Restore.
+8. Verify checksum.
 
-Run backup and restore at normal and debug log levels.
+Expected:
 
-Verify that none of the following appear:
+The remote backup payload is encrypted.
 
-* KEK;
-* DEK;
-* Secret `data.key`;
-* plaintext backup data.
+---
 
-Generate a Longhorn support bundle and perform the same check.
+## Test 3 - BackupTarget Override
 
-### Performance test
+Configure:
+
+```text
+Global:
+    disabled
+
+BackupTarget:
+    enabled
+
+Volume:
+    inherit
+```
+
+Verify the backup is encrypted.
+
+---
+
+## Test 4 - Volume Override
+
+Configure:
+
+```text
+Global:
+    disabled
+
+BackupTarget:
+    disabled
+
+Volume:
+    enabled
+```
+
+Verify the backup is encrypted.
+
+---
+
+## Test 5 - Volume Opt-Out
+
+Configure:
+
+```text
+Global:
+    enabled
+
+BackupTarget:
+    inherit
+
+Volume:
+    disabled
+```
+
+Verify the backup remains unencrypted.
+
+---
+
+## Test 6 - Incremental Backup
+
+1. Create initial data.
+2. Create backup A.
+3. Modify a small amount of data.
+4. Create backup B.
+5. Verify unchanged blocks are reused when the encryption context matches.
+6. Restore backup A.
+7. Verify data.
+8. Restore backup B.
+9. Verify data.
+
+---
+
+## Test 7 - Different Encryption Keys
+
+1. Create backup A using key-A.
+2. Change the effective configuration to key-B.
+3. Create backup B.
+4. Verify backup A remains associated with key-A.
+5. Verify backup B is associated with key-B.
+6. Verify blocks are not incorrectly reused across incompatible encryption contexts.
+7. Restore both backups using the corresponding keys.
+
+---
+
+## Test 8 - Missing Key
+
+1. Create encrypted backup.
+2. Remove the encryption Secret.
+3. Attempt restore.
+
+Expected:
+
+Restore fails with a clear missing-key error.
+
+---
+
+## Test 9 - Incorrect Key
+
+1. Create encrypted backup with key-A.
+2. Replace configuration with key-B.
+3. Attempt restore without key-A.
+
+Expected:
+
+Authentication/decryption fails.
+
+No plaintext fallback occurs.
+
+---
+
+## Test 10 - Corrupted Ciphertext
+
+1. Create encrypted backup.
+2. Modify encrypted object data directly in S3.
+3. Attempt restore.
+
+Expected:
+
+Authenticated decryption detects corruption and restore fails.
+
+---
+
+## Test 11 - Disaster Recovery
+
+1. Create encrypted backups in cluster A.
+2. Remove cluster A.
+3. Install Longhorn in cluster B.
+4. Configure the same S3 BackupTarget.
+5. Restore the required encryption Secret.
+6. Synchronize backups.
+7. Restore the Volume.
+8. Verify checksum.
+
+---
+
+## Test 12 - AWS S3
+
+Verify:
+
+* encrypted backup;
+* encrypted restore;
+* multipart upload;
+* incremental backup;
+* backup synchronization;
+* backup deletion.
+
+---
+
+## Test 13 - MinIO
+
+Repeat the applicable E2E tests using MinIO.
+
+Verify:
+
+* encrypted backup;
+* encrypted restore;
+* multipart behavior;
+* incremental backup;
+* synchronization;
+* deletion.
+
+---
+
+## Test 14 - Other Existing S3-Compatible Providers
+
+Regression-test currently supported S3-compatible providers where practical.
+
+Client-side encryption should not introduce provider-specific encryption requirements because the provider only stores ciphertext.
+
+---
+
+## Test 15 - Upgrade
+
+1. Install an older Longhorn release.
+2. Create an unencrypted backup.
+3. Upgrade Longhorn.
+4. Verify the old backup remains visible.
+5. Restore it.
+6. Enable client-side encryption.
+7. Create a new encrypted backup.
+8. Restore it.
+
+---
+
+## Test 16 - Mixed Backup History
+
+Create:
+
+```text
+backup-1:
+    unencrypted
+
+backup-2:
+    encrypted / key-A
+
+backup-3:
+    encrypted / key-B
+```
+
+Verify:
+
+* all backups are synchronized;
+* each backup reports the correct encryption status;
+* each backup can be restored with its required configuration.
+
+---
+
+# Manual Security Test
+
+Write a known plaintext pattern into a Volume.
+
+Create a client-side encrypted backup.
+
+Download the remote S3 backup data without using Longhorn.
+
+Verify the known plaintext cannot be found.
+
+Inspect:
+
+* longhorn-manager logs;
+* engine logs;
+* Kubernetes Events;
+* Volume CR;
+* BackupTarget CR;
+* Backup CR;
+* support bundle.
+
+Verify encryption keys are not exposed.
+
+---
+
+# Performance Test
 
 Compare:
 
 ```text
-unencrypted backup
+Unencrypted backup
 vs.
-encrypted backup
+Client-side encrypted backup
 ```
 
-and:
+And:
 
 ```text
-unencrypted restore
+Unencrypted restore
 vs.
-encrypted restore
+Client-side encrypted restore
 ```
 
 Measure:
@@ -1237,261 +2368,389 @@ Measure:
 * throughput;
 * CPU usage;
 * memory usage;
-* total object size;
 * backup duration;
-* restore duration.
+* restore duration;
+* remote object size.
 
-The encryption implementation should remain streaming and must not buffer an entire backup object in memory.
-
-### Failure/retry testing
-
-Introduce network interruptions during encrypted S3 upload/download.
-
-Verify:
-
-* retry does not produce invalid ciphertext;
-* failed partial uploads are cleaned up according to current backup behavior;
-* retrying the backup produces a valid encrypted object.
+The implementation should remain streaming and must not require memory proportional to the size of the entire backup object.
 
 ---
 
-## Performance Considerations
+# Security Considerations
 
-Client-side encryption introduces additional CPU usage during backup and restore.
+Client-side encryption changes the trust boundary.
 
-Unlike in-cluster volume encryption, however, this cost exists only while backup or restore I/O is being processed.
-
-The expected pipeline is:
+Without client-side encryption:
 
 ```text
-compression -> encryption -> network
+Longhorn
+   |
+   v
+S3 provider receives backup payload
 ```
 
-so encryption does not prevent Longhorn from compressing the backup first.
-
-The encryption library must operate in a streaming manner to avoid memory usage proportional to backup size.
-
-Benchmarks should be collected before release to determine the performance impact on:
-
-* small backups;
-* large backups;
-* highly compressible data;
-* incompressible data;
-* CPUs with AES hardware acceleration;
-* CPUs without AES hardware acceleration.
-
----
-
-## Risks and Mitigations
-
-### Key loss
-
-**Risk:** The user loses the encryption Secret.
-
-**Impact:** Backups cannot be restored.
-
-**Mitigation:** Strong UI/documentation warnings and disaster-recovery documentation.
-
-### Incorrect key changes
-
-**Risk:** A target contains blocks encrypted under multiple unexpected keys.
-
-**Impact:** Some incremental backups may become unrestorable.
-
-**Mitigation:** Disallow changing the effective key while encrypted backups exist in the target/prefix.
-
-### S3 interoperability
-
-**Risk:** Encryption integration changes stream behavior and exposes differences among S3-compatible providers.
-
-**Mitigation:** Keep the existing AWS SDK v2 transport and make AWS S3 and MinIO E2E testing release-blocking.
-
-### Ciphertext corruption
-
-**Risk:** Remote objects are damaged or modified.
-
-**Impact:** Restore failure.
-
-**Mitigation:** Authenticated encryption detects corruption and Longhorn fails closed.
-
-### Downgrade
-
-**Risk:** User downgrades to a Longhorn release without backup encryption support.
-
-**Impact:** Older Longhorn cannot restore encrypted backups.
-
-**Mitigation:** Document the compatibility boundary and do not modify encrypted backups during downgrade.
-
-### Encryption metadata compatibility
-
-**Risk:** Future implementation changes make existing encrypted backups unreadable.
-
-**Mitigation:** Use a versioned Longhorn encryption envelope and treat the encrypted-object format as a persistent compatibility contract.
-
----
-
-## Rollout Plan
-
-### Phase 1: Encryption format and POC
-
-Implement a prototype in `backupstore` using `minio/sio`.
-
-Validate:
-
-* stream encryption/decryption;
-* AWS SDK v2 multipart upload;
-* existing single-part path;
-* AWS S3;
-* MinIO;
-* existing S3-compatible custom endpoint behavior.
-
-The POC should be completed before finalizing the on-disk/on-S3 encryption format.
-
-### Phase 2: API and key management
-
-Implement:
-
-* BackupTarget fields;
-* Secret validation;
-* encryption configuration plumbing;
-* key-provider abstraction;
-* Backup/BackupTarget status.
-
-### Phase 3: Backupstore integration
-
-Implement:
-
-* encrypted Write;
-* decrypted Read;
-* encrypted Upload;
-* decrypted Download;
-* legacy plaintext detection;
-* integrity error handling.
-
-### Phase 4: Manager/UI/documentation
-
-Add:
-
-* validation;
-* status;
-* UI controls;
-* key-loss warnings;
-* disaster-recovery documentation.
-
-### Phase 5: E2E and interoperability
-
-Complete #12297 and validate:
-
-* AWS S3;
-* MinIO;
-* V1/V2 backup paths;
-* incremental backup;
-* upgrade;
-* restore;
-* corruption handling.
-
----
-
-## Future Enhancements
-
-### External KMS
-
-Implement additional `DataKeyProvider` implementations such as:
+With client-side encryption:
 
 ```text
-AWS KMS
-Vault
-other enterprise KMS providers
+Longhorn
+   |
+   v
+Encrypt locally
+   |
+   v
+S3 provider receives ciphertext
 ```
 
-The backup format already contains:
+This protects backup payload confidentiality from the remote object-storage provider.
 
-```text
-key provider
-key ID
-wrapped DEK
-```
+Authenticated encryption also protects integrity by detecting modified ciphertext.
 
-so these providers can be added without redesigning content encryption.
+The feature does not hide:
 
-### Key rotation
+* bucket names;
+* object names;
+* object sizes;
+* timestamps;
+* access patterns.
 
-Add a controlled process to rotate the KEK.
+The feature also cannot protect data if both the encryption key and encrypted backup data are compromised.
 
-Because each object uses a DEK, a future implementation may be able to re-wrap DEKs where the storage format permits it rather than decrypting and re-encrypting the complete backup payload.
+---
 
-### Per-volume policy
+# Risks and Mitigations
 
-Allow individual Longhorn volumes to override the BackupTarget encryption default.
+## Key Loss
 
-For example:
+### Risk
 
-```yaml
-spec:
-  backupEncryption: inherit
-```
+The user loses the encryption key.
 
-with possible values:
+### Impact
+
+Encrypted backups cannot be restored.
+
+### Mitigation
+
+Provide clear UI and documentation warnings.
+
+Document key backup as part of disaster-recovery procedures.
+
+---
+
+## Different Keys and Incremental Backups
+
+### Risk
+
+A block encrypted under one encryption context is incorrectly reused by another backup.
+
+### Impact
+
+The backup may not be restorable.
+
+### Mitigation
+
+Make encryption context part of the block-reuse decision or backup-block namespace.
+
+Validate the final design during the POC.
+
+---
+
+## Configuration Complexity
+
+### Risk
+
+Users may not know which configuration is effective because the feature has three configuration levels.
+
+### Mitigation
+
+Use explicit:
 
 ```text
 inherit
-enabled
 disabled
+enabled
 ```
 
-This requires additional design around shared backup blocks and key consistency and is intentionally deferred from the first implementation.
+states.
 
-### Server-side encryption
+Show configured value, effective value, and policy source in the UI.
 
-SSE-C or other S3 server-side encryption can be implemented independently for users who prefer provider-managed encryption.
-
-It should be considered an additional protection option rather than a replacement for client-side encryption.
+Use complete-policy inheritance rather than field-level inheritance.
 
 ---
 
-## Decision
+## Secret Replacement
 
-The proposed first implementation is:
+### Risk
+
+The encryption Secret is overwritten with another key while old backups still depend on the original key.
+
+### Impact
+
+Old backups may become unrestorable.
+
+### Mitigation
+
+Use a key ID.
+
+Require a new key ID for a new key.
+
+Document that users must retain old keys until dependent backups are removed.
+
+---
+
+## Persistent Format Compatibility
+
+### Risk
+
+Future changes to encryption implementation make existing encrypted backups unreadable.
+
+### Mitigation
+
+Use a versioned encryption format.
+
+Treat the encrypted backup format as a persistent compatibility contract.
+
+---
+
+# Documentation
+
+Documentation must cover:
+
+* purpose of client-side backup encryption;
+* difference from Longhorn volume encryption;
+* configuration hierarchy;
+* Global configuration;
+* BackupTarget configuration;
+* Volume configuration;
+* `Volume > BackupTarget > Global` precedence;
+* `inherit`, `disabled`, and `enabled`;
+* creating the encryption Secret;
+* key requirements;
+* key ID requirements;
+* disaster recovery;
+* restoring into another cluster;
+* key-loss consequences;
+* key-change behavior;
+* incremental backup considerations;
+* S3-compatible provider support;
+* upgrade behavior;
+* downgrade limitation.
+
+The documentation must clearly state:
+
+> Server-side encryption is outside the scope of this enhancement.
+
+---
+
+# Rollout Plan
+
+## Phase 1 - POC
+
+Validate:
+
+* streaming encryption/decryption;
+* selected encryption library;
+* encrypted-object format;
+* JSON metadata/container approach;
+* metadata authentication;
+* multipart upload;
+* retry behavior;
+* backupstore `Read` and `Write`;
+* incremental backup block reuse;
+* multiple encryption contexts;
+* AWS S3;
+* MinIO.
+
+The POC should resolve the backup-block encryption-context design before the persistent format is finalized.
+
+---
+
+## Phase 2 - API and CRDs
+
+Implement:
+
+* common backup-encryption API types;
+* Volume CRD changes;
+* BackupTarget CRD changes;
+* Backup status changes;
+* global settings;
+* admission validation;
+* generated clients;
+* deep-copy changes;
+* CRD YAML changes.
+
+---
+
+## Phase 3 - Key Management
+
+Implement:
+
+* key-provider abstraction;
+* Kubernetes Secret key provider;
+* key validation;
+* DEK generation;
+* DEK wrapping and unwrapping;
+* key ID handling;
+* secure Secret handling.
+
+---
+
+## Phase 4 - Encryption Integration
+
+Implement:
+
+* streaming encryption;
+* streaming authenticated decryption;
+* encryption metadata;
+* backupstore integration;
+* backup synchronization;
+* restore behavior;
+* incremental backup encryption-context isolation.
+
+---
+
+## Phase 5 - Manager and UI
+
+Implement:
+
+* effective-policy resolution;
+* Global configuration;
+* BackupTarget configuration;
+* Volume configuration;
+* effective-policy display;
+* error handling;
+* key-loss warnings.
+
+---
+
+## Phase 6 - Tests and Documentation
+
+Complete:
+
+* unit tests;
+* E2E tests;
+* AWS S3 validation;
+* MinIO validation;
+* upgrade tests;
+* disaster-recovery tests;
+* performance tests;
+* documentation;
+* release notes.
+
+---
+
+# Final Design Decision
 
 ```text
-Scope:
-    S3 / S3-compatible backup targets only
+Feature:
+    Client-side backup encryption
+
+Backup store scope:
+    S3 and S3-compatible targets only
+
+Server-side encryption:
+    Out of scope
+
+Configuration levels:
+    Global
+    BackupTarget
+    Volume
+
+Precedence:
+    Volume > BackupTarget > Global
+
+Configuration states:
+    inherit
+    disabled
+    enabled
+
+Global supported states:
+    disabled
+    enabled
+
+Global default:
+    disabled
+
+BackupTarget default:
+    inherit
+
+Volume default:
+    inherit
+
+Inheritance:
+    Complete encryption policy
+    Not field-by-field
 
 Encryption location:
-    Longhorn client side, before S3 upload
+    Longhorn client side
+    Before S3 upload
+    After compression
 
-S3 library:
-    Existing aws-sdk-go-v2 implementation
+Encryption requirement:
+    Authenticated encryption
 
-Streaming encryption:
-    github.com/minio/sio
+Streaming encryption candidate:
+    minio/sio / DARE
 
-Content encryption:
-    AES-256-GCM authenticated encryption
+Initial key provider:
+    Kubernetes Secret
 
-Configuration:
-    BackupTarget level
+Future key providers:
+    External KMS providers
+    Separate follow-up enhancement
 
-Initial key source:
-    Kubernetes Secret containing a 256-bit key
+Key design:
+    User KEK
+       |
+       v
+    wrapped per-object DEK
+       |
+       v
+    encrypted backup payload
 
-Key model:
-    Per-object random DEK protected by the configured KEK
+Plaintext KEK in backup:
+    Never
 
-External KMS:
-    Extensible interface, implementation deferred
+Plaintext DEK in backup:
+    Never
+
+Backup metadata:
+    Versioned encryption information
+    Key ID
+    Wrapped DEK where required
+
+S3 transport:
+    Existing Longhorn S3 implementation
 
 Existing backups:
-    Remain supported and are not automatically migrated
+    Supported unchanged
 
-Key rotation:
-    Not supported for existing backups in the initial release
+Existing Volume CR:
+    inherit
 
-Required interoperability:
-    AWS S3 and MinIO
+Existing BackupTarget CR:
+    inherit
 
-Default:
-    Disabled
+Effective encryption:
+    Resolved when backup is created
+
+Restore:
+    Uses the encryption metadata of the backup
+    rather than the current policy
+
+Incremental backups:
+    Reuse blocks only across compatible
+    encryption contexts
+
+Key changes:
+    Do not modify existing backups
+
+Failure behavior:
+    Fail closed
+    Never silently create plaintext backup
+
+Primary interoperability tests:
+    AWS S3
+    MinIO
 ```
-
-This design keeps S3-provider compatibility separate from encryption, avoids requiring trust in the remote object-storage service, preserves Longhorn's existing S3 transport implementation and incremental-backup architecture, and provides a path for future KMS and key-rotation support.

--- a/enhancements/20260810-backup-store-s3-encryption.md
+++ b/enhancements/20260810-backup-store-s3-encryption.md
@@ -1188,6 +1188,7 @@ Verify the plaintext object remains readable.
 
 Add or update automated test coverage associated with #12297.
 
+
 ## Manual Test Plan
 
 ### Security inspection

--- a/enhancements/20260810-backup-store-s3-encryption.md
+++ b/enhancements/20260810-backup-store-s3-encryption.md
@@ -1,0 +1,1496 @@
+# Client-Side Encryption for S3 Volume Backups
+
+## Summary
+
+Longhorn currently supports volume encryption inside the Kubernetes cluster. When an encrypted volume is backed up, the backup data stored in the remote backup target is also protected because the source volume data is already encrypted.
+
+However, this couples backup-at-rest encryption to in-cluster volume encryption. Users who do not need or do not want the runtime overhead and operational complexity of encrypted Longhorn volumes cannot independently protect their remote backups with client-side encryption.
+
+This enhancement introduces **client-side encryption for Longhorn S3 backups**, independent of Longhorn in-cluster volume encryption.
+
+When enabled, Longhorn encrypts backup data locally before sending it to the S3 or S3-compatible backup target and decrypts it locally while restoring. The S3 provider only receives encrypted data and does not receive the encryption key.
+
+The feature is disabled by default to preserve the existing behavior.
+
+The initial implementation supports:
+
+* S3 and S3-compatible backup targets only.
+* Client-side authenticated encryption using AES-256.
+* Encryption keys stored in a Kubernetes Secret.
+* Transparent backup, restore, backup listing, synchronization, and deletion.
+* Existing unencrypted backups without migration.
+* AWS S3 and MinIO interoperability.
+* An extensible key-provider design so external KMS integration can be added later.
+
+### Related Issues
+
+* #5220 - Encrypt volume backup to remote backup store without in-cluster volume encryption
+* #8453 - Backup encryption
+* #12297 - Automated test coverage for backup encryption
+* #4883 - Block volume encryption
+
+---
+
+## Motivation
+
+Longhorn currently provides encryption at the volume level. This is useful when data must be encrypted on Longhorn storage nodes, but volume encryption and backup encryption serve different security requirements.
+
+For example, a user might trust the storage nodes running inside their Kubernetes cluster but use an external S3-compatible provider for disaster-recovery backups.
+
+In this case, enabling volume encryption solely to secure remote backups introduces unnecessary coupling.
+
+Other applications commonly encrypt their backup data locally before sending it to object storage. Longhorn should provide the same option so users do not have to depend on storage-provider-specific server-side encryption or an additional encryption proxy.
+
+Server-side encryption such as SSE-S3, SSE-KMS, or SSE-C does not completely address this use case because encryption is still implemented by the object-storage service. It may also differ between AWS S3 and other S3-compatible providers.
+
+The intended security boundary for this enhancement is:
+
+```text
+Longhorn
+   |
+   | plaintext
+   v
+Compression
+   |
+   | compressed plaintext
+   v
+Client-side encryption
+   |
+   | ciphertext only
+   v
+S3 client
+   |
+   | ciphertext
+   v
+Remote S3 / S3-compatible storage
+```
+
+The remote backup provider must never need access to the plaintext backup payload or the Longhorn backup encryption key.
+
+### Goals
+
+1. Allow users to encrypt remote S3 backups without enabling Longhorn volume encryption.
+
+2. Encrypt backup data before it leaves the Longhorn backup process.
+
+3. Decrypt backup data only after it is downloaded from the remote backup target.
+
+4. Use authenticated encryption so corruption or malicious modification of encrypted objects is detected.
+
+5. Support a user-managed AES-256 key stored in a Kubernetes Secret.
+
+6. Remain compatible with AWS S3 and S3-compatible storage such as MinIO.
+
+7. Preserve Longhorn's existing incremental backup and block deduplication behavior.
+
+8. Preserve compatibility with existing plaintext backups.
+
+9. Keep encryption disabled by default.
+
+10. Design the encryption metadata and key-provider abstraction so support for external KMS providers can be added without changing the encrypted data format unnecessarily.
+
+11. Ensure encryption keys and plaintext key material are never written to backup-store objects, logs, events, Backup CRs, or support bundles.
+
+### Non-goals
+
+The following are outside the scope of the initial implementation:
+
+* Client-side encryption for NFS, CIFS, Azure Blob, or other non-S3 backup targets.
+* Changing Longhorn in-cluster volume encryption.
+* SSE-S3, SSE-KMS, or SSE-C support as the implementation of this feature.
+* Encrypting S3 object names, object sizes, timestamps, or other storage-provider-visible metadata.
+* Automatic migration of existing plaintext backups to encrypted backups.
+* Automatic migration of encrypted backups back to plaintext.
+* In-place encryption-key rotation or re-encryption of existing backup data.
+* Generic external KMS support in the first implementation.
+* Recovering backups when the user has lost the encryption key.
+* Allowing older Longhorn versions that do not understand this encryption format to restore encrypted backups.
+
+---
+
+## Proposal
+
+### User Stories
+
+#### User Story 1: Protect backups stored by an external provider
+
+A user runs Longhorn on infrastructure they control and does not need encryption for the running Longhorn volume.
+
+The user sends Longhorn backups to a third-party S3-compatible object-storage service.
+
+The user wants Longhorn to encrypt the backup locally so the object-storage provider cannot access the original volume data.
+
+The user enables client-side backup encryption on the BackupTarget and provides a Kubernetes Secret containing the encryption key.
+
+Longhorn encrypts every new backup object before uploading it.
+
+#### User Story 2: Separate volume and backup encryption policies
+
+A user has different compliance requirements for production storage and disaster-recovery storage.
+
+The Longhorn volume may be:
+
+```text
+unencrypted volume -> encrypted backup
+```
+
+or:
+
+```text
+encrypted volume -> independently encrypted backup
+```
+
+Backup encryption does not depend on whether Longhorn volume encryption is enabled.
+
+#### User Story 3: Restore into another cluster
+
+A disaster occurs and the original Kubernetes cluster is unavailable.
+
+The administrator installs Longhorn in another cluster, configures the same S3 backup target, and creates the Kubernetes Secret containing the correct backup encryption key.
+
+Longhorn discovers the encrypted backups and restores them transparently.
+
+Without the correct encryption key, Longhorn reports that the backup is encrypted and cannot be restored.
+
+#### User Story 4: Use MinIO or another S3-compatible provider
+
+A user stores Longhorn backups in MinIO or another S3-compatible service.
+
+Because encryption happens before data reaches the S3 API, the storage service does not need to implement Longhorn-specific encryption or SSE-C.
+
+The existing S3 compatibility layer remains responsible only for storing and retrieving ciphertext objects.
+
+---
+
+## Analysis
+
+### Existing Longhorn S3 implementation
+
+Longhorn's `backupstore` already uses `aws-sdk-go-v2` for S3 operations. It also supports custom S3 endpoints using `AWS_ENDPOINTS` and configures path-style addressing when necessary for S3-compatible providers.
+
+Therefore, this enhancement does not require replacing the existing S3 client.
+
+The existing transport architecture should remain:
+
+```text
+Longhorn backupstore
+        |
+        +-- encryption/decryption layer
+        |
+        +-- existing aws-sdk-go-v2 S3 implementation
+        |
+        +-- AWS S3 / MinIO / S3-compatible provider
+```
+
+The current `BackupStoreDriver` exposes generic operations such as `Read`, `Write`, `Upload`, and `Download`, which makes it possible to place the encryption functionality between Longhorn's backup logic and the existing S3 implementation.
+
+Longhorn's S3 implementation also already contains special compatibility handling for multipart uploads, single-part uploads, custom endpoints, path-style access, checksum behavior, and provider-specific S3 differences. The encryption feature should preserve this code rather than introduce another S3 transport implementation.
+
+### Option 1: S3 server-side encryption
+
+Examples include:
+
+* SSE-S3
+* SSE-KMS
+* SSE-C
+
+This is relatively simple to implement but does not satisfy the primary requirement.
+
+With server-side encryption, Longhorn must trust the remote S3 implementation to correctly protect the data. It also introduces differences between S3 providers.
+
+SSE-C additionally sends the customer-provided key to the storage server as part of each applicable request.
+
+This option is therefore not selected as the solution for #5220.
+
+Server-side encryption can be considered separately in the future.
+
+### Option 2: `minio/sio`
+
+`github.com/minio/sio` implements the Data At Rest Encryption (DARE) format.
+
+The library provides streaming authenticated encryption and is explicitly intended for use cases including files, backups, and large object storage.
+
+It supports authenticated encryption algorithms including AES-256-GCM and supports long streams without requiring the complete object to be held in memory.
+
+Because the library operates on an `io.Reader`/`io.Writer` data stream rather than implementing the S3 protocol itself, the existing AWS SDK v2 S3 code remains unchanged.
+
+The resulting architecture is:
+
+```text
+                    Longhorn backup logic
+                             |
+                             | compressed data
+                             v
+                    +------------------+
+                    | Encryption layer |
+                    |    minio/sio     |
+                    +------------------+
+                             |
+                             | encrypted stream
+                             v
+                   Existing S3 backupstore
+                    aws-sdk-go-v2
+                             |
+                  +----------+----------+
+                  |                     |
+                  v                     v
+               AWS S3                MinIO
+                                      / other
+                                  S3-compatible
+```
+
+This is the proposed implementation approach.
+
+---
+
+## User Experience In Detail
+
+### Enabling backup encryption
+
+Encryption should be configured on the `BackupTarget`, because encryption is a property of the backup destination rather than of the running Longhorn volume.
+
+A proposed configuration is:
+
+```yaml
+apiVersion: longhorn.io/v1beta2
+kind: BackupTarget
+metadata:
+  name: default
+  namespace: longhorn-system
+spec:
+  backupTargetURL: s3://backup-bucket@region/
+  credentialSecret: longhorn-backup-credential
+  clientSideEncryption: true
+  encryptionSecret: longhorn-backup-encryption
+```
+
+The exact API field names can be adjusted during implementation.
+
+When `clientSideEncryption` is false or omitted, Longhorn behaves exactly as it does today.
+
+When `clientSideEncryption` is true:
+
+1. The backup target must use the `s3` driver.
+2. `encryptionSecret` must be specified.
+3. The encryption Secret must exist and contain a valid 256-bit key.
+4. Longhorn validates the configuration before allowing encrypted backup operations.
+
+### Encryption Secret
+
+Example:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: longhorn-backup-encryption
+  namespace: longhorn-system
+type: Opaque
+data:
+  key: <base64-encoded-32-byte-key>
+stringData:
+  keyID: backup-key-2026-01
+```
+
+`key` contains exactly 32 bytes after base64 decoding.
+
+`keyID` is a non-sensitive identifier used to identify which key was used for encryption. It can be stored with encrypted objects and exposed in Longhorn status information.
+
+The actual key must never be stored in:
+
+* BackupTarget status,
+* Backup status,
+* BackupVolume status,
+* backup metadata,
+* S3 object metadata in plaintext,
+* logs,
+* events,
+* support bundles.
+
+### BackupTarget-level configuration instead of per-volume configuration
+
+The first version should configure encryption at the BackupTarget level.
+
+This has several advantages:
+
+* all backups written to the destination follow a consistent policy;
+* key management is simpler;
+* incremental backup blocks do not unexpectedly cross different encryption policies;
+* disaster-recovery configuration is easier to understand;
+* the BackupTarget is already responsible for the remote destination and its credential Secret.
+
+A per-volume encryption override can be added in a later enhancement if there is sufficient demand.
+
+---
+
+## API Changes
+
+### BackupTarget
+
+Proposed additions to `BackupTargetSpec`:
+
+```go
+type BackupTargetSpec struct {
+    BackupTargetURL      string
+    CredentialSecret     string
+    PollInterval         metav1.Duration
+
+    // ClientSideEncryption enables encryption before data is uploaded
+    // to the backup target.
+    ClientSideEncryption bool
+
+    // EncryptionSecret references the Secret containing the
+    // backup encryption key.
+    EncryptionSecret string
+}
+```
+
+The actual Go structure must follow Longhorn API conventions.
+
+### BackupTarget status
+
+BackupTarget status should expose only non-sensitive information.
+
+For example:
+
+```yaml
+status:
+  available: true
+  encryption:
+    enabled: true
+    algorithm: AES-256-GCM
+    keyID: backup-key-2026-01
+```
+
+This allows users and support engineers to identify encryption configuration without exposing key material.
+
+### Backup and BackupVolume
+
+The backup status should indicate whether the remote backup is encrypted.
+
+For example:
+
+```yaml
+status:
+  encrypted: true
+  encryptionKeyID: backup-key-2026-01
+```
+
+This information must also be persisted in the remote backup metadata so a new cluster can recognize encrypted backups.
+
+---
+
+## Design
+
+### Encryption location
+
+Encryption should be implemented inside the `backupstore` data path rather than in the S3 provider itself.
+
+The order for backup processing should be:
+
+```text
+Volume data
+    |
+    v
+Changed-block detection
+    |
+    v
+Compression
+    |
+    v
+Client-side encryption
+    |
+    v
+S3 upload
+```
+
+Encryption must happen **after compression**.
+
+Compressing ciphertext is ineffective and would increase backup size and processing cost.
+
+Encryption must also happen after Longhorn has performed the calculations needed for incremental backup and block deduplication. Otherwise, randomized encryption could cause identical blocks to appear different and break the existing deduplication behavior.
+
+Restore uses the reverse flow:
+
+```text
+S3 download
+    |
+    v
+Client-side decryption/authentication
+    |
+    v
+Decompression
+    |
+    v
+Longhorn restore
+```
+
+### Encryption algorithm
+
+The initial encrypted-object format uses:
+
+```text
+Content encryption: AES-256-GCM
+Streaming format:    DARE
+Key size:            256 bits
+Implementation:      github.com/minio/sio
+```
+
+Authenticated encryption is required.
+
+If ciphertext, authentication data, or block ordering has been modified, decryption must fail rather than return potentially corrupted plaintext.
+
+### Key hierarchy
+
+The Kubernetes Secret contains a Key Encryption Key (KEK).
+
+Longhorn should not directly encrypt every backup object with the same key.
+
+Instead, each encrypted object receives a randomly generated 256-bit Data Encryption Key (DEK).
+
+Conceptually:
+
+```text
+Kubernetes Secret
+      |
+      | 256-bit KEK
+      v
++------------------+
+| Key wrapping     |
++------------------+
+      |
+      +-------------------------+
+                                |
+                     random 256-bit DEK
+                                |
+                                v
+                      +------------------+
+                      | AES-256-GCM/DARE |
+                      +------------------+
+                                |
+                                v
+                         Backup ciphertext
+```
+
+The plaintext DEK exists only in memory during encryption/decryption.
+
+The DEK is wrapped using the KEK and the wrapped value is stored in the Longhorn encryption header.
+
+This design provides a clean extension point for future KMS support.
+
+For example:
+
+```text
+Secret provider:
+    KEK from Kubernetes Secret
+        -> wrap/unwrap DEK locally
+
+Future KMS provider:
+    External KMS
+        -> generate/wrap/unwrap DEK
+```
+
+Both providers can produce the same encrypted backup payload format.
+
+### Encrypted object format
+
+Longhorn should add a small self-describing envelope before the DARE ciphertext.
+
+Conceptually:
+
+```text
++------------------------------------------------+
+| Longhorn encryption magic                     |
+| Format version                                 |
+| Cipher / encryption format                    |
+| Key provider                                   |
+| Key ID                                         |
+| Wrapped data-key length                        |
+| Wrapped data key                               |
+| Key-wrap nonce / required metadata             |
++------------------------------------------------+
+|                                                |
+| DARE encrypted data stream                     |
+|                                                |
++------------------------------------------------+
+```
+
+For example:
+
+```text
+Magic:       LHBE
+Version:     1
+Algorithm:   AES-256-GCM-DARE
+KeyProvider: secret
+KeyID:       backup-key-2026-01
+WrappedDEK:  ...
+Ciphertext:  ...
+```
+
+The exact binary encoding should be defined in the implementation and documented so future Longhorn versions can maintain compatibility.
+
+The header must contain no plaintext encryption key.
+
+### Detecting encrypted and plaintext objects
+
+Existing backup targets may contain plaintext objects.
+
+Longhorn must therefore distinguish:
+
+```text
+Legacy plaintext object
+```
+
+from:
+
+```text
+Longhorn encrypted object
+```
+
+The encryption magic and format version provide this distinction.
+
+On read:
+
+1. Read enough bytes to inspect the Longhorn encryption header.
+2. If the encryption magic is present, initialize the decrypting reader.
+3. If the object is a known legacy plaintext object, process it using the existing path.
+4. Never fall back to plaintext processing after authentication of an encrypted object fails.
+
+Step 4 is important.
+
+For example, if an encrypted object has been corrupted, Longhorn must return:
+
+```text
+failed to decrypt backup object: authentication failed
+```
+
+rather than attempting to interpret the corrupted ciphertext as a legacy plaintext object.
+
+### Metadata encryption
+
+Backup data blocks are not the only potentially sensitive information in the backup target.
+
+Objects such as:
+
+```text
+volume.cfg
+backup_*.cfg
+```
+
+can expose volume-related metadata.
+
+Therefore, data written through the normal S3 `Write` path should also be encrypted when backup encryption is enabled.
+
+Object names and directory/prefix structure remain visible. Encrypting S3 keys or directory layout is outside the scope of this enhancement.
+
+### S3 integration
+
+The encryption layer should wrap the existing input/output streams.
+
+Conceptually:
+
+```go
+func (s *service) PutObject(...) {
+    reader := originalReader
+
+    if encryptionEnabled {
+        reader = encryption.EncryptReader(originalReader)
+    }
+
+    // Existing aws-sdk-go-v2 upload path.
+    upload(reader)
+}
+```
+
+For read:
+
+```go
+func (s *service) GetObject(...) {
+    reader := existingS3GetObject()
+
+    if isEncrypted(reader) {
+        return encryption.DecryptReader(reader)
+    }
+
+    return reader
+}
+```
+
+The actual implementation needs to preserve the `io.ReadSeeker` requirements of the current `BackupStoreDriver.Write` and the retry behavior of the AWS SDK uploader.
+
+If an encryption reader cannot provide seek semantics safely, the implementation can provide an encrypted temporary/spooled reader or introduce an encryption-aware wrapper before the final S3 call.
+
+This must be covered by unit and S3 interoperability tests, especially multipart retry cases.
+
+### Multipart uploads
+
+Longhorn currently uses AWS SDK v2's uploader, which can switch to multipart upload for sufficiently large objects.
+
+The encrypted stream must therefore continue to work through the existing multipart implementation.
+
+Encryption is performed before the stream is divided into S3 multipart pieces:
+
+```text
+plaintext
+   |
+   v
+compression
+   |
+   v
+DARE encryption stream
+   |
+   v
++--------+--------+--------+
+| part 1 | part 2 | part 3 |
++--------+--------+--------+
+           |
+           v
+          S3
+```
+
+The remote provider only sees parts of one encrypted object.
+
+The multipart boundary is an S3 transport detail and must not become part of the encryption format.
+
+### Incremental backup compatibility
+
+Longhorn backups reuse unchanged blocks between backup revisions.
+
+Client-side encryption must not change the identity used by Longhorn to determine whether a block already exists.
+
+For example:
+
+```text
+Backup 1:
+    block A -> encrypt -> object A
+    block B -> encrypt -> object B
+
+Backup 2:
+    block A unchanged -> reuse existing object A
+    block C new       -> encrypt -> object C
+```
+
+Longhorn should not create a new randomized ciphertext object for block A merely because another backup references the same block.
+
+This preserves the storage efficiency of incremental backups.
+
+### Key changes
+
+Changing the key while existing encrypted backups are present is dangerous because incremental backups can share blocks.
+
+For the initial implementation, Longhorn should reject changing the effective encryption key for a BackupTarget containing encrypted backup data.
+
+For example:
+
+```text
+Current target:
+    encryption enabled
+    keyID = key-A
+    existing backups = yes
+
+User changes:
+    keyID = key-B
+
+Result:
+    reject configuration / mark BackupTarget unavailable
+```
+
+Users who need a new key can initially:
+
+1. create/use another backup target or S3 prefix;
+2. configure the new encryption key;
+3. create new backups there;
+4. retire the old target according to their retention policy.
+
+Online key rotation and re-wrapping existing DEKs can be designed as a separate enhancement.
+
+### Key loss
+
+If the key is lost, encrypted backup data cannot be recovered.
+
+The UI and documentation should clearly warn users about this.
+
+For example:
+
+> Losing the backup encryption key permanently prevents Longhorn from restoring backups encrypted with that key. Store the key securely outside the Longhorn cluster as part of the disaster-recovery plan.
+
+Longhorn must not generate a replacement key automatically if the configured Secret disappears.
+
+---
+
+## External KMS Design
+
+External KMS integration is not required for the first implementation, but the design must leave a clean extension point.
+
+The encryption code should use a key-provider interface similar to:
+
+```go
+type DataKeyProvider interface {
+    GenerateDataKey(ctx context.Context) (
+        plaintextKey []byte,
+        encryptedKey []byte,
+        keyID string,
+        err error,
+    )
+
+    DecryptDataKey(
+        ctx context.Context,
+        encryptedKey []byte,
+        keyID string,
+    ) ([]byte, error)
+}
+```
+
+Initial implementation:
+
+```text
+DataKeyProvider
+    |
+    +-- KubernetesSecretKeyProvider
+```
+
+Possible future implementations:
+
+```text
+DataKeyProvider
+    |
+    +-- KubernetesSecretKeyProvider
+    |
+    +-- AWSKMSKeyProvider
+    |
+    +-- VaultKeyProvider
+    |
+    +-- other external KMS provider
+```
+
+This prevents the backup encryption format from being coupled directly to AWS KMS even though the backup destination is S3.
+
+A user using MinIO should not be forced to use AWS KMS.
+
+---
+
+## Backup and Restore Behavior
+
+### Backup
+
+For every new object requiring encryption:
+
+1. Load the effective backup-encryption configuration.
+2. Validate the Secret and key.
+3. Generate a cryptographically secure random DEK.
+4. Wrap the DEK using the configured key provider.
+5. Compress backup data using the existing Longhorn behavior.
+6. Encrypt the compressed stream using the DEK.
+7. Add the Longhorn encryption envelope.
+8. Upload the encrypted object using the existing S3 implementation.
+9. Clear temporary plaintext key material as soon as practical.
+10. Record non-sensitive encryption information such as encryption version and key ID.
+
+### Restore
+
+For each object:
+
+1. Download the object using the existing S3 client.
+2. Inspect the object header.
+3. Detect whether the object is encrypted.
+4. Read the key provider and key ID.
+5. Obtain the required KEK/KMS configuration.
+6. Unwrap the DEK.
+7. Authenticate and decrypt the encrypted stream.
+8. Decompress the resulting backup data.
+9. Restore the data using the existing Longhorn restore path.
+
+A missing or incorrect key must result in a clear restore failure.
+
+### Backup synchronization
+
+BackupTarget synchronization must be able to discover encrypted backup volumes.
+
+If reading backup configuration requires the encryption key and the Secret is unavailable, Longhorn should report the BackupTarget as unavailable or degraded with an explicit reason such as:
+
+```text
+BackupEncryptionKeyUnavailable
+```
+
+rather than reporting that the backup is corrupt or missing.
+
+### Delete
+
+Deletion is based primarily on S3 object keys and does not require plaintext object contents where possible.
+
+Encrypted objects should be deleted using the existing S3 deletion implementation.
+
+---
+
+## Failure Handling
+
+Longhorn must fail closed for encryption errors.
+
+Examples include:
+
+### Missing Secret
+
+```text
+backup encryption is enabled but Secret
+"longhorn-backup-encryption" does not exist
+```
+
+### Invalid key length
+
+```text
+backup encryption key must contain exactly 32 bytes
+```
+
+### Wrong key
+
+```text
+failed to decrypt backup object:
+authentication failed for encryption key "backup-key-2026-01"
+```
+
+### Corrupt object
+
+```text
+failed to decrypt backup object:
+ciphertext authentication failed
+```
+
+### Unsupported encryption format
+
+```text
+backup uses unsupported encryption format version 2
+```
+
+### Unsupported backup target
+
+```text
+client-side backup encryption is supported only for S3 backup targets
+```
+
+Errors must never print:
+
+* key contents;
+* unwrapped DEKs;
+* Secret data;
+* KMS plaintext responses.
+
+---
+
+## Backward Compatibility
+
+### Existing unencrypted backups
+
+The feature is disabled by default.
+
+Existing S3 backup targets and existing plaintext backups continue to work without modification.
+
+Longhorn must continue to detect and restore legacy plaintext backup objects.
+
+### Upgrade
+
+Upgrading Longhorn does not automatically encrypt existing backups.
+
+For example:
+
+```text
+Before upgrade:
+    backup-1 -> plaintext
+
+After upgrade and encryption enabled:
+    backup-1 -> remains plaintext
+    backup-2 -> encrypted
+```
+
+However, to avoid ambiguity and shared-block issues, enabling encryption for a BackupTarget containing existing backup data should initially require either:
+
+* an empty/new S3 prefix, or
+* explicit validation that the backup volume can safely use the selected policy.
+
+The safest initial behavior is to recommend or require a new backup-target prefix when transitioning an existing target from plaintext to encrypted backups.
+
+### Downgrade
+
+Longhorn versions that predate this feature cannot restore the new encrypted backup format.
+
+Documentation must clearly state this limitation.
+
+Downgrading Longhorn does not decrypt existing backup objects.
+
+---
+
+## Security Considerations
+
+### Threats addressed
+
+The feature protects backup payloads against:
+
+* unauthorized reading of objects from the S3 bucket;
+* a compromised S3 storage provider reading Longhorn backup data;
+* accidental exposure of backup objects;
+* modification of encrypted backup data, because authenticated encryption detects tampering.
+
+### Threats not addressed
+
+The feature does not hide:
+
+* bucket name;
+* object names;
+* Longhorn backup prefix layout;
+* object sizes;
+* modification timestamps;
+* backup access patterns.
+
+It also does not protect backup data if:
+
+* the Kubernetes encryption Secret is compromised;
+* the Longhorn process performing backup/restore is compromised;
+* an attacker has access to both encrypted backup data and the encryption key.
+
+### Key handling
+
+Key material must:
+
+* only be loaded when needed;
+* never be logged;
+* never be included in errors;
+* never be persisted in CR status;
+* never be included in support bundles as plaintext;
+* be passed only to processes/components participating in backup or restore;
+* use Kubernetes RBAC to restrict Secret access.
+
+---
+
+## Implementation Overview
+
+### backupstore
+
+Add a client-side encryption package, for example:
+
+```text
+backupstore/
+    encryption/
+        encryption.go
+        header.go
+        key_provider.go
+        secret_key_provider.go
+        reader.go
+        writer.go
+```
+
+Responsibilities:
+
+* define the encrypted object format;
+* generate DEKs;
+* wrap/unwrap DEKs;
+* create streaming encryption readers;
+* create streaming decryption readers;
+* identify encrypted objects;
+* validate encryption headers;
+* validate authentication;
+* return sanitized errors.
+
+Add `github.com/minio/sio` as the streaming authenticated-encryption dependency.
+
+### S3 driver
+
+Modify the S3 driver to optionally insert encryption/decryption around object I/O.
+
+Existing:
+
+```text
+Write -> PutObject
+Read  -> GetObject
+```
+
+New:
+
+```text
+Write -> Encrypt -> PutObject
+Read  -> GetObject -> Detect -> Decrypt
+```
+
+Similarly:
+
+```text
+Upload   -> Encrypt -> existing S3 upload
+Download -> existing S3 download -> Decrypt
+```
+
+The existing AWS SDK v2 client remains responsible for:
+
+* AWS authentication;
+* S3-compatible endpoints;
+* path-style addressing;
+* custom CAs;
+* retries;
+* multipart upload;
+* provider-specific compatibility workarounds.
+
+### longhorn-manager
+
+Longhorn Manager responsibilities include:
+
+* validating BackupTarget encryption configuration;
+* reading the encryption Secret;
+* ensuring the S3 target uses a supported configuration;
+* securely passing encryption information into the backup operation;
+* exposing non-sensitive encryption status;
+* rejecting unsafe key changes.
+
+### longhorn-engine / backup process
+
+Extend the existing backup credential/configuration plumbing so the process performing the backup can obtain the encryption configuration.
+
+No persistent plaintext key should be written to disk as part of the configuration transfer.
+
+### Longhorn UI
+
+Add BackupTarget encryption configuration:
+
+```text
+Client-Side Backup Encryption
+    [ ] Enable
+
+Encryption Secret
+    [ longhorn-backup-encryption ]
+```
+
+When enabled, show a warning:
+
+```text
+The encryption key is required to restore these backups.
+Longhorn cannot recover the data if the key is lost.
+```
+
+Backup detail pages can show:
+
+```text
+Encryption: Client-side
+Algorithm:  AES-256-GCM
+Key ID:     backup-key-2026-01
+```
+
+The key itself is never displayed.
+
+### Documentation
+
+Documentation must cover:
+
+* generating a secure 256-bit key;
+* creating the Kubernetes Secret;
+* enabling backup encryption;
+* creating encrypted backups;
+* restoring encrypted backups into another cluster;
+* disaster-recovery handling of the Secret;
+* key-loss consequences;
+* upgrade/downgrade behavior;
+* supported S3 providers;
+* current key-rotation limitations.
+
+---
+
+## Test Plan
+
+### Unit Tests
+
+#### Encryption/decryption
+
+Verify:
+
+1. plaintext encrypts successfully;
+2. ciphertext decrypts to the original plaintext;
+3. ciphertext does not contain the original plaintext;
+4. encrypting the same content multiple times results in different ciphertext because random key/nonce material is used;
+5. zero-length input is supported;
+6. small input is supported;
+7. large streaming input is supported.
+
+#### Authentication
+
+Verify decryption fails when:
+
+* ciphertext bytes are modified;
+* ciphertext is truncated;
+* encrypted chunks are reordered;
+* header information is corrupted;
+* the wrong DEK is supplied;
+* the wrong KEK is supplied.
+
+No unauthenticated plaintext should be returned.
+
+#### Encryption header
+
+Verify:
+
+* correct magic is recognized;
+* version 1 is parsed;
+* unsupported versions are rejected;
+* invalid field lengths are rejected;
+* unknown algorithm identifiers are rejected;
+* plaintext legacy objects are not incorrectly recognized as encrypted objects.
+
+#### Key handling
+
+Verify:
+
+* 32-byte key succeeds;
+* shorter keys fail;
+* longer keys fail;
+* missing Secret data fails;
+* missing key ID behavior follows the API contract;
+* wrong Secret fails during restore;
+* sensitive values do not appear in returned errors.
+
+#### S3 write/read
+
+With encryption disabled:
+
+```text
+Write -> S3 object == original input
+Read  -> original input
+```
+
+With encryption enabled:
+
+```text
+Write -> S3 object != original input
+Read  -> original input
+```
+
+#### Multipart upload
+
+Test encrypted objects large enough to trigger the current AWS SDK multipart uploader.
+
+Verify:
+
+* backup succeeds;
+* retry succeeds;
+* resulting object decrypts correctly;
+* encryption boundaries are independent from multipart boundaries.
+
+#### Existing single-part fallback
+
+Test S3 provider paths that use `PutObjectAsSinglePart` or the existing single-part compatibility fallback.
+
+Encryption must work with both multipart and single-part paths.
+
+#### Legacy compatibility
+
+Store an existing unencrypted backup object.
+
+Enable the new encryption-capable Longhorn code.
+
+Verify the plaintext object remains readable.
+
+---
+
+## Automated E2E Tests
+
+Add or update automated test coverage associated with #12297.
+
+## Manual Test Plan
+
+### Security inspection
+
+After creating an encrypted backup:
+
+1. Download objects directly from S3 without using Longhorn.
+2. Search for known filesystem/application contents.
+3. Verify plaintext content cannot be found.
+4. Verify backup configuration payloads protected by the encryption layer are not readable.
+5. Confirm object keys and sizes remain visible as documented.
+
+### Log inspection
+
+Run backup and restore at normal and debug log levels.
+
+Verify that none of the following appear:
+
+* KEK;
+* DEK;
+* Secret `data.key`;
+* plaintext backup data.
+
+Generate a Longhorn support bundle and perform the same check.
+
+### Performance test
+
+Compare:
+
+```text
+unencrypted backup
+vs.
+encrypted backup
+```
+
+and:
+
+```text
+unencrypted restore
+vs.
+encrypted restore
+```
+
+Measure:
+
+* throughput;
+* CPU usage;
+* memory usage;
+* total object size;
+* backup duration;
+* restore duration.
+
+The encryption implementation should remain streaming and must not buffer an entire backup object in memory.
+
+### Failure/retry testing
+
+Introduce network interruptions during encrypted S3 upload/download.
+
+Verify:
+
+* retry does not produce invalid ciphertext;
+* failed partial uploads are cleaned up according to current backup behavior;
+* retrying the backup produces a valid encrypted object.
+
+---
+
+## Performance Considerations
+
+Client-side encryption introduces additional CPU usage during backup and restore.
+
+Unlike in-cluster volume encryption, however, this cost exists only while backup or restore I/O is being processed.
+
+The expected pipeline is:
+
+```text
+compression -> encryption -> network
+```
+
+so encryption does not prevent Longhorn from compressing the backup first.
+
+The encryption library must operate in a streaming manner to avoid memory usage proportional to backup size.
+
+Benchmarks should be collected before release to determine the performance impact on:
+
+* small backups;
+* large backups;
+* highly compressible data;
+* incompressible data;
+* CPUs with AES hardware acceleration;
+* CPUs without AES hardware acceleration.
+
+---
+
+## Risks and Mitigations
+
+### Key loss
+
+**Risk:** The user loses the encryption Secret.
+
+**Impact:** Backups cannot be restored.
+
+**Mitigation:** Strong UI/documentation warnings and disaster-recovery documentation.
+
+### Incorrect key changes
+
+**Risk:** A target contains blocks encrypted under multiple unexpected keys.
+
+**Impact:** Some incremental backups may become unrestorable.
+
+**Mitigation:** Disallow changing the effective key while encrypted backups exist in the target/prefix.
+
+### S3 interoperability
+
+**Risk:** Encryption integration changes stream behavior and exposes differences among S3-compatible providers.
+
+**Mitigation:** Keep the existing AWS SDK v2 transport and make AWS S3 and MinIO E2E testing release-blocking.
+
+### Ciphertext corruption
+
+**Risk:** Remote objects are damaged or modified.
+
+**Impact:** Restore failure.
+
+**Mitigation:** Authenticated encryption detects corruption and Longhorn fails closed.
+
+### Downgrade
+
+**Risk:** User downgrades to a Longhorn release without backup encryption support.
+
+**Impact:** Older Longhorn cannot restore encrypted backups.
+
+**Mitigation:** Document the compatibility boundary and do not modify encrypted backups during downgrade.
+
+### Encryption metadata compatibility
+
+**Risk:** Future implementation changes make existing encrypted backups unreadable.
+
+**Mitigation:** Use a versioned Longhorn encryption envelope and treat the encrypted-object format as a persistent compatibility contract.
+
+---
+
+## Rollout Plan
+
+### Phase 1: Encryption format and POC
+
+Implement a prototype in `backupstore` using `minio/sio`.
+
+Validate:
+
+* stream encryption/decryption;
+* AWS SDK v2 multipart upload;
+* existing single-part path;
+* AWS S3;
+* MinIO;
+* existing S3-compatible custom endpoint behavior.
+
+The POC should be completed before finalizing the on-disk/on-S3 encryption format.
+
+### Phase 2: API and key management
+
+Implement:
+
+* BackupTarget fields;
+* Secret validation;
+* encryption configuration plumbing;
+* key-provider abstraction;
+* Backup/BackupTarget status.
+
+### Phase 3: Backupstore integration
+
+Implement:
+
+* encrypted Write;
+* decrypted Read;
+* encrypted Upload;
+* decrypted Download;
+* legacy plaintext detection;
+* integrity error handling.
+
+### Phase 4: Manager/UI/documentation
+
+Add:
+
+* validation;
+* status;
+* UI controls;
+* key-loss warnings;
+* disaster-recovery documentation.
+
+### Phase 5: E2E and interoperability
+
+Complete #12297 and validate:
+
+* AWS S3;
+* MinIO;
+* V1/V2 backup paths;
+* incremental backup;
+* upgrade;
+* restore;
+* corruption handling.
+
+---
+
+## Future Enhancements
+
+### External KMS
+
+Implement additional `DataKeyProvider` implementations such as:
+
+```text
+AWS KMS
+Vault
+other enterprise KMS providers
+```
+
+The backup format already contains:
+
+```text
+key provider
+key ID
+wrapped DEK
+```
+
+so these providers can be added without redesigning content encryption.
+
+### Key rotation
+
+Add a controlled process to rotate the KEK.
+
+Because each object uses a DEK, a future implementation may be able to re-wrap DEKs where the storage format permits it rather than decrypting and re-encrypting the complete backup payload.
+
+### Per-volume policy
+
+Allow individual Longhorn volumes to override the BackupTarget encryption default.
+
+For example:
+
+```yaml
+spec:
+  backupEncryption: inherit
+```
+
+with possible values:
+
+```text
+inherit
+enabled
+disabled
+```
+
+This requires additional design around shared backup blocks and key consistency and is intentionally deferred from the first implementation.
+
+### Server-side encryption
+
+SSE-C or other S3 server-side encryption can be implemented independently for users who prefer provider-managed encryption.
+
+It should be considered an additional protection option rather than a replacement for client-side encryption.
+
+---
+
+## Decision
+
+The proposed first implementation is:
+
+```text
+Scope:
+    S3 / S3-compatible backup targets only
+
+Encryption location:
+    Longhorn client side, before S3 upload
+
+S3 library:
+    Existing aws-sdk-go-v2 implementation
+
+Streaming encryption:
+    github.com/minio/sio
+
+Content encryption:
+    AES-256-GCM authenticated encryption
+
+Configuration:
+    BackupTarget level
+
+Initial key source:
+    Kubernetes Secret containing a 256-bit key
+
+Key model:
+    Per-object random DEK protected by the configured KEK
+
+External KMS:
+    Extensible interface, implementation deferred
+
+Existing backups:
+    Remain supported and are not automatically migrated
+
+Key rotation:
+    Not supported for existing backups in the initial release
+
+Required interoperability:
+    AWS S3 and MinIO
+
+Default:
+    Disabled
+```
+
+This design keeps S3-provider compatibility separate from encryption, avoids requiring trust in the remote object-storage service, preserves Longhorn's existing S3 transport implementation and incremental-backup architecture, and provides a path for future KMS and key-rotation support.


### PR DESCRIPTION

Issue #5220

### What this PR does / why we need it:

Adds a LEP for client-side backup encryption (#5220).

Longhorn can encrypt a volume in-cluster but cannot encrypt only that volume's backup. Users who trust their cluster but not their backup destination currently have to enable in-cluster volume encryption purely to protect remote backup data.

This LEP proposes encrypting backup data locally, after compression and before the backup store, so the target only ever receives ciphertext.
It is configured independently of volume encryption, applies to every target `backupstore` supports (S3, NFS, CIFS) by sitting above `BackupStoreDriver`, and uses a Kubernetes Secret as the key source.

Configuration has two levels: `Volume.Spec.BackupEncryptionSecret` overrides the global `backup-encryption-secret` setting. If neither is set, backups behave exactly as they do today.

### Special notes for your reviewer:

- Server-side encryption removed and moved to Non-goals, tracked in #14037 .
- `inherit` state removed; resolution is Volume, then global.
- `BackupTarget`-level configuration dropped for the first version.
- `Enabled` removed from backup status; a non-empty Secret name means encrypted.
- S3-only restriction removed; encryption sits above `BackupStoreDriver`.
- `S3-Compatible Providers` section removed.
- Streaming is no longer required; `BackupStoreDriver.Write` takes an
  `io.ReadSeeker`, so encrypted temp files are used for whole-file paths.

Three points worth a close look, since they are new since the last round:

### Additional documentation or context
