### PR TITLE
feat(chart): expose topologySpreadConstraints for longhorn-ui

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -242,6 +242,7 @@ Longhorn consists of user-deployed components (for example, Longhorn Manager, Lo
 | longhornUI.priorityClass | string | `"longhorn-critical"` | PriorityClass for Longhorn UI. |
 | longhornUI.replicas | int | `2` | Replica count for Longhorn UI. |
 | longhornUI.tolerations | list | `[]` | Toleration for Longhorn UI on nodes allowed to run Longhorn components. |
+| longhornUI.topologySpreadConstraints | list | `[]` | Topology spread constraints for Longhorn UI pods. Unlike `longhornUI.affinity`, these can guarantee that replicas stay spread across a topology domain during a rolling update or a mass reschedule. |
 
 ### Ingress Settings
 

--- a/chart/templates/deployment-ui.yaml
+++ b/chart/templates/deployment-ui.yaml
@@ -56,6 +56,10 @@ spec:
       serviceAccountName: longhorn-ui-service-account
       affinity:
       {{- toYaml .Values.longhornUI.affinity | nindent 8 }}
+      {{- with .Values.longhornUI.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       {{- if .Values.openshift.enabled }}
       {{- if .Values.openshift.ui.route }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -572,6 +572,16 @@ longhornUI:
                   values:
                     - longhorn-ui
             topologyKey: kubernetes.io/hostname
+  # -- Topology spread constraints for Longhorn UI pods. Unlike `longhornUI.affinity`, these can guarantee that replicas stay spread across a topology domain during a rolling update or a mass reschedule.
+  topologySpreadConstraints: []
+  ## If you want to set topology spread constraints for Longhorn UI Deployment, delete the `[]` in the line above
+  ## and uncomment this example block
+  # - maxSkew: 1
+  #   topologyKey: topology.kubernetes.io/zone
+  #   whenUnsatisfiable: DoNotSchedule
+  #   labelSelector:
+  #     matchLabels:
+  #       app: longhorn-ui
   # -- Toleration for Longhorn UI on nodes allowed to run Longhorn components.
   tolerations: []
   ## If you want to set tolerations for Longhorn UI Deployment, delete the `[]` in the line above


### PR DESCRIPTION
## Which issue(s) this PR fixes

Issue longhorn/longhorn#13731

## What this PR does / why we need it

Adds a `topologySpreadConstraints` passthrough to the `longhorn-ui` Deployment in the Helm chart, mirroring the existing `affinity` one. Opening this per @c3y1huang's request on the issue.

`chart/templates/deployment-ui.yaml` renders `affinity`, `tolerations`, `nodeSelector`, `priorityClassName` and `imagePullSecrets`, but no `topologySpreadConstraints`. That makes it impossible to *guarantee* that `longhorn-ui`'s two replicas stay spread across a custom topology domain (rack, hypervisor host, failure domain), and neither form of `podAntiAffinity` substitutes for it:

- **Soft `podAntiAffinity`** (the chart default, retargeted to a custom key) does not hold. A rolling update schedules both replacements as a *pair*, before either is Running, so the preference has nothing to repel against. Measured over 4 consecutive `kubectl rollout restart` attempts: 4/4 landed co-located.
- **Hard `podAntiAffinity`** deadlocks the roll. With `replicas: 2` and no `strategy` passthrough, the Deployment inherits `maxSurge: 25%` → 1 and `maxUnavailable: 25%` → 0. The surge pod must avoid both occupied domains, so there is no legal node and the rollout wedges.

`maxSkew` is a tolerance on the distribution, so it has slack sized exactly to the one-pod surge; `podAntiAffinity` is a per-pair boolean with zero slack. There is also no repair path today — the descheduler's `RemovePodsViolatingTopologySpreadConstraint` only selects workloads that *declare* `topologySpreadConstraints`, so a workload that cannot declare them is invisible to the plugin that would fix it.

Observed twice on a 7-node cluster with a custom `proxmox-host` topology label (2 hypervisors), both replicas landing on one host — once for ~29h after a chart upgrade, once for ~2 days after a power event and mass reschedule. Both times the workload looked healthy by every other measure.

## Special notes for your reviewer

The default is `[]` and the block is guarded with `{{- with }}`, so rendered output is byte-identical for anyone who does not set the value. `deploy/longhorn.yaml` is therefore unchanged.

`chart/README.md` carries the corresponding helm-docs row.

## Additional documentation or context

The issue is labelled `require/doc` and `require/backport`; happy to follow up with a `longhorn/website` PR once this lands.

Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/

## Test steps and results

```text
Test environment:
- Longhorn version/image: v1.12.1 (chart longhorn-1.12.1, longhornio/longhorn-ui:v1.12.1)
- Chart change built against: master @ 4f510d3
- Kubernetes version: v1.36.2+k3s1
- Kubernetes distribution: k3s
- Node count: 7 (3 server, 4 agent), spread over 2 Proxmox hypervisors carrying a custom `proxmox-host` topology label
- OS: Ubuntu 24.04.4 LTS
- Data engine: V1 (`v2-data-engine: false`)
- Installation method: Helm (chart deployed and reconciled by Argo CD)
- Helm client for the template/lint steps below: v4.2.4 on macOS
```

Steps 1-3 were run against the modified chart directory. Step 4 states what was **not** run and why.

**1. Defaults unchanged — no field rendered:**

```console
$ helm template lh chart/ -s templates/deployment-ui.yaml | grep -c topologySpreadConstraints
0
```

**2. Value set — renders correctly under the pod spec:**

```console
$ cat tsc.yaml
longhornUI:
  topologySpreadConstraints:
    - maxSkew: 1
      topologyKey: proxmox-host
      whenUnsatisfiable: DoNotSchedule
      labelSelector:
        matchLabels:
          app: longhorn-ui

$ helm template lh chart/ -s templates/deployment-ui.yaml -f tsc.yaml
...
    spec:
      serviceAccountName: longhorn-ui-service-account
      affinity:
        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
          - podAffinityTerm:
              labelSelector:
                matchExpressions:
                - key: app
                  operator: In
                  values:
                  - longhorn-ui
              topologyKey: kubernetes.io/hostname
            weight: 1
      topologySpreadConstraints:
        - labelSelector:
            matchLabels:
              app: longhorn-ui
          maxSkew: 1
          topologyKey: proxmox-host
          whenUnsatisfiable: DoNotSchedule
      containers:
...
```

**3. Lint:**

```console
$ helm lint chart/ -f tsc.yaml
==> Linting chart/

1 chart(s) linted, 0 chart(s) failed
```

**4. Not run - end-to-end deployment of the patched chart.** Reason: this repository holds the chart source only, and the change is a pure template passthrough guarded by `{{- with }}`. Step 1 shows the default render is byte-identical, so no existing installation can be affected. The scheduling behaviour the field enables is stock upstream `topologySpreadConstraints`, not Longhorn logic.

The co-location failures motivating the request **were** measured on the environment above, against the *current* chart: soft `podAntiAffinity` retargeted to `proxmox-host` left 4/4 consecutive `kubectl rollout restart` runs co-located, and a hard `podAntiAffinity` term wedged the rollout with the surge pod Pending. Details in longhorn/longhorn#13731.

**Result: PASS** for steps 1-3. Happy to stand up a scratch cluster and run an end-to-end Helm install/upgrade with the field set if reviewers want that before merge.

## Known risks, limitations, and follow-up work

- **Risk: none to existing installations.** The default is `[]` and the block is `{{- with }}`-guarded, so the rendered Deployment is unchanged unless a user opts in. `deploy/longhorn.yaml` is unchanged.
- **Compatibility:** `topologySpreadConstraints` on a pod spec is GA since Kubernetes 1.19, well below Longhorn's supported floor. No API-version gating needed.
- **Limitation:** this covers the `longhorn-ui` Deployment only. The CSI components are a separate concern tracked in #6959 and #12079.
- **Limitation:** `whenUnsatisfiable: DoNotSchedule` combined with `longhornUI.replicas` exceeding the number of topology domains can leave surplus replicas Pending. That is inherent to the primitive and the operator's choice to make; the values comment points at the upstream documentation.
- **Follow-up:** the issue carries `require/doc` and `require/backport`. I can open the `longhorn/website` documentation PR once this merges; backport targeting is left to maintainers.
- **Not addressed here:** a `strategy` passthrough for the same Deployment. It was considered and rejected in the issue as strictly worse - it needs two coordinated settings and still cannot express balance across N domains.
