### PR TITLE
docs(network-policy): add scoped Prometheus ingress example

### DIFF
--- a/examples/network-policy/allow-prometheus-to-longhorn-manager.yaml
+++ b/examples/network-policy/allow-prometheus-to-longhorn-manager.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-prometheus-to-longhorn-manager
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchLabels:
+      app: longhorn-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        # Keep both selectors in this from item; Kubernetes ANDs them.
+        # Change the namespace value to the namespace where Prometheus runs.
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: default
+          # Change these labels to identify only the Prometheus scraper pods.
+          podSelector:
+            matchLabels:
+              longhorn.io/metrics-scraper: "true"
+      ports:
+        - protocol: TCP
+          port: 9500


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #13740

Add an additive NetworkPolicy example that allows only labeled scraper pods in a selected namespace to reach Longhorn manager port 9500.

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
