### PR TITLE
fix(chart): restore OAuth proxy registry precedence

### DIFF
--- a/chart/templates/deployment-ui.yaml
+++ b/chart/templates/deployment-ui.yaml
@@ -61,7 +61,7 @@ spec:
       {{- if .Values.openshift.ui.route }}
       - name: oauth-proxy
         {{- if .Values.image.openshift.oauthProxy.repository }}
-        image: {{ with (coalesce .Values.image.openshift.oauthProxy.registry .Values.global.imageRegistry (include "registry_url" .) "docker.io") }}{{ . }}/{{ end }}{{ .Values.image.openshift.oauthProxy.repository }}:{{ .Values.image.openshift.oauthProxy.tag }}
+        image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.openshift.oauthProxy.registry "docker.io") }}{{ . }}/{{ end }}{{ .Values.image.openshift.oauthProxy.repository }}:{{ .Values.image.openshift.oauthProxy.tag }}
         {{- else }}
         image: ""
         {{- end }}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/12611

Hi @derekbit. Sorry, my [comment](https://github.com/longhorn/longhorn/pull/13729#discussion_r3791922252) was misleading, I didn't actual fix the ordering for the OpenShift OAuth proxy image. I've just realized what Copliot was talking about.

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
