### PR TITLE
docs(lep): new data engine for strict-local volumes

### DIFF
--- a/enhancements/20260826-local-data-engine.md
+++ b/enhancements/20260826-local-data-engine.md
@@ -1,0 +1,334 @@
+# Local Data Engine
+
+## Summary
+
+Longhorn supports `strict-local` data locality, which is designed for latency-sensitive applications. In
+practice, however, it remains significantly slower than local-disk storage because I/O must still traverse a
+data path designed for distributed block storage. This enhancement proposes a local-only Longhorn data engine
+backed by LVM logical volumes. It removes the Longhorn engine and replica processes from the data path. Each
+volume is exposed directly as a local kernel block device, allowing I/O to pass through the kernel LVM stack
+to the physical disk. This delivers near-local-disk performance while retaining the same properties as
+existing `strict-local` volumes.
+
+### Related Issues
+
+- https://github.com/longhorn/longhorn/issues/13481
+
+Measured results for the design described here are in the companion report,
+[Local Data Engine Performance Benchmark](./assets/local-data-engine/performance-benchmark.md).
+
+## Motivation
+
+### Goals
+
+- Deliver performance close to that of a local disk.
+- Remove all Longhorn userspace processes and network transports from the I/O path.
+- Integrate the LVM-based local data engine into Longhorn so that one storage system can provide both
+  high-performance replicated volumes and high-performance local volumes.
+  - Support v1/v2 features that do not depend on synchronous replication:
+    - Over-provisioning.
+    - Snapshots, backups, and restores.
+    - Encryption.
+
+### Non-goals
+
+- Synchronous replication, automatic replica rebuild, or transparent failover after node or disk loss.
+- Asynchronous replication or automatic failover after node or disk loss.
+  - Asynchronous replication may be considered in the future, but it cannot prevent partial data loss.
+- Read-write-many volumes or simultaneous attachment from multiple nodes.
+
+### Advantages over v1/v2 `strict-local` volumes
+
+- Significantly better performance than v1/v2 `strict-local` volumes.
+- No Longhorn userspace components in the data path.
+  - There is no engine process comparable to v1/v2, so engine live upgrades are unnecessary.
+  - This is especially valuable for v2, where live upgrades of `strict-local` volumes would be complicated,
+    if not impossible.
+  - The instance manager operates only in the control plane, handling volume and disk lifecycle operations.
+
+### Advantages over using standalone LVM storage providers
+
+- Automatic physical volume and volume group management. Unlike TopoLVM and OpenEBS LocalPV-LVM, which
+  require administrators to create and manage volume groups in advance, Longhorn will manage:
+  - Physical volume initialization.
+  - Volume group creation and expansion.
+- Integrated backup and restore.
+  - TopoLVM and OpenEBS LocalPV-LVM do not offer backup and restore natively and rely on third-party tools
+    such as Velero.
+- Out-of-the-box encryption.
+  - TopoLVM and OpenEBS LocalPV-LVM require administrator-created dm-crypt devices.
+- A single storage system and operational model.
+  - Users do not need to deploy and manage Longhorn alongside a separate local-storage provider.
+
+## User Stories
+
+### Story 1 — One storage system instead of two
+
+An operator uses Longhorn for workloads that require replicated storage. The same cluster also runs
+latency-sensitive applications that provide their own replication and need local-only volumes, but existing
+`strict-local` volumes do not meet their performance requirements.
+
+By enabling the local data engine and selecting it through a StorageClass, the operator can manage replicated
+and local-only volumes through the same Longhorn installation, CRDs, CSI driver, UI, monitoring, backup
+targets, and operational knowledge. There is no need to deploy and maintain a second CSI storage system.
+
+### Story 2 — Instance-manager upgrades without I/O interruption
+
+An operator needs to roll out a new instance-manager image while local-storage workloads continue to serve
+traffic.
+
+Because an attached local volume is a kernel device-mapper device, its I/O does not depend on the instance
+manager process. Restarting or replacing the instance-manager pod temporarily pauses new control-plane
+operations, while reads and writes to existing mounts continue uninterrupted.
+
+### User Experience In Detail
+
+The administrator enables the local data engine and adds an LVM-type disk to a Longhorn Node resource. The
+instance manager contains the required `lvm2` tools, so the host does not need to provide them. When the disk
+is registered, the instance manager verifies that it has no existing filesystem or partition table,
+initializes it as a physical volume, and creates its volume group.
+
+The host prerequisites are the ones Longhorn already requires. The instance-manager pod is privileged and
+mounts the host root filesystem for every data engine, so it already reaches the host's block devices and
+`/dev/mapper/control`, and the existing environment check already probes for the `device-mapper` host package
+and the `dm_crypt` module. Thin mode is the only case that adds a requirement: it needs the `dm_thin_pool`
+module, which the environment check does not cover today, so it is added to the checked modules when the
+local data engine is enabled.
+
+A user selects the local data engine through a StorageClass and creates a PVC normally. Longhorn enforces
+`strict-local` data locality and exactly one replica. When the `csi-storage-capacity-tracking` setting is
+enabled, the kube-scheduler filters out nodes that cannot fit the requested volume; otherwise it places the
+pod without regard to local capacity, and provisioning fails on a node without enough capacity. The instance
+manager then creates a logical volume, and CSI formats and mounts the logical-volume device directly into the
+workload.
+
+### API Changes
+
+- Add one data-engine identifier for the local data engine.
+- Add `lvm` as a disk type.
+- Add the `local-data-engine` setting that enables or disables the local data engine.
+- Add the `local-data-engine-provisioning-mode` setting, with the options `thick` and `thin`.
+- Add an immutable Volume spec field recording the effective provisioning mode. It is empty for v1 and v2
+  volumes.
+- Add a `localProvisioningMode` StorageClass parameter.
+- Add the `local-data-engine-storage-layout` setting, with the options `per-disk` and `per-node`.
+- Extend the node environment check to require the `dm_thin_pool` kernel module when the local data engine
+  is enabled in thin mode. No other host prerequisite is added.
+- Extend the instance-manager protobuf data-engine and disk-type enumerations.
+- Extend the existing CRD validation enums and generated clients for the new values.
+- Do not add new Kubernetes resource kinds. Existing Volume, Engine, Replica, Node, VolumeAttachment,
+  Snapshot, Backup, and related resources are reused.
+
+The name for the new data engine must be decided. This document uses `local`, but `vlocal`, `v-local`, `v0`,
+and `v3` remain alternatives until the LEP review is complete.
+
+## Design
+
+### Terminology
+
+| Term | Meaning |
+|---|---|
+| PV (physical volume) | A block device initialized for LVM use. |
+| VG (volume group) | A storage pool formed from one or more PVs. Logical volumes are allocated from its extents. |
+| LV (logical volume) | A block device allocated from a VG and exposed at `/dev/<vg>/<lv>`. |
+| Thick LV | An LV that reserves its full physical capacity at creation and maps logical blocks to fixed VG extents. |
+| Thin pool | A special LV holding the data and metadata of thin LVs. |
+| Thin LV | An LV that reserves virtual capacity only and allocates chunks from a thin pool as it is written, which is what allows over-provisioning. |
+
+### Object Model
+
+Existing Longhorn resources retain their control-plane roles:
+
+| Longhorn object | Local-engine representation                                           |
+|---|-----------------------------------------------------------------------|
+| Replica | The thick or thin logical volume (LV) containing the volume data      |
+| Engine | The `longhorn-engine=<engine-name>` tag on the replica LV; no process |
+| Volume | The existing user-facing Longhorn volume                              |
+
+LVM has no Engine equivalent, but Longhorn's control-plane model depends on the Engine entity. Removing it
+only for the local data engine would require substantial changes across the existing controllers. To
+preserve this model, the Replica and Engine must represent the 3 lifecycle states below. The simplest
+mapping uses LV activation for Replica state and an LV tag for Engine state:
+
+```text
+1. LV inactive                      Replica stopped    Engine stopped
+       │ activate
+       ▼
+2. LV active, no engine tag         Replica running    Engine stopped
+       │ add tag longhorn-engine=<name>
+       ▼
+3. LV active, engine tag present    Replica running    Engine running
+```
+
+This design minimizes local engine specific controller code while keeping the Engine representation as
+lightweight as possible. The tag persists in LVM metadata, allowing the instance manager to rediscover the
+attachment after restarting without adding another process, device-mapper layer, or state store.
+
+The local engine always uses one replica and `strict-local` placement. Admission validation rejects any
+other replica count, locality, shared-access, or migration configuration.
+
+### Thin Versus Thick Provisioning
+
+A thick LV reserves its requested physical capacity when it is created and maps logical blocks directly to
+fixed VG extents. This provides predictable capacity and a simple data path close to direct-disk
+performance.
+
+A thin LV reserves virtual capacity, while physical chunks are allocated from a shared thin pool as data is
+written. This permits over-provisioning.
+
+Thin snapshots are also cheaper than classic thick LVM snapshots. A thin snapshot is created through
+metadata operations, reserves no separate fixed-size COW volume, and shares unchanged chunks with the source
+and other snapshots. A thick snapshot requires a separate COW LV with reserved capacity; when source data
+changes, the original blocks must be copied into the applicable snapshot COW volumes. Its capacity
+consumption and write amplification can therefore increase as snapshots accumulate.
+
+#### Provisioning options
+
+The local data engine operates in one cluster-wide provisioning mode:
+
+- **`thick`** (default) fully allocates each LV. It does not support over-provisioning.
+- **`thin`** uses thin LVs and zeroes newly allocated pool chunks before exposing them.
+
+Thick is the default because it offers the most predictable performance. The mode can change only when no
+local data engine volumes exist. Each local StorageClass may declare its expected mode through the
+`localProvisioningMode` parameter. If the parameter is omitted, it defaults to `thick`. Provisioning is
+rejected when the StorageClass mode differs from the cluster-wide mode, preventing an outdated StorageClass
+from silently creating a different kind of volume.
+
+Each Volume records the effective provisioning mode in an immutable spec field. This field remains
+authoritative for expansion, actual-size accounting, snapshot validation. It is empty for v1 and v2 volumes.
+
+In thin mode, creating the first volume in a VG creates a thin pool named `longhorn-thin-pool`. The
+pool reserves 5 GiB of the VG for metadata, metadata repair, and future metadata expansion, and uses the
+remaining capacity for pool data. Deleting the last thin LV in the VG also deletes the thin pool, so no empty
+thin pool remains in any VG.
+
+If the managed thin pool exists, disk status reports its data capacity and usage as well as metadata
+fullness. Otherwise, disk status reports VG capacity and free extents. Thin mode respects Longhorn's global
+storage over-provisioning setting. Thick mode limits effective over-provisioning to 100%, regardless of a
+higher global value.
+
+For thick LVs, actual size equals the provisioned size. For thin LVs without snapshots, actual size is the
+physically allocated data. Thin volumes with snapshots require snapshot-aware accounting so that chunks
+shared by the head and snapshots are not counted more than once.
+
+Supporting both modes on the same disk at once was considered and deliberately rejected, because every way of
+sharing one VG between thick LVs and a thin pool complicates capacity accounting. A fixed split, such as
+50/50, wastes whichever side is idle. Growing the thin pool as thin volumes are scheduled is workable, but
+LVM cannot shrink a thin pool once it has been extended, so capacity freed by a deleted thin volume stays
+locked in the pool, and replica scheduling and over-provisioning accounting then have to reason about
+capacity that is neither in use nor available. A dedicated disk type per mode would avoid the shared-capacity
+problem, but it adds another disk concept for administrators to manage. One cluster-wide mode keeps capacity
+accounting unambiguous. This can be revisited if there is demand for mixing the two.
+
+### Node storage layout
+
+The local data engine operates in one cluster-wide storage layout:
+
+- **`per-disk`** (default) creates a separate VG for each LVM disk.
+- **`per-node`** adds all LVM disks on a node to one shared VG. This layout is risky because failure of a
+  single member disk can make all local volumes on the node unusable.
+
+#### Per-disk mode
+
+```text
+Disk 1 ─► PV 1 ─► VG 1
+Disk 2 ─► PV 2 ─► VG 2
+Disk 3 ─► PV 3 ─► VG 3
+```
+
+Every disk reports its VG capacity and is independently schedulable.
+
+#### Per-node mode
+
+```text
+Disk 1 ─► PV 1 (representative) ─┐
+Disk 2 ─► PV 2 (member)          ├─► one node VG
+Disk 3 ─► PV 3 (member)         ─┘
+```
+
+The representative disk reports the shared VG capacity and receives all replica assignments. Other members
+remain visible and ready but report zero schedulable capacity, preventing the shared capacity from being
+counted more than once.
+
+Each disk is identified by its PV UUID. VGs use opaque, randomly generated names such as`longhorn-vg-a7f3c921`.
+
+Adding a disk in `per-node` mode extends the existing VG. If the VG contains a managed thin pool, the new
+capacity also extends that pool.
+
+The layout can change only while every node has at most one LVM disk. The representative disk cannot be
+removed while the VG has other PVs; member disks must be removed first. No disk can be removed while its VG
+contains LVs.
+
+### LVM command execution
+
+All instance-manager LVM commands use `--devicesfile longhorn.devices`. Longhorn persists this file on the
+host and mounts it into local instance-manager pods, keeping the managed-device set consistent across pod
+restarts and upgrades. This cleanly isolates Longhorn-managed LVM storage from other LVM configurations on
+the host, prevents Longhorn from modifying unrelated devices, and avoids failures or hangs caused by LVM
+scanning unresponsive devices that do not belong to Longhorn.
+
+LVM normally delegates device-node management to udev and synchronizes through udev cookies, which would
+require the instance-manager pod to share the host IPC namespace. Because host IPC is invasive and may be
+blocked in security-restricted environments, udev integration is disabled entirely with
+`--config 'devices { external_device_info_source = "none" } activation { udev_sync = 0 udev_rules = 0 }'`.
+LVM and device-mapper then work without udev, managing device nodes themselves and synchronously in the
+host-bound `/dev`.
+
+### Continuous I/O During Instance Manager Restart or Upgrade
+
+During a local instance-manager restart, the replica state and volume robustness temporarily become
+`unknown`, because the control plane cannot confirm the LV state. The volume remains attached and the
+workload pod is not disturbed: its I/O continues through the existing kernel device-mapper device without
+depending on the instance manager. When the replacement instance manager rediscovers the LV, the replica
+returns to `running` and the volume robustness returns to `healthy`.
+
+### Metrics
+
+Capacity and health metrics come from LVM status. In thick mode, disk status reports VG capacity and free
+space. In thin mode, it reports thin-pool data capacity and usage, so the disk is not reported as having no
+free space and allocated capacity is represented correctly. I/O throughput, IOPS, and latency are derived
+from Linux block-device statistics for each LV and disk.
+
+### Snapshots
+
+Snapshots use native LVM thin snapshots and are therefore available in thin provisioning mode. Snapshot
+creation is a metadata operation, and the source and snapshot share unchanged chunks until one of them is
+modified. Whether thick volumes should also support snapshots, through classic COW LVs, is still open.
+
+### Backup and Restore
+
+The existing Longhorn backup control plane, recurring jobs, backup format, deduplication, compression,
+backup targets, retention, and garbage collection are reused. The local engine implements the engine-side
+operations required to read a snapshot, identify changed ranges, and write restored blocks to a new LV.
+
+Changed blocks can be obtained from thin-pool metadata using `thin_delta`. Longhorn backup blocks use a
+fixed 2 MiB unit, so changed thin-pool chunks must be coalesced into aligned 2 MiB ranges. If efficient delta
+calculation is unavailable, the implementation can conservatively report all backup blocks; checksum-based
+deduplication preserves correctness at the cost of additional reads.
+
+A completed off-node backup is the only Longhorn-managed protection against permanent loss of a local
+volume. The UI and documentation must state this explicitly and expose the time of the last successful
+backup.
+
+### Encryption
+
+Encryption reuses Longhorn's CSI-layer LUKS/dm-crypt flow. The encrypted mapping sits above the LV, so
+the data path remains kernel-only.
+
+### Test Plan
+
+A comprehensive end-to-end test suite is added for the local data engine. Because the change also touches
+shared data-engine dispatch, the existing v1 and v2 regression suites must continue to pass.
+
+Benchmarks comparing `strict-local` v1 and v2 volumes, a directly consumed local disk, and the local data
+engine are also part of validation. The local data engine is expected to perform within a single-digit
+percentage of direct local-disk performance.
+
+## Upgrade Strategy
+
+There is no per-volume or per-node engine binary to upgrade. Instance manager upgrades temporarily
+prevent disk/volume management operations on the affected node, but attached volumes continue I/O through
+the kernel device-mapper stack.
+
+## Alternatives Considered

