### PR TITLE
feat(chart): mirror dataEngineTransport CRD field for v2 RDMA

### DIFF
--- a/chart/templates/crds.yaml
+++ b/chart/templates/crds.yaml
@@ -4593,6 +4593,18 @@ spec:
                 - v1
                 - v2
                 type: string
+              dataEngineTransport:
+                description: |-
+                  DataEngineTransport selects the NVMe-oF transport for the internal
+                  engine<->replica fabric of a v2 volume (tcp or rdma). Empty defaults to tcp.
+                  It is immutable and has no effect on v1 volumes.
+                enum:
+                - tcp
+                - rdma
+                type: string
+                x-kubernetes-validations:
+                - message: DataEngineTransport is immutable
+                  rule: self == oldSelf
               dataLayout:
                 description: |-
                   DataLayout declares the user's intended data layout (topology type, protection mode, and EC parameters).

--- a/deploy/longhorn-okd.yaml
+++ b/deploy/longhorn-okd.yaml
@@ -4966,6 +4966,18 @@ spec:
                 - v1
                 - v2
                 type: string
+              dataEngineTransport:
+                description: |-
+                  DataEngineTransport selects the NVMe-oF transport for the internal
+                  engine<->replica fabric of a v2 volume (tcp or rdma). Empty defaults to tcp.
+                  It is immutable and has no effect on v1 volumes.
+                enum:
+                - tcp
+                - rdma
+                type: string
+                x-kubernetes-validations:
+                - message: DataEngineTransport is immutable
+                  rule: self == oldSelf
               dataLayout:
                 description: |-
                   DataLayout declares the user's intended data layout (topology type, protection mode, and EC parameters).

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -4964,6 +4964,18 @@ spec:
                 - v1
                 - v2
                 type: string
+              dataEngineTransport:
+                description: |-
+                  DataEngineTransport selects the NVMe-oF transport for the internal
+                  engine<->replica fabric of a v2 volume (tcp or rdma). Empty defaults to tcp.
+                  It is immutable and has no effect on v1 volumes.
+                enum:
+                - tcp
+                - rdma
+                type: string
+                x-kubernetes-validations:
+                - message: DataEngineTransport is immutable
+                  rule: self == oldSelf
               dataLayout:
                 description: |-
                   DataLayout declares the user's intended data layout (topology type, protection mode, and EC parameters).


### PR DESCRIPTION
### What

Mirror the new `VolumeSpec.dataEngineTransport` field into the chart's generated CRD (`chart/templates/crds.yaml`) and the rendered install manifests (`deploy/longhorn.yaml`, `deploy/longhorn-okd.yaml`).

### Why

`chart/templates/crds.yaml` is a generated byte-mirror of `longhorn-manager/k8s/crds.yaml`. Without mirroring the new field here, a Helm- or manifest-based install validates Volume CRs against a CRD that lacks `dataEngineTransport`, and the API server prunes the field via structural-schema validation — the per-volume transport selection would silently disappear at apply time.

### How

- Added the `dataEngineTransport` block (enum `tcp|rdma`, default `tcp`, immutable) to the Volume CRD in `chart/templates/crds.yaml`, matching the manager-side generated block exactly.
- Regenerated `deploy/longhorn.yaml` and `deploy/longhorn-okd.yaml` with `scripts/generate-longhorn-yaml.sh` (helm v3.17.1). The diff is exactly the 12-line field addition in each of the three files — **no other drift**.

### Related

- Feature design + full PR set: longhorn/longhorn#13796
- Manager API/CRD source of truth: longhorn/longhorn-manager#5107

Chart/manifest companion required for the v2 RDMA (RoCEv2) NVMe-oF transport feature to survive a Helm install.

Ref: longhorn/longhorn#13796
