### PR TITLE
fix(chart): honor per-image registries

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -42,7 +42,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion }}
 {{- if .Values.global.cattle.systemDefaultRegistry -}}
 {{- .Values.global.cattle.systemDefaultRegistry -}}
 {{- else -}}
-{{- "docker.io" -}}
+{{- "" -}}
 {{- end -}}
 {{- end -}}
 

--- a/chart/templates/daemonset-sa.yaml
+++ b/chart/templates/daemonset-sa.yaml
@@ -22,7 +22,7 @@ spec:
       {{- $longhornControlPath := default "/var/lib/longhorn/" .Values.defaultSettings.defaultControlPath }}
       containers:
       - name: longhorn-manager
-        image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.manager.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
+        image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.manager.registry "docker.io") }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
           privileged: true
@@ -34,17 +34,17 @@ spec:
         {{- end }}
         - daemon
         - --engine-image
-        - "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.engine.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.engine.repository }}:{{ .Values.image.longhorn.engine.tag }}"
+        - "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.engine.registry "docker.io") }}{{ . }}/{{ end }}{{ .Values.image.longhorn.engine.repository }}:{{ .Values.image.longhorn.engine.tag }}"
         - --instance-manager-image
-        - "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.instanceManager.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.instanceManager.repository }}:{{ .Values.image.longhorn.instanceManager.tag }}"
+        - "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.instanceManager.registry "docker.io") }}{{ . }}/{{ end }}{{ .Values.image.longhorn.instanceManager.repository }}:{{ .Values.image.longhorn.instanceManager.tag }}"
         - --share-manager-image
-        - "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.shareManager.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.shareManager.repository }}:{{ .Values.image.longhorn.shareManager.tag }}"
+        - "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.shareManager.registry "docker.io") }}{{ . }}/{{ end }}{{ .Values.image.longhorn.shareManager.repository }}:{{ .Values.image.longhorn.shareManager.tag }}"
         - --backing-image-manager-image
-        - "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.backingImageManager.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.backingImageManager.repository }}:{{ .Values.image.longhorn.backingImageManager.tag }}"
+        - "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.backingImageManager.registry "docker.io") }}{{ . }}/{{ end }}{{ .Values.image.longhorn.backingImageManager.repository }}:{{ .Values.image.longhorn.backingImageManager.tag }}"
         - --support-bundle-manager-image
-        - "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.supportBundleKit.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.supportBundleKit.repository }}:{{ .Values.image.longhorn.supportBundleKit.tag }}"
+        - "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.supportBundleKit.registry "docker.io") }}{{ . }}/{{ end }}{{ .Values.image.longhorn.supportBundleKit.repository }}:{{ .Values.image.longhorn.supportBundleKit.tag }}"
         - --manager-image
-        - "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.manager.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}"
+        - "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.manager.registry "docker.io") }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}"
         - --service-account
         - longhorn-service-account
         {{- if .Values.preUpgradeChecker.upgradeVersionCheck}}
@@ -123,7 +123,7 @@ spec:
         {{- end }}
       - name: pre-pull-share-manager-image
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.shareManager.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.shareManager.repository }}:{{ .Values.image.longhorn.shareManager.tag }}
+        image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.shareManager.registry "docker.io") }}{{ . }}/{{ end }}{{ .Values.image.longhorn.shareManager.repository }}:{{ .Values.image.longhorn.shareManager.tag }}
         command: ["sh", "-c", "echo share-manager image pulled && sleep infinity"]
       volumes:
       - name: boot

--- a/chart/templates/deployment-driver.yaml
+++ b/chart/templates/deployment-driver.yaml
@@ -16,11 +16,11 @@ spec:
     spec:
       initContainers:
         - name: wait-longhorn-manager
-          image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.manager.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
+          image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.manager.registry "docker.io") }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
           command: ['sh', '-c', 'while [ $(curl -m 1 -s -o /dev/null -w "%{http_code}" http://longhorn-backend:9500/v1) != "200" ]; do echo waiting; sleep 2; done']
       containers:
         - name: longhorn-driver-deployer
-          image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.manager.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
+          image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.manager.registry "docker.io") }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
           - longhorn-manager
@@ -30,7 +30,7 @@ spec:
           {{- end }}
           - deploy-driver
           - --manager-image
-          - "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.manager.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}"
+          - "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.manager.registry "docker.io") }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}"
           - --manager-url
           - http://longhorn-backend:9500/v1
           env:
@@ -56,27 +56,27 @@ spec:
           {{- end }}
           {{- if and .Values.image.csi.attacher.repository .Values.image.csi.attacher.tag }}
           - name: CSI_ATTACHER_IMAGE
-            value: "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.csi.attacher.registry) }}{{ . }}/{{ end }}{{ .Values.image.csi.attacher.repository }}:{{ .Values.image.csi.attacher.tag }}"
+            value: "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.csi.attacher.registry "docker.io") }}{{ . }}/{{ end }}{{ .Values.image.csi.attacher.repository }}:{{ .Values.image.csi.attacher.tag }}"
           {{- end }}
           {{- if and .Values.image.csi.provisioner.repository .Values.image.csi.provisioner.tag }}
           - name: CSI_PROVISIONER_IMAGE
-            value: "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.csi.provisioner.registry) }}{{ . }}/{{ end }}{{ .Values.image.csi.provisioner.repository }}:{{ .Values.image.csi.provisioner.tag }}"
+            value: "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.csi.provisioner.registry "docker.io") }}{{ . }}/{{ end }}{{ .Values.image.csi.provisioner.repository }}:{{ .Values.image.csi.provisioner.tag }}"
           {{- end }}
           {{- if and .Values.image.csi.nodeDriverRegistrar.repository .Values.image.csi.nodeDriverRegistrar.tag }}
           - name: CSI_NODE_DRIVER_REGISTRAR_IMAGE