--- a/enhancements/assets/images/local-data-engine/read-iops.svg
+++ b/enhancements/assets/images/local-data-engine/read-iops.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1515" height="689" viewBox="0 0 1515 689">
+<rect width="100%" height="100%" fill="white"/>
+<text x="30" y="56" font-family="Arial, sans-serif" font-size="25" fill="#6f6f6f">Read IOPS</text>
+<line x1="95" y1="614.0" x2="945" y2="614.0" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="619.0" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">0</text>
+<line x1="95" y1="563.6" x2="945" y2="563.6" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="513.2" x2="945" y2="513.2" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="518.2" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">240,000</text>
+<line x1="95" y1="462.8" x2="945" y2="462.8" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="412.4" x2="945" y2="412.4" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="417.4" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">480,000</text>
+<line x1="95" y1="362.0" x2="945" y2="362.0" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="311.6" x2="945" y2="311.6" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="316.6" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">720,000</text>
+<line x1="95" y1="261.2" x2="945" y2="261.2" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="210.8" x2="945" y2="210.8" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="215.8" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">960,000</text>
+<line x1="95" y1="160.4" x2="945" y2="160.4" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="110.0" x2="945" y2="110.0" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="115.0" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">1.2M</text>
+<line x1="95" y1="614" x2="945" y2="614" stroke="#333" stroke-width="1"/>
+<rect x="317.0" y="184.5" width="42" height="429.5" fill="#999999"><title>Direct NVMe (baseline): 1,022,730.35</title></rect>
+<rect x="369.0" y="600.9" width="42" height="13.1" fill="#ff1010"><title>v1 strict-local: 31,131.65</title></rect>
+<rect x="421.0" y="597.4" width="42" height="16.6" fill="#c6d9f1"><title>v2 best-effort, 1 CPU: 39,595.17</title></rect>
+<rect x="473.0" y="531.9" width="42" height="82.1" fill="#8db4e2"><title>v2 best-effort, 4 CPUs: 195,474.15</title></rect>
+<rect x="525.0" y="475.0" width="42" height="139.0" fill="#4f81bd"><title>v2 best-effort, 8 CPUs: 330,945.14</title></rect>
+<rect x="577.0" y="497.8" width="42" height="116.2" fill="#1f4e79"><title>v2 best-effort, 16 CPUs: 276,735.99</title></rect>
+<rect x="629.0" y="176.1" width="42" height="437.9" fill="#70ad47"><title>Local engine, thick: 1,042,598.24</title></rect>
+<rect x="681.0" y="352.7" width="42" height="261.3" fill="#f2c94c"><title>Local engine, thin: 622,126.60</title></rect>
+<text x="520.0" y="642" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" fill="#333">1 replica</text>
+<rect x="995" y="100" width="13" height="13" fill="#999999"/>
+<text x="1017" y="112" font-family="Arial, sans-serif" font-size="14" fill="#333">Direct NVMe (baseline)</text>
+<rect x="995" y="134" width="13" height="13" fill="#ff1010"/>
+<text x="1017" y="146" font-family="Arial, sans-serif" font-size="14" fill="#333">v1 strict-local</text>
+<rect x="995" y="168" width="13" height="13" fill="#c6d9f1"/>
+<text x="1017" y="180" font-family="Arial, sans-serif" font-size="14" fill="#333">v2 best-effort, 1 CPU</text>
+<rect x="995" y="202" width="13" height="13" fill="#8db4e2"/>
+<text x="1017" y="214" font-family="Arial, sans-serif" font-size="14" fill="#333">v2 best-effort, 4 CPUs</text>
+<rect x="995" y="236" width="13" height="13" fill="#4f81bd"/>
+<text x="1017" y="248" font-family="Arial, sans-serif" font-size="14" fill="#333">v2 best-effort, 8 CPUs</text>
+<rect x="995" y="270" width="13" height="13" fill="#1f4e79"/>
+<text x="1017" y="282" font-family="Arial, sans-serif" font-size="14" fill="#333">v2 best-effort, 16 CPUs</text>
+<rect x="995" y="304" width="13" height="13" fill="#70ad47"/>
+<text x="1017" y="316" font-family="Arial, sans-serif" font-size="14" fill="#333">Local engine, thick</text>
+<rect x="995" y="338" width="13" height="13" fill="#f2c94c"/>
+<text x="1017" y="350" font-family="Arial, sans-serif" font-size="14" fill="#333">Local engine, thin</text>
+</svg>

