### PR TITLE
fix: revert "fix: mount manager data path from default-data-path"

### DIFF
--- a/chart/questions.yaml
+++ b/chart/questions.yaml
@@ -315,14 +315,7 @@ questions:
       - variable: defaultSettings.defaultDataPath
         label: Default Data Path
         description: >-
-          Default path to use for storing data on a host. An absolute directory path indicates a filesystem-type disk used by the V1 Data Engine, while a path to a block device indicates a block-type disk used by the V2 Data Engine. When this setting is a block device path, runtime and control-plane paths are configured separately by default-control-path. The default value is "/var/lib/longhorn/".
-        group: Longhorn Default Settings
-        type: string
-        default: /var/lib/longhorn/
-      - variable: defaultSettings.defaultControlPath
-        label: Default Control Path
-        description: >-
-          Default path to use for storing runtime and control-plane artifacts on a host. This setting must be an absolute directory path. Engine binaries, metadata, sockets, and logs are stored under this path. The default value is "/var/lib/longhorn/".
+          Default path to use for storing data on a host. An absolute directory path indicates a filesystem-type disk used by the V1 Data Engine, while a path to a block device indicates a block-type disk used by the V2 Data Engine. The default value is "/var/lib/longhorn/".
         group: Longhorn Default Settings
         type: string
         default: /var/lib/longhorn/

--- a/chart/templates/daemonset-sa.yaml
+++ b/chart/templates/daemonset-sa.yaml
@@ -18,8 +18,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      {{- $longhornDataPath := default "/var/lib/longhorn/" .Values.defaultSettings.defaultDataPath }}
-      {{- $longhornControlPath := default "/var/lib/longhorn/" .Values.defaultSettings.defaultControlPath }}
       containers:
       - name: longhorn-manager
         image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.manager.registry "docker.io") }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
@@ -75,12 +73,8 @@ spec:
           mountPath: /host/etc/
           readOnly: true
         - name: longhorn
-          mountPath: {{ $longhornDataPath | quote }}
+          mountPath: /var/lib/longhorn/
           mountPropagation: Bidirectional
-        {{- if ne $longhornControlPath $longhornDataPath }}
-        - name: longhorn-control
-          mountPath: {{ $longhornControlPath | quote }}
-        {{- end }}
         - name: longhorn-grpc-tls
           mountPath: /tls-files/
         {{- if .Values.enableGoCoverDir }}
@@ -104,10 +98,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        - name: LONGHORN_DATA_PATH
-          value: {{ $longhornDataPath | quote }}
-        - name: LONGHORN_CONTROL_PATH
-          value: {{ $longhornControlPath | quote }}
         {{- if .Values.longhornManager.distro }}
         - name: LONGHORN_DISTRO
           value: {{ .Values.longhornManager.distro | quote }}
@@ -140,13 +130,7 @@ spec:
           path: /etc/
       - name: longhorn
         hostPath:
-          path: {{ $longhornDataPath | quote }}
-      {{- if ne $longhornControlPath $longhornDataPath }}
-      - name: longhorn-control
-        hostPath:
-          path: {{ $longhornControlPath | quote }}
-          type: DirectoryOrCreate
-      {{- end }}
+          path: /var/lib/longhorn/
       {{- if .Values.enableGoCoverDir }}
       - name: go-cover-dir
         hostPath:

--- a/chart/templates/default-setting.yaml
+++ b/chart/templates/default-setting.yaml
@@ -15,9 +15,6 @@ data:
     {{- if not (kindIs "invalid" .Values.defaultSettings.defaultDataPath) }}
     default-data-path: {{ .Values.defaultSettings.defaultDataPath | quote }}
     {{- end }}
-    {{- if not (kindIs "invalid" .Values.defaultSettings.defaultControlPath) }}
-    default-control-path: {{ .Values.defaultSettings.defaultControlPath | quote }}
-    {{- end }}
     {{- if not (kindIs "invalid" .Values.defaultSettings.replicaSoftAntiAffinity) }}
     replica-soft-anti-affinity: {{ .Values.defaultSettings.replicaSoftAntiAffinity }}
     {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -270,8 +270,6 @@ defaultSettings:
   createDefaultDiskLabeledNodes: ~
   # -- Default path to use for storing data on a host. An absolute directory path indicates a filesystem-type disk used by the V1 Data Engine, while a path to a block device indicates a block-type disk used by the V2 Data Engine. The default value is "/var/lib/longhorn/".
   defaultDataPath: ~
-  # -- Default path to use for storing runtime and control-plane artifacts on a host. This setting must be an absolute directory path. The default value is "/var/lib/longhorn/".
-  defaultControlPath: ~
   # -- Default data locality. A Longhorn volume has data locality if a local replica of the volume exists on the same node as the pod that is using the volume.
   defaultDataLocality: ~
   # -- Setting that allows scheduling on nodes with healthy replicas of the same volume. This setting is disabled by default.

--- a/deploy/longhorn-okd.yaml
+++ b/deploy/longhorn-okd.yaml
@@ -6007,7 +6007,7 @@ spec:
           mountPath: /host/etc/
           readOnly: true
         - name: longhorn
-          mountPath: "/var/lib/longhorn/"
+          mountPath: /var/lib/longhorn/
           mountPropagation: Bidirectional
         - name: longhorn-grpc-tls
           mountPath: /tls-files/
@@ -6028,10 +6028,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        - name: LONGHORN_DATA_PATH
-          value: "/var/lib/longhorn/"
-        - name: LONGHORN_CONTROL_PATH
-          value: "/var/lib/longhorn/"
         - name: LONGHORN_DISTRO
           value: "longhorn"
         
@@ -6054,7 +6050,7 @@ spec:
           path: /etc/
       - name: longhorn
         hostPath:
-          path: "/var/lib/longhorn/"
+          path: /var/lib/longhorn/
       - name: longhorn-grpc-tls
         secret:
           secretName: longhorn-grpc-tls

--- a/deploy/longhorn.yaml
+++ b/deploy/longhorn.yaml
@@ -5944,7 +5944,7 @@ spec:
           mountPath: /host/etc/
           readOnly: true
         - name: longhorn
-          mountPath: "/var/lib/longhorn/"
+          mountPath: /var/lib/longhorn/
           mountPropagation: Bidirectional
         - name: longhorn-grpc-tls
           mountPath: /tls-files/
@@ -5965,10 +5965,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        - name: LONGHORN_DATA_PATH
-          value: "/var/lib/longhorn/"
-        - name: LONGHORN_CONTROL_PATH
-          value: "/var/lib/longhorn/"
         - name: LONGHORN_DISTRO
           value: "longhorn"
         
@@ -5991,7 +5987,7 @@ spec:
           path: /etc/
       - name: longhorn
         hostPath:
-          path: "/var/lib/longhorn/"
+          path: /var/lib/longhorn/
       - name: longhorn-grpc-tls
         secret:
           secretName: longhorn-grpc-tls


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

https://github.com/longhorn/longhorn/issues/9083


#### Special notes for your reviewer:

https://github.com/longhorn/longhorn/issues/9083#issuecomment-5404695306