### PR TITLE
feat(chart): Gateway API Filters support

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -261,14 +261,15 @@ Longhorn consists of user-deployed components (for example, Longhorn Manager, Lo
 
 ### HTTPRoute Settings
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| httproute.annotations | object | `{}` | Annotations for the HTTPRoute resource in the form of key-value pairs. |
-| httproute.enabled | bool | `false` | Setting that allows Longhorn to generate HTTPRoute records for the Longhorn UI service using Gateway API. |
-| httproute.hostnames | list | `[]` | List of hostnames for the HTTPRoute. Multiple hostnames are supported. |
-| httproute.parentRefs | list | `[]` | Gateway references for HTTPRoute. Specify which Gateway(s) should handle this route. |
-| httproute.path | string | `"/"` | Default path for HTTPRoute. You can access the Longhorn UI by following the full path. |
-| httproute.pathType | string | `"PathPrefix"` | Path match type for HTTPRoute. (Options: "Exact", "PathPrefix") |
+| Key                   | Type | Default | Description                                                                                          |
+|-----------------------|------|---------|------------------------------------------------------------------------------------------------------|
+| httproute.annotations | object | `{}` | Key-value annotations to apply to the HTTPRoute resource.                                            |
+| httproute.enabled     | bool | `false` | When `true`, Longhorn generates HTTPRoute records for the Longhorn UI service using the Gateway API. |
+| httproute.hostnames   | list | `[]` | List of hostnames bound to the HTTPRoute.                                                            |
+| httproute.parentRefs  | list | `[]` | List of Gateway references specifying which Gateway(s) should handle this route.                     |
+| httproute.filters     | list | `[]` | List of Gateway API filters to attach to the HTTPRoute rule for the Longhorn UI service.             |
+| httproute.path        | string | `"/"` | The routing path used to access the Longhorn UI.                                                     |
+| httproute.pathType    | string | `"PathPrefix"` | The path match type for the HTTPRoute. Valid options are `"Exact"` or `"PathPrefix"`.                |
 
 ### Private Registry Settings
 

--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -1320,6 +1320,13 @@ questions:
         type: string
         required: true
         label: Hostnames (JSON array)
+      - variable: httproute.filters
+        default: '[]'
+        description: >-
+          Gateway API filters (such as authentication middleware) to attach to the HTTPRoute rule for the Longhorn UI service. It is a JSON array of HTTPRouteFilter objects. Example: '[{"type":"ExtensionRef","extensionRef":{"group":"traefik.io","kind":"Middleware","name":"oauth-forwardauth"}}]'
+        type: string
+        required: false
+        label: Filters (JSON array)
       - variable: httproute.path
         default: /
         description: >-

--- a/chart/templates/httproute.yaml
+++ b/chart/templates/httproute.yaml
@@ -1,4 +1,19 @@
 {{- if .Values.httproute.enabled -}}
+  {{- $filters := .Values.httproute.filters -}}
+  {{- if $filters }}
+    {{- if not (kindIs "slice" $filters) }}
+      {{- fail "httproute.filters must be a YAML list of HTTPRouteFilter objects" }}
+    {{- end }}
+    {{- range $index, $filter := $filters }}
+      {{- if not (kindIs "map" $filter) }}
+        {{- fail (printf "httproute.filters[%d] must be an HTTPRouteFilter object" $index) }}
+      {{- end }}
+      {{- $type := get $filter "type" }}
+      {{- if or (not (kindIs "string" $type)) (empty $type) }}
+        {{- fail (printf "httproute.filters[%d].type must be a non-empty string" $index) }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -36,6 +51,10 @@ spec:
     - path:
         type: {{ .Values.httproute.pathType | default "PathPrefix" }}
         value: {{ .Values.httproute.path | default "/" }}
+    {{- with .Values.httproute.filters }}
+    filters:
+      {{- toYaml . | nindent 10 }}
+    {{- end }}
     backendRefs:
     - name: longhorn-frontend
       port: 80

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -661,6 +661,19 @@ httproute:
   ## Example:
   # - longhorn.example.com
   # - longhorn.example.org
+  # -- List of allowed HTTPRouteFilter rules.
+  filters: []
+  ## Example:
+  #  - type: ExtensionRef
+  #    extensionRef:
+  #      group: traefik.io
+  #      kind: Middleware
+  #      name: oauth-forwardauth
+  #  - type: ExtensionRef
+  #    extensionRef:
+  #      group: traefik.io
+  #      kind: Middleware
+  #      name: oauth-forwardauth-service
   # -- Default path for HTTPRoute. You can access the Longhorn UI by following the full path.
   path: /
   # -- Path match type for HTTPRoute. (Options: "Exact", "PathPrefix")


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue #12976 

#### What this PR does / why we need it:
Adds `httproute.filters` field in chart template to allow configuring filters that mirrors the upstream Gateway API `HTTPRouteFilter` schema.

#### Special notes for your reviewer:

#### Additional documentation or context

- https://github.com/longhorn/longhorn/pull/13708