--- a/enhancements/assets/images/local-data-engine/read-latency.svg
+++ b/enhancements/assets/images/local-data-engine/read-latency.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1515" height="689" viewBox="0 0 1515 689">
+<rect width="100%" height="100%" fill="white"/>
+<text x="30" y="56" font-family="Arial, sans-serif" font-size="25" fill="#6f6f6f">Read Latency (microseconds)</text>
+<line x1="95" y1="614.0" x2="945" y2="614.0" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="619.0" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">0</text>
+<line x1="95" y1="563.6" x2="945" y2="563.6" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="513.2" x2="945" y2="513.2" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="518.2" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">80</text>
+<line x1="95" y1="462.8" x2="945" y2="462.8" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="412.4" x2="945" y2="412.4" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="417.4" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">160</text>
+<line x1="95" y1="362.0" x2="945" y2="362.0" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="311.6" x2="945" y2="311.6" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="316.6" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">240</text>
+<line x1="95" y1="261.2" x2="945" y2="261.2" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="210.8" x2="945" y2="210.8" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="215.8" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">320</text>
+<line x1="95" y1="160.4" x2="945" y2="160.4" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="110.0" x2="945" y2="110.0" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="115.0" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">400</text>
+<line x1="95" y1="614" x2="945" y2="614" stroke="#333" stroke-width="1"/>
+<rect x="317.0" y="525.2" width="42" height="88.8" fill="#999999"><title>Direct NVMe (baseline): 70.48</title></rect>
+<rect x="369.0" y="226.2" width="42" height="387.8" fill="#ff1010"><title>v1 strict-local: 307.80</title></rect>
+<rect x="421.0" y="396.9" width="42" height="217.1" fill="#c6d9f1"><title>v2 best-effort, 1 CPU: 172.28</title></rect>
+<rect x="473.0" y="436.6" width="42" height="177.4" fill="#8db4e2"><title>v2 best-effort, 4 CPUs: 140.77</title></rect>
+<rect x="525.0" y="406.8" width="42" height="207.2" fill="#4f81bd"><title>v2 best-effort, 8 CPUs: 164.43</title></rect>
+<rect x="577.0" y="445.2" width="42" height="168.8" fill="#1f4e79"><title>v2 best-effort, 16 CPUs: 134.00</title></rect>
+<rect x="629.0" y="519.9" width="42" height="94.1" fill="#70ad47"><title>Local engine, thick: 74.72</title></rect>
+<rect x="681.0" y="515.5" width="42" height="98.5" fill="#f2c94c"><title>Local engine, thin: 78.17</title></rect>
+<text x="520.0" y="642" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" fill="#333">1 replica</text>
+<rect x="995" y="100" width="13" height="13" fill="#999999"/>
+<text x="1017" y="112" font-family="Arial, sans-serif" font-size="14" fill="#333">Direct NVMe (baseline)</text>
+<rect x="995" y="134" width="13" height="13" fill="#ff1010"/>
+<text x="1017" y="146" font-family="Arial, sans-serif" font-size="14" fill="#333">v1 strict-local</text>
+<rect x="995" y="168" width="13" height="13" fill="#c6d9f1"/>
+<text x="1017" y="180" font-family="Arial, sans-serif" font-size="14" fill="#333">v2 best-effort, 1 CPU</text>
+<rect x="995" y="202" width="13" height="13" fill="#8db4e2"/>
+<text x="1017" y="214" font-family="Arial, sans-serif" font-size="14" fill="#333">v2 best-effort, 4 CPUs</text>
+<rect x="995" y="236" width="13" height="13" fill="#4f81bd"/>
+<text x="1017" y="248" font-family="Arial, sans-serif" font-size="14" fill="#333">v2 best-effort, 8 CPUs</text>
+<rect x="995" y="270" width="13" height="13" fill="#1f4e79"/>
+<text x="1017" y="282" font-family="Arial, sans-serif" font-size="14" fill="#333">v2 best-effort, 16 CPUs</text>
+<rect x="995" y="304" width="13" height="13" fill="#70ad47"/>
+<text x="1017" y="316" font-family="Arial, sans-serif" font-size="14" fill="#333">Local engine, thick</text>
+<rect x="995" y="338" width="13" height="13" fill="#f2c94c"/>
+<text x="1017" y="350" font-family="Arial, sans-serif" font-size="14" fill="#333">Local engine, thin</text>
+</svg>