-            value: "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.csi.nodeDriverRegistrar.registry) }}{{ . }}/{{ end }}{{ .Values.image.csi.nodeDriverRegistrar.repository }}:{{ .Values.image.csi.nodeDriverRegistrar.tag }}"
+            value: "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.csi.nodeDriverRegistrar.registry "docker.io") }}{{ . }}/{{ end }}{{ .Values.image.csi.nodeDriverRegistrar.repository }}:{{ .Values.image.csi.nodeDriverRegistrar.tag }}"
           {{- end }}
           {{- if and .Values.image.csi.resizer.repository .Values.image.csi.resizer.tag }}
           - name: CSI_RESIZER_IMAGE
-            value: "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.csi.resizer.registry) }}{{ . }}/{{ end }}{{ .Values.image.csi.resizer.repository }}:{{ .Values.image.csi.resizer.tag }}"
+            value: "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.csi.resizer.registry "docker.io") }}{{ . }}/{{ end }}{{ .Values.image.csi.resizer.repository }}:{{ .Values.image.csi.resizer.tag }}"
           {{- end }}
           {{- if and .Values.image.csi.snapshotter.repository .Values.image.csi.snapshotter.tag }}
           - name: CSI_SNAPSHOTTER_IMAGE
-            value: "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.csi.snapshotter.registry) }}{{ . }}/{{ end }}{{ .Values.image.csi.snapshotter.repository }}:{{ .Values.image.csi.snapshotter.tag }}"
+            value: "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.csi.snapshotter.registry "docker.io") }}{{ . }}/{{ end }}{{ .Values.image.csi.snapshotter.repository }}:{{ .Values.image.csi.snapshotter.tag }}"
           {{- end }}
           {{- if and .Values.image.csi.livenessProbe.repository .Values.image.csi.livenessProbe.tag }}
           - name: CSI_LIVENESS_PROBE_IMAGE
-            value: "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.csi.livenessProbe.registry) }}{{ . }}/{{ end }}{{ .Values.image.csi.livenessProbe.repository }}:{{ .Values.image.csi.livenessProbe.tag }}"
+            value: "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.csi.livenessProbe.registry "docker.io") }}{{ . }}/{{ end }}{{ .Values.image.csi.livenessProbe.repository }}:{{ .Values.image.csi.livenessProbe.tag }}"
           {{- end }}
           {{- if .Values.csi.attacherReplicaCount }}
           - name: CSI_ATTACHER_REPLICA_COUNT

--- a/chart/templates/deployment-ui.yaml
+++ b/chart/templates/deployment-ui.yaml
@@ -61,7 +61,7 @@ spec:
       {{- if .Values.openshift.ui.route }}
       - name: oauth-proxy
         {{- if .Values.image.openshift.oauthProxy.repository }}
-        image: {{ with (coalesce .Values.image.openshift.oauthProxy.registry .Values.global.imageRegistry (include "registry_url" .)) }}{{ . }}/{{ end }}{{ .Values.image.openshift.oauthProxy.repository }}:{{ .Values.image.openshift.oauthProxy.tag }}
+        image: {{ with (coalesce .Values.image.openshift.oauthProxy.registry .Values.global.imageRegistry (include "registry_url" .) "docker.io") }}{{ . }}/{{ end }}{{ .Values.image.openshift.oauthProxy.repository }}:{{ .Values.image.openshift.oauthProxy.tag }}
         {{- else }}
         image: ""
         {{- end }}
@@ -84,7 +84,7 @@ spec:
       {{- end }}
       {{- end }}
       - name: longhorn-ui
-        image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.ui.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.ui.repository }}:{{ .Values.image.longhorn.ui.tag }}
+        image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.ui.registry "docker.io") }}{{ . }}/{{ end }}{{ .Values.image.longhorn.ui.repository }}:{{ .Values.image.longhorn.ui.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
         - name: nginx-cache

--- a/chart/templates/postupgrade-job.yaml
+++ b/chart/templates/postupgrade-job.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: longhorn-post-upgrade
-        image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.manager.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
+        image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.manager.registry "docker.io") }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
         - longhorn-manager

--- a/chart/templates/preupgrade-job.yaml
+++ b/chart/templates/preupgrade-job.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: longhorn-pre-upgrade
-        image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.manager.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
+        image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.manager.registry "docker.io") }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
           privileged: true

--- a/chart/templates/uninstall-job.yaml
+++ b/chart/templates/uninstall-job.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: longhorn-uninstall
-        image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.manager.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
+        image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.manager.registry "docker.io") }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
         - longhorn-manager


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Fixes #12611

#### What this PR does / why we need it:

Moves the implicit `docker.io` fallback after per-image registry values while preserving the existing precedence of global, private, and Rancher system registries.

The resulting precedence is:

```text
global.imageRegistry
→ privateRegistry.registryUrl
→ global.cattle.systemDefaultRegistry
→ image.*.*.registry
→ docker.io fallback
```

#### Testing

- `helm lint ./chart --kube-version 1.35.0`
- Verified default images still use `docker.io`
- Verified Longhorn and CSI per-image registries are honored
- Verified private registry precedence remains unchanged for #11243
- Verified Rancher system registry precedence remains unchanged for #13094
- Verified global registry precedence remains unchanged
- Compared complete default, private-registry, and Rancher-registry rendered manifests against the pre-fix chart; all are unchanged