### PR TITLE
feat(chart): expose trafficDistribution for the Longhorn Services

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -148,12 +148,16 @@ The `values.yaml` contains items used to tweak a deployment of this chart.
 
 | Key | Description |
 |-----|-------------|
+| service.admissionWebhook.trafficDistribution | Traffic distribution preference for the Longhorn admission webhook service. (Options: "PreferSameZone", "PreferSameNode") When unspecified, Kubernetes distributes traffic across all endpoints. |
 | service.manager.nodePort | NodePort port number for Longhorn Manager. When unspecified, Longhorn selects a free port between 30000 and 32767. |
+| service.manager.trafficDistribution | Traffic distribution preference for the Longhorn Manager service. (Options: "PreferSameZone", "PreferSameNode") When unspecified, Kubernetes distributes traffic across all endpoints. |
 | service.manager.type | Service type for Longhorn Manager. |
+| service.recoveryBackend.trafficDistribution | Traffic distribution preference for the Longhorn recovery backend service. (Options: "PreferSameZone", "PreferSameNode") When unspecified, Kubernetes distributes traffic across all endpoints. |
 | service.ui.annotations | Annotation for the Longhorn UI service. |
 | service.ui.labels |  |
 | service.ui.loadBalancerClass | Class of a load balancer implementation |
 | service.ui.nodePort | NodePort port number for Longhorn UI. When unspecified, Longhorn selects a free port between 30000 and 32767. |
+| service.ui.trafficDistribution | Traffic distribution preference for the Longhorn UI service. (Options: "PreferSameZone", "PreferSameNode") When unspecified, Kubernetes distributes traffic across all endpoints. |
 | service.ui.type | Service type for Longhorn UI. (Options: "ClusterIP", "NodePort", "LoadBalancer", "Rancher-Proxy") |
 
 ### StorageClass Settings

--- a/chart/templates/daemonset-sa.yaml
+++ b/chart/templates/daemonset-sa.yaml
@@ -215,7 +215,7 @@ metadata:
 spec:
   type: {{ .Values.service.manager.type }}
   {{- with .Values.service.manager.trafficDistribution }}
-  trafficDistribution: {{ . }}
+  trafficDistribution: {{ . | quote }}
   {{- end }}
   selector:
     app: longhorn-manager

--- a/chart/templates/daemonset-sa.yaml
+++ b/chart/templates/daemonset-sa.yaml
@@ -214,6 +214,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.manager.type }}
+  {{- with .Values.service.manager.trafficDistribution }}
+  trafficDistribution: {{ . }}
+  {{- end }}
   selector:
     app: longhorn-manager
   ports:

--- a/chart/templates/deployment-ui.yaml
+++ b/chart/templates/deployment-ui.yaml
@@ -190,6 +190,9 @@ spec:
   {{- if and (eq .Values.service.ui.type "LoadBalancer") .Values.service.ui.loadBalancerClass }}
   loadBalancerClass: {{ .Values.service.ui.loadBalancerClass }}
   {{- end }}
+  {{- with .Values.service.ui.trafficDistribution }}
+  trafficDistribution: {{ . }}
+  {{- end }}
   selector:
     app: longhorn-ui
   ports:

--- a/chart/templates/deployment-ui.yaml
+++ b/chart/templates/deployment-ui.yaml
@@ -191,7 +191,7 @@ spec:
   loadBalancerClass: {{ .Values.service.ui.loadBalancerClass }}
   {{- end }}
   {{- with .Values.service.ui.trafficDistribution }}
-  trafficDistribution: {{ . }}
+  trafficDistribution: {{ . | quote }}
   {{- end }}
   selector:
     app: longhorn-ui

--- a/chart/templates/services.yaml
+++ b/chart/templates/services.yaml
@@ -7,6 +7,9 @@ metadata:
   namespace: {{ include "release_namespace" . }}
 spec:
   type: ClusterIP