--- a/enhancements/assets/images/local-data-engine/read-throughput.svg
+++ b/enhancements/assets/images/local-data-engine/read-throughput.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1515" height="689" viewBox="0 0 1515 689">
+<rect width="100%" height="100%" fill="white"/>
+<text x="30" y="56" font-family="Arial, sans-serif" font-size="25" fill="#6f6f6f">Read Throughput (MiB/s)</text>
+<line x1="95" y1="614.0" x2="945" y2="614.0" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="619.0" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">0</text>
+<line x1="95" y1="563.6" x2="945" y2="563.6" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="513.2" x2="945" y2="513.2" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="518.2" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">1,600</text>
+<line x1="95" y1="462.8" x2="945" y2="462.8" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="412.4" x2="945" y2="412.4" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="417.4" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">3,200</text>
+<line x1="95" y1="362.0" x2="945" y2="362.0" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="311.6" x2="945" y2="311.6" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="316.6" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">4,800</text>
+<line x1="95" y1="261.2" x2="945" y2="261.2" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="210.8" x2="945" y2="210.8" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="215.8" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">6,400</text>
+<line x1="95" y1="160.4" x2="945" y2="160.4" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="110.0" x2="945" y2="110.0" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="115.0" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">8,000</text>
+<line x1="95" y1="614" x2="945" y2="614" stroke="#333" stroke-width="1"/>
+<rect x="317.0" y="185.7" width="42" height="428.3" fill="#999999"><title>Direct NVMe (baseline): 6,798.82</title></rect>
+<rect x="369.0" y="362.7" width="42" height="251.3" fill="#ff1010"><title>v1 strict-local: 3,988.90</title></rect>
+<rect x="421.0" y="525.2" width="42" height="88.8" fill="#c6d9f1"><title>v2 best-effort, 1 CPU: 1,408.87</title></rect>
+<rect x="473.0" y="489.0" width="42" height="125.0" fill="#8db4e2"><title>v2 best-effort, 4 CPUs: 1,984.45</title></rect>
+<rect x="525.0" y="488.8" width="42" height="125.2" fill="#4f81bd"><title>v2 best-effort, 8 CPUs: 1,987.90</title></rect>
+<rect x="577.0" y="417.1" width="42" height="196.9" fill="#1f4e79"><title>v2 best-effort, 16 CPUs: 3,125.07</title></rect>
+<rect x="629.0" y="186.5" width="42" height="427.5" fill="#70ad47"><title>Local engine, thick: 6,785.82</title></rect>
+<rect x="681.0" y="186.9" width="42" height="427.1" fill="#f2c94c"><title>Local engine, thin: 6,778.94</title></rect>
+<text x="520.0" y="642" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" fill="#333">1 replica</text>
+<rect x="995" y="100" width="13" height="13" fill="#999999"/>
+<text x="1017" y="112" font-family="Arial, sans-serif" font-size="14" fill="#333">Direct NVMe (baseline)</text>
+<rect x="995" y="134" width="13" height="13" fill="#ff1010"/>
+<text x="1017" y="146" font-family="Arial, sans-serif" font-size="14" fill="#333">v1 strict-local</text>
+<rect x="995" y="168" width="13" height="13" fill="#c6d9f1"/>
+<text x="1017" y="180" font-family="Arial, sans-serif" font-size="14" fill="#333">v2 best-effort, 1 CPU</text>
+<rect x="995" y="202" width="13" height="13" fill="#8db4e2"/>
+<text x="1017" y="214" font-family="Arial, sans-serif" font-size="14" fill="#333">v2 best-effort, 4 CPUs</text>
+<rect x="995" y="236" width="13" height="13" fill="#4f81bd"/>
+<text x="1017" y="248" font-family="Arial, sans-serif" font-size="14" fill="#333">v2 best-effort, 8 CPUs</text>
+<rect x="995" y="270" width="13" height="13" fill="#1f4e79"/>
+<text x="1017" y="282" font-family="Arial, sans-serif" font-size="14" fill="#333">v2 best-effort, 16 CPUs</text>
+<rect x="995" y="304" width="13" height="13" fill="#70ad47"/>
+<text x="1017" y="316" font-family="Arial, sans-serif" font-size="14" fill="#333">Local engine, thick</text>
+<rect x="995" y="338" width="13" height="13" fill="#f2c94c"/>
+<text x="1017" y="350" font-family="Arial, sans-serif" font-size="14" fill="#333">Local engine, thin</text>
+</svg>

--- a/enhancements/assets/images/local-data-engine/write-iops.svg
+++ b/enhancements/assets/images/local-data-engine/write-iops.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1515" height="689" viewBox="0 0 1515 689">
+<rect width="100%" height="100%" fill="white"/>
+<text x="30" y="56" font-family="Arial, sans-serif" font-size="25" fill="#6f6f6f">Write IOPS</text>
+<line x1="95" y1="614.0" x2="945" y2="614.0" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="619.0" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">0</text>
+<line x1="95" y1="563.6" x2="945" y2="563.6" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="513.2" x2="945" y2="513.2" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="518.2" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">160,000</text>
+<line x1="95" y1="462.8" x2="945" y2="462.8" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="412.4" x2="945" y2="412.4" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="417.4" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">320,000</text>
+<line x1="95" y1="362.0" x2="945" y2="362.0" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="311.6" x2="945" y2="311.6" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="316.6" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">480,000</text>
+<line x1="95" y1="261.2" x2="945" y2="261.2" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="210.8" x2="945" y2="210.8" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="215.8" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">640,000</text>
+<line x1="95" y1="160.4" x2="945" y2="160.4" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="110.0" x2="945" y2="110.0" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="115.0" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">800,000</text>
+<line x1="95" y1="614" x2="945" y2="614" stroke="#333" stroke-width="1"/>
+<rect x="317.0" y="241.3" width="42" height="372.7" fill="#999999"><title>Direct NVMe (baseline): 591,511.65</title></rect>
+<rect x="369.0" y="589.4" width="42" height="24.6" fill="#ff1010"><title>v1 strict-local: 39,110.77</title></rect>
+<rect x="421.0" y="585.3" width="42" height="28.7" fill="#c6d9f1"><title>v2 best-effort, 1 CPU: 45,498.59</title></rect>
+<rect x="473.0" y="491.7" width="42" height="122.3" fill="#8db4e2"><title>v2 best-effort, 4 CPUs: 194,151.84</title></rect>
+<rect x="525.0" y="428.8" width="42" height="185.2" fill="#4f81bd"><title>v2 best-effort, 8 CPUs: 293,987.92</title></rect>
+<rect x="577.0" y="423.8" width="42" height="190.2" fill="#1f4e79"><title>v2 best-effort, 16 CPUs: 301,831.04</title></rect>
+<rect x="629.0" y="241.7" width="42" height="372.3" fill="#70ad47"><title>Local engine, thick: 590,897.47</title></rect>
+<rect x="681.0" y="314.2" width="42" height="299.8" fill="#f2c94c"><title>Local engine, thin: 475,879.15</title></rect>
+<text x="520.0" y="642" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" fill="#333">1 replica</text>
+<rect x="995" y="100" width="13" height="13" fill="#999999"/>
+<text x="1017" y="112" font-family="Arial, sans-serif" font-size="14" fill="#333">Direct NVMe (baseline)</text>
+<rect x="995" y="134" width="13" height="13" fill="#ff1010"/>
+<text x="1017" y="146" font-family="Arial, sans-serif" font-size="14" fill="#333">v1 strict-local</text>
+<rect x="995" y="168" width="13" height="13" fill="#c6d9f1"/>
+<text x="1017" y="180" font-family="Arial, sans-serif" font-size="14" fill="#333">v2 best-effort, 1 CPU</text>
+<rect x="995" y="202" width="13" height="13" fill="#8db4e2"/>
+<text x="1017" y="214" font-family="Arial, sans-serif" font-size="14" fill="#333">v2 best-effort, 4 CPUs</text>
+<rect x="995" y="236" width="13" height="13" fill="#4f81bd"/>
+<text x="1017" y="248" font-family="Arial, sans-serif" font-size="14" fill="#333">v2 best-effort, 8 CPUs</text>
+<rect x="995" y="270" width="13" height="13" fill="#1f4e79"/>
+<text x="1017" y="282" font-family="Arial, sans-serif" font-size="14" fill="#333">v2 best-effort, 16 CPUs</text>
+<rect x="995" y="304" width="13" height="13" fill="#70ad47"/>
+<text x="1017" y="316" font-family="Arial, sans-serif" font-size="14" fill="#333">Local engine, thick</text>
+<rect x="995" y="338" width="13" height="13" fill="#f2c94c"/>
+<text x="1017" y="350" font-family="Arial, sans-serif" font-size="14" fill="#333">Local engine, thin</text>
+</svg>