+  {{- with .Values.service.admissionWebhook.trafficDistribution }}
+  trafficDistribution: {{ . }}
+  {{- end }}
   selector:
     longhorn.io/admission-webhook: longhorn-admission-webhook
   ports:
@@ -23,6 +26,9 @@ metadata:
   namespace: {{ include "release_namespace" . }}
 spec:
   type: ClusterIP
+  {{- with .Values.service.recoveryBackend.trafficDistribution }}
+  trafficDistribution: {{ . }}
+  {{- end }}
   selector:
     longhorn.io/recovery-backend: longhorn-recovery-backend
   ports:

--- a/chart/templates/services.yaml
+++ b/chart/templates/services.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   type: ClusterIP
   {{- with .Values.service.admissionWebhook.trafficDistribution }}
-  trafficDistribution: {{ . }}
+  trafficDistribution: {{ . | quote }}
   {{- end }}
   selector:
     longhorn.io/admission-webhook: longhorn-admission-webhook

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -153,6 +153,8 @@ service:
   ui:
     # -- Service type for Longhorn UI. (Options: "ClusterIP", "NodePort", "LoadBalancer", "Rancher-Proxy")
     type: ClusterIP
+    # -- Traffic distribution preference for the Longhorn UI service. (Options: "PreferSameZone", "PreferSameNode") When unspecified, Kubernetes distributes traffic across all endpoints.
+    trafficDistribution: ""
     # -- NodePort port number for Longhorn UI. When unspecified, Longhorn selects a free port between 30000 and 32767.
     nodePort: null
     # -- Class of a load balancer implementation
@@ -173,6 +175,14 @@ service:
     type: ClusterIP
     # -- NodePort port number for Longhorn Manager. When unspecified, Longhorn selects a free port between 30000 and 32767.
     nodePort: ""
+    # -- Traffic distribution preference for the Longhorn Manager service. (Options: "PreferSameZone", "PreferSameNode") When unspecified, Kubernetes distributes traffic across all endpoints.
+    trafficDistribution: ""
+  admissionWebhook:
+    # -- Traffic distribution preference for the Longhorn admission webhook service. (Options: "PreferSameZone", "PreferSameNode") When unspecified, Kubernetes distributes traffic across all endpoints.
+    trafficDistribution: ""
+  recoveryBackend:
+    # -- Traffic distribution preference for the Longhorn recovery backend service. (Options: "PreferSameZone", "PreferSameNode") When unspecified, Kubernetes distributes traffic across all endpoints.
+    trafficDistribution: ""
 persistence:
   # -- Setting that allows you to create the default Longhorn StorageClass ConfigMap. Set to false to skip StorageClass creation.
   createStorageClass: true


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue #13814 

#### What this PR does / why we need it:

Adds `service.{ui,manager,admissionWebhook,recoveryBackend}.trafficDistribution`, mapping to `longhorn-frontend`, `longhorn-backend`, `longhorn-admission-webhook` and `longhorn-recovery-backend`.

#### Special notes for your reviewer:

Each value defaults to `""` and renders through `{{- with }}`, so the field is omitted unless set.

`helm template` output is byte-identical to `master` with default values, and with a real production `values.yaml`. Setting one value leaves the other three Services untouched; checked for all four.

No validation in the chart, on purpose: the API server already rejects bad values and lists the supported ones, and stays correct as Kubernetes adds more.
Same as `service.ui.type` today. Happy to add a `fail` guard if you prefer.

`longhorn-frontend` is included for consistency even though many users run a single UI replica.

`chart/README.md` generated with `scripts/helm-docs.sh`

#### Additional documentation or context

Verified against Kubernetes v1.36.
Every rendered Service passed `kubectl apply --dry-run=server`, including the combinations that touch the same templates (`service.ui.type=LoadBalancer` with `loadBalancerClass`, `NodePort` with `nodePort` for both ui and manager, `openshift.enabled=true`, and all four values at once).

`helm lint` clean