--- a/enhancements/assets/images/local-data-engine/write-latency.svg
+++ b/enhancements/assets/images/local-data-engine/write-latency.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1515" height="689" viewBox="0 0 1515 689">
+<rect width="100%" height="100%" fill="white"/>
+<text x="30" y="56" font-family="Arial, sans-serif" font-size="25" fill="#6f6f6f">Write Latency (microseconds)</text>
+<line x1="95" y1="614.0" x2="945" y2="614.0" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="619.0" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">0</text>
+<line x1="95" y1="563.6" x2="945" y2="563.6" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="513.2" x2="945" y2="513.2" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="518.2" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">60</text>
+<line x1="95" y1="462.8" x2="945" y2="462.8" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="412.4" x2="945" y2="412.4" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="417.4" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">120</text>
+<line x1="95" y1="362.0" x2="945" y2="362.0" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="311.6" x2="945" y2="311.6" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="316.6" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">180</text>
+<line x1="95" y1="261.2" x2="945" y2="261.2" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="210.8" x2="945" y2="210.8" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="215.8" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">240</text>
+<line x1="95" y1="160.4" x2="945" y2="160.4" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="110.0" x2="945" y2="110.0" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="115.0" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">300</text>
+<line x1="95" y1="614" x2="945" y2="614" stroke="#333" stroke-width="1"/>
+<rect x="317.0" y="583.1" width="42" height="30.9" fill="#999999"><title>Direct NVMe (baseline): 18.42</title></rect>
+<rect x="369.0" y="204.3" width="42" height="409.7" fill="#ff1010"><title>v1 strict-local: 243.89</title></rect>
+<rect x="421.0" y="436.8" width="42" height="177.2" fill="#c6d9f1"><title>v2 best-effort, 1 CPU: 105.48</title></rect>
+<rect x="473.0" y="452.7" width="42" height="161.3" fill="#8db4e2"><title>v2 best-effort, 4 CPUs: 96.03</title></rect>
+<rect x="525.0" y="453.9" width="42" height="160.1" fill="#4f81bd"><title>v2 best-effort, 8 CPUs: 95.31</title></rect>
+<rect x="577.0" y="457.1" width="42" height="156.9" fill="#1f4e79"><title>v2 best-effort, 16 CPUs: 93.40</title></rect>
+<rect x="629.0" y="574.6" width="42" height="39.4" fill="#70ad47"><title>Local engine, thick: 23.43</title></rect>
+<rect x="681.0" y="568.4" width="42" height="45.6" fill="#f2c94c"><title>Local engine, thin: 27.15</title></rect>
+<text x="520.0" y="642" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" fill="#333">1 replica</text>
+<rect x="995" y="100" width="13" height="13" fill="#999999"/>
+<text x="1017" y="112" font-family="Arial, sans-serif" font-size="14" fill="#333">Direct NVMe (baseline)</text>
+<rect x="995" y="134" width="13" height="13" fill="#ff1010"/>
+<text x="1017" y="146" font-family="Arial, sans-serif" font-size="14" fill="#333">v1 strict-local</text>
+<rect x="995" y="168" width="13" height="13" fill="#c6d9f1"/>
+<text x="1017" y="180" font-family="Arial, sans-serif" font-size="14" fill="#333">v2 best-effort, 1 CPU</text>
+<rect x="995" y="202" width="13" height="13" fill="#8db4e2"/>
+<text x="1017" y="214" font-family="Arial, sans-serif" font-size="14" fill="#333">v2 best-effort, 4 CPUs</text>
+<rect x="995" y="236" width="13" height="13" fill="#4f81bd"/>
+<text x="1017" y="248" font-family="Arial, sans-serif" font-size="14" fill="#333">v2 best-effort, 8 CPUs</text>
+<rect x="995" y="270" width="13" height="13" fill="#1f4e79"/>
+<text x="1017" y="282" font-family="Arial, sans-serif" font-size="14" fill="#333">v2 best-effort, 16 CPUs</text>
+<rect x="995" y="304" width="13" height="13" fill="#70ad47"/>
+<text x="1017" y="316" font-family="Arial, sans-serif" font-size="14" fill="#333">Local engine, thick</text>
+<rect x="995" y="338" width="13" height="13" fill="#f2c94c"/>
+<text x="1017" y="350" font-family="Arial, sans-serif" font-size="14" fill="#333">Local engine, thin</text>
+</svg>

--- a/enhancements/assets/images/local-data-engine/write-throughput.svg
+++ b/enhancements/assets/images/local-data-engine/write-throughput.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1515" height="689" viewBox="0 0 1515 689">
+<rect width="100%" height="100%" fill="white"/>
+<text x="30" y="56" font-family="Arial, sans-serif" font-size="25" fill="#6f6f6f">Write Throughput (MiB/s)</text>
+<line x1="95" y1="614.0" x2="945" y2="614.0" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="619.0" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">0</text>
+<line x1="95" y1="563.6" x2="945" y2="563.6" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="513.2" x2="945" y2="513.2" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="518.2" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">600</text>
+<line x1="95" y1="462.8" x2="945" y2="462.8" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="412.4" x2="945" y2="412.4" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="417.4" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">1,200</text>
+<line x1="95" y1="362.0" x2="945" y2="362.0" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="311.6" x2="945" y2="311.6" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="316.6" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">1,800</text>
+<line x1="95" y1="261.2" x2="945" y2="261.2" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="210.8" x2="945" y2="210.8" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="215.8" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">2,400</text>
+<line x1="95" y1="160.4" x2="945" y2="160.4" stroke="#e6e6e6" stroke-width="1"/>
+<line x1="95" y1="110.0" x2="945" y2="110.0" stroke="#c9c9c9" stroke-width="1"/>
+<text x="85" y="115.0" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#333">3,000</text>
+<line x1="95" y1="614" x2="945" y2="614" stroke="#333" stroke-width="1"/>
+<rect x="317.0" y="210.3" width="42" height="403.7" fill="#999999"><title>Direct NVMe (baseline): 2,403.03</title></rect>
+<rect x="369.0" y="588.0" width="42" height="26.0" fill="#ff1010"><title>v1 strict-local: 154.85</title></rect>
+<rect x="421.0" y="508.0" width="42" height="106.0" fill="#c6d9f1"><title>v2 best-effort, 1 CPU: 631.22</title></rect>
+<rect x="473.0" y="266.9" width="42" height="347.1" fill="#8db4e2"><title>v2 best-effort, 4 CPUs: 2,065.96</title></rect>
+<rect x="525.0" y="211.9" width="42" height="402.1" fill="#4f81bd"><title>v2 best-effort, 8 CPUs: 2,393.71</title></rect>
+<rect x="577.0" y="212.0" width="42" height="402.0" fill="#1f4e79"><title>v2 best-effort, 16 CPUs: 2,393.02</title></rect>
+<rect x="629.0" y="210.7" width="42" height="403.3" fill="#70ad47"><title>Local engine, thick: 2,400.33</title></rect>
+<rect x="681.0" y="210.0" width="42" height="404.0" fill="#f2c94c"><title>Local engine, thin: 2,404.74</title></rect>
+<text x="520.0" y="642" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" fill="#333">1 replica</text>
+<rect x="995" y="100" width="13" height="13" fill="#999999"/>
+<text x="1017" y="112" font-family="Arial, sans-serif" font-size="14" fill="#333">Direct NVMe (baseline)</text>
+<rect x="995" y="134" width="13" height="13" fill="#ff1010"/>
+<text x="1017" y="146" font-family="Arial, sans-serif" font-size="14" fill="#333">v1 strict-local</text>
+<rect x="995" y="168" width="13" height="13" fill="#c6d9f1"/>
+<text x="1017" y="180" font-family="Arial, sans-serif" font-size="14" fill="#333">v2 best-effort, 1 CPU</text>
+<rect x="995" y="202" width="13" height="13" fill="#8db4e2"/>
+<text x="1017" y="214" font-family="Arial, sans-serif" font-size="14" fill="#333">v2 best-effort, 4 CPUs</text>
+<rect x="995" y="236" width="13" height="13" fill="#4f81bd"/>
+<text x="1017" y="248" font-family="Arial, sans-serif" font-size="14" fill="#333">v2 best-effort, 8 CPUs</text>
+<rect x="995" y="270" width="13" height="13" fill="#1f4e79"/>
+<text x="1017" y="282" font-family="Arial, sans-serif" font-size="14" fill="#333">v2 best-effort, 16 CPUs</text>
+<rect x="995" y="304" width="13" height="13" fill="#70ad47"/>
+<text x="1017" y="316" font-family="Arial, sans-serif" font-size="14" fill="#333">Local engine, thick</text>
+<rect x="995" y="338" width="13" height="13" fill="#f2c94c"/>
+<text x="1017" y="350" font-family="Arial, sans-serif" font-size="14" fill="#333">Local engine, thin</text>
+</svg>

--- a/enhancements/assets/local-data-engine/performance-benchmark.md
+++ b/enhancements/assets/local-data-engine/performance-benchmark.md
@@ -1,0 +1,123 @@
+# Local Data Engine Performance Benchmark
+
+This report accompanies the [Local Data Engine for Strict-Local Volumes](../../20260826-local-data-engine.md)
+enhancement proposal. It compares the proposed LVM-backed local data engine with a direct NVMe baseline, a
+v1 `strict-local` volume, and a v2 volume with one replica.
+
+The benchmark was run on 2026-08-18.
+
+## Environment
+
+| | |
+|---|---|
+| Deployment | Single-node bare-metal Kubernetes cluster |
+| Machine | Intel Xeon Silver 4214; 48 logical CPUs; 125 GiB RAM |
+| OS | RHEL 9 compatible; kernel 6.12.48 |
+| Kubernetes | v1.35.7 |
+| Number of nodes | 1 |
+| Storage | NVMe SSD (SAMSUNG MZPLJ1T6HBJR-0007C); 1.45 TiB; no RAID |
+| Filesystem | ext4 |
+
+The direct NVMe baseline, the v2 cases, and every local data engine case reused the same physical NVMe
+device sequentially; no two configurations ran at the same time. The v2 cases used the `nvme` disk driver.
+
+The v1 `strict-local` case used the node's existing Longhorn filesystem disk, so it is not a same-device
+hardware comparison and should be read as an order-of-magnitude reference rather than a like-for-like
+result.
+
+Each Longhorn case used a 33 GiB PVC and a 30 GiB fio test file. The fio pod was pinned to host CPUs
+`40-47`, and the v2 instance-manager CPU allocation was assigned to CPUs `0-39`. The node provided 2 GiB of
+2 MiB hugepages on NUMA node 1.
+
+## fio parameters
+
+| Metric | Parameters |
+|---|---|
+| IOPS | `bs=4K`, `iodepth=128`, `numjobs=8`, `norandommap=1` |
+| Throughput | `bs=128K`, `iodepth=16`, `numjobs=4` |
+| Latency | `bs=4K`, `iodepth=1`, `numjobs=1` |
+
+Common parameters were `ioengine=libaio`, `direct=1`, `time_based=1`, `ramp_time=60s`, `runtime=60s`,
+`group_reporting=1`, `randrepeat=0`, and `verify=0`. Each run performed an unmeasured 60-second ramp
+followed by a single 60-second measurement, and the test file was removed before each metric category.
+
+These are the same parameters used by the upstream
+[performance benchmark](https://github.com/longhorn/longhorn/wiki/Performance-Benchmark), so the numbers
+below can be compared with published Longhorn results.
+
+## Results
+
+Latency is the fio mean total latency, which includes submission and completion; lower is better. All charts
+use a linear scale.
+
+![Read IOPS](../images/local-data-engine/read-iops.svg)
+
+![Write IOPS](../images/local-data-engine/write-iops.svg)
+
+![Read throughput](../images/local-data-engine/read-throughput.svg)
+
+![Write throughput](../images/local-data-engine/write-throughput.svg)
+
+![Read latency](../images/local-data-engine/read-latency.svg)
+
+![Write latency](../images/local-data-engine/write-latency.svg)
+
+### Measured values
+
+Random 4 KiB IOPS:
+
+| Configuration | Read IOPS | Write IOPS |
+|---|---:|---:|
+| Direct NVMe (baseline) | 1,022,730 | 591,512 |
+| v1 strict-local | 31,132 | 39,111 |
+| v2 best-effort, 1 CPU | 39,595 | 45,499 |
+| v2 best-effort, 4 CPUs | 195,474 | 194,152 |
+| v2 best-effort, 8 CPUs | 330,945 | 293,988 |
+| v2 best-effort, 16 CPUs | 276,736 | 301,831 |
+| Local engine, thick | 1,042,598 | 590,897 |
+| Local engine, thin | 622,127 | 475,879 |
+
+Sequential 128 KiB throughput, in MiB/s:
+
+| Configuration | Read | Write |
+|---|---:|---:|
+| Direct NVMe (baseline) | 6,798.82 | 2,403.03 |
+| v1 strict-local | 3,988.90 | 154.85 |
+| v2 best-effort, 1 CPU | 1,408.87 | 631.22 |
+| v2 best-effort, 4 CPUs | 1,984.45 | 2,065.96 |
+| v2 best-effort, 8 CPUs | 1,987.90 | 2,393.71 |
+| v2 best-effort, 16 CPUs | 3,125.07 | 2,393.02 |
+| Local engine, thick | 6,785.82 | 2,400.33 |
+| Local engine, thin | 6,778.94 | 2,404.74 |
+
+Queue-depth-1 4 KiB latency, in microseconds:
+
+| Configuration | Read | Write |
+|---|---:|---:|
+| Direct NVMe (baseline) | 70.48 | 18.42 |
+| v1 strict-local | 307.80 | 243.89 |
+| v2 best-effort, 1 CPU | 172.28 | 105.48 |
+| v2 best-effort, 4 CPUs | 140.77 | 96.03 |
+| v2 best-effort, 8 CPUs | 164.43 | 95.31 |
+| v2 best-effort, 16 CPUs | 134.00 | 93.40 |
+| Local engine, thick | 74.72 | 23.43 |
+| Local engine, thin | 78.17 | 27.15 |
+
+## Interpretation
+
+- Thick provisioning performed at the direct NVMe baseline in every category. Random read and write IOPS,
+  sequential throughput, and latency were all within a few percent of the raw device, which is the result the
+  design predicts: once the LV is active, no Longhorn userspace code is in the I/O path.
+- Thin provisioning kept sequential throughput at the baseline and stayed within roughly 4 microseconds of
+  thick latency, but random IOPS was lower, mostly because the thin pool allocates and zeroes chunks on first
+  write.
+- Even in thin mode, the local data engine was well ahead of a single-replica v2 volume, including the v2
+  runs given 8 or 16 dedicated CPU cores, and it needs no CPU allocation of its own.
+- The v2 results scale with the CPU cores given to the SPDK target and plateau between 8 and 16 cores. The
+  local data engine reaches higher numbers with no dedicated cores at all.
+- An earlier thin configuration with thin-pool zeroing disabled was also measured. It did not perform
+  measurably better than zeroed thin provisioning while it did expose stale chunk contents, so that mode was
+  removed and is not reported here.
+
+A future version may expose selected thin-pool tuning parameters, such as chunk size, if workload-specific
+benchmarking shows that the configurability is worthwhile.


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#13481

#### What this PR does / why we need it:

Adds a LEP for a local-only data engine backed by LVM logical volumes.

#### Additional documentation or context

Measured results are in `enhancements/assets/local-data-engine/performance-benchmark.md`.